### PR TITLE
feat(fees): add fee management system

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,6 +4,7 @@ FROM mcr.microsoft.com/devcontainers/typescript-node:24
 RUN apt-get update && apt-get install -y \
     postgresql-client \
     redis-tools \
+    bubblewrap \
     && rm -rf /var/lib/apt/lists/*
 
 # Install pnpm

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -45,11 +45,10 @@
 
   "mounts": [
     "source=${localEnv:HOME}/.claude,target=/home/node/.claude,type=bind",
-    "source=${localEnv:HOME}/.claude.json,target=/home/node/.claude.json,type=bind",
     "source=clubmanager-local-${devcontainerId},target=/home/node/.local,type=volume"
   ],
 
   "forwardPorts": [33000, 33001, 35432, 36379, 35050, 35900, 35901, 38081, 39999],
 
-  "postCreateCommand": "sudo chown -R node:node /home/node/.local /home/node/.codex /home/node/.gemini 2>/dev/null || true; command -v pnpm >/dev/null || { SHELL=/bin/bash pnpm setup 2>/dev/null || true; export PNPM_HOME=\"$HOME/.local/share/pnpm\" && export PATH=\"$PNPM_HOME:$PATH\" && pnpm self-update 2>/dev/null || true; }; command -v claude >/dev/null || curl -fsSL https://claude.ai/install.sh | bash; command -v codex >/dev/null || npm install -g @openai/codex; command -v gemini >/dev/null || npm install -g @google/gemini-cli; if [ -f package.json ]; then pnpm install && (pnpm db:migrate >/dev/null 2>&1 || echo 'Note: db:migrate skipped - run manually if needed'); fi"
+  "postCreateCommand": "sudo chown -R node:node /home/node/.local /home/node/.codex /home/node/.gemini 2>/dev/null || true; [ -f /home/node/.claude/claude.json ] && ln -sf /home/node/.claude/claude.json /home/node/.claude.json; command -v pnpm >/dev/null || { SHELL=/bin/bash pnpm setup 2>/dev/null || true; export PNPM_HOME=\"$HOME/.local/share/pnpm\" && export PATH=\"$PNPM_HOME:$PATH\" && pnpm self-update 2>/dev/null || true; }; command -v claude >/dev/null || curl -fsSL https://claude.ai/install.sh | bash; command -v codex >/dev/null || npm install -g @openai/codex; command -v gemini >/dev/null || npm install -g @google/gemini-cli; if [ -f package.json ]; then pnpm install && (pnpm db:migrate >/dev/null 2>&1 || echo 'Note: db:migrate skipped - run manually if needed'); fi"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -51,5 +51,5 @@
 
   "forwardPorts": [33000, 33001, 35432, 36379, 35050, 35900, 35901, 38081, 39999],
 
-  "postCreateCommand": "sudo chown -R node:node /home/node/.local 2>/dev/null || true; command -v pnpm >/dev/null || { SHELL=/bin/bash pnpm setup 2>/dev/null || true; export PNPM_HOME=\"$HOME/.local/share/pnpm\" && export PATH=\"$PNPM_HOME:$PATH\" && pnpm self-update 2>/dev/null || true; }; command -v claude >/dev/null || curl -fsSL https://claude.ai/install.sh | bash; if [ -f package.json ]; then pnpm install && (pnpm db:migrate >/dev/null 2>&1 || echo 'Note: db:migrate skipped - run manually if needed'); fi"
+  "postCreateCommand": "sudo chown -R node:node /home/node/.local /home/node/.codex /home/node/.gemini 2>/dev/null || true; command -v pnpm >/dev/null || { SHELL=/bin/bash pnpm setup 2>/dev/null || true; export PNPM_HOME=\"$HOME/.local/share/pnpm\" && export PATH=\"$PNPM_HOME:$PATH\" && pnpm self-update 2>/dev/null || true; }; command -v claude >/dev/null || curl -fsSL https://claude.ai/install.sh | bash; command -v codex >/dev/null || npm install -g @openai/codex; command -v gemini >/dev/null || npm install -g @google/gemini-cli; if [ -f package.json ]; then pnpm install && (pnpm db:migrate >/dev/null 2>&1 || echo 'Note: db:migrate skipped - run manually if needed'); fi"
 }

--- a/.devcontainer/docker-compose.local.yml.example
+++ b/.devcontainer/docker-compose.local.yml.example
@@ -10,5 +10,9 @@ services:
       # Permissions: Issues (read/write)
       - GH_TOKEN=ghp_your_token_here
     volumes:
-      # Mount Claude config from host for persistent login
+      # Mount Claude config directory from host for persistent login.
+      # NOTE: ~/.claude.json lives INSIDE this directory (as claude.json) and is
+      # symlinked by postCreateCommand. Do NOT add a separate file bind mount for
+      # ~/.claude.json — file bind mounts break on atomic writes and cause corruption.
       - ~/.claude:/home/node/.claude:cached
+

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       - ..:/workspace:cached
       - node_modules:/workspace/node_modules
       - pnpm-store:/home/node/.local/share/pnpm
+      - gemini-config:/home/node/.gemini
+      - codex-config:/home/node/.codex
     environment:
       - NODE_ENV=development
       - DATABASE_URL=postgresql://clubmanager:clubmanager@postgres:5432/clubmanager
@@ -40,3 +42,5 @@ services:
 volumes:
   node_modules:
   pnpm-store:
+  gemini-config:
+  codex-config:

--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ temp/
 # SBOM / VEX (generated in CI)
 sbom.json
 vex.json
+
+# UAT prompts (ephemeral)
+.uat/

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -21,6 +21,7 @@ import { TierGuard } from './common/guards/tier.guard.js';
 import { PermissionGuard } from './common/guards/permission.guard.js';
 import { DeactivatedClubGuard } from './common/guards/deactivated-club.guard.js';
 import { ClubDeletionModule } from './club-deletion/club-deletion.module';
+import { FeesModule } from './fees/fees.module';
 
 @Module({
   imports: [
@@ -41,6 +42,7 @@ import { ClubDeletionModule } from './club-deletion/club-deletion.module';
     MembershipTypesModule,
     FilesModule,
     ClubDeletionModule,
+    FeesModule,
     HealthModule,
   ],
   providers: [

--- a/apps/api/src/fees/dto/billing-run-confirm.dto.ts
+++ b/apps/api/src/fees/dto/billing-run-confirm.dto.ts
@@ -7,27 +7,27 @@ export class BillingRunConfirmDto {
     description: 'Start of the billing period (ISO date string)',
     example: '2026-01-01',
   })
-  @IsDateString({}, { message: 'Periodenbeginn muss ein gueltiges Datum sein' })
+  @IsDateString({}, { message: 'Periodenbeginn muss ein gültiges Datum sein' })
   periodStart!: string;
 
   @ApiProperty({
     description: 'End of the billing period (ISO date string)',
     example: '2026-12-31',
   })
-  @IsDateString({}, { message: 'Periodenende muss ein gueltiges Datum sein' })
+  @IsDateString({}, { message: 'Periodenende muss ein gültiges Datum sein' })
   periodEnd!: string;
 
   @ApiProperty({
     description: 'Billing interval to generate charges for',
     enum: BillingInterval,
   })
-  @IsEnum(BillingInterval, { message: 'Ungueltiger Abrechnungszeitraum' })
+  @IsEnum(BillingInterval, { message: 'Ungültiger Abrechnungszeitraum' })
   billingInterval!: BillingInterval;
 
   @ApiProperty({
     description: 'Due date for all generated charges (ISO date string)',
     example: '2026-02-15',
   })
-  @IsDateString({}, { message: 'Faelligkeitsdatum muss ein gueltiges Datum sein' })
+  @IsDateString({}, { message: 'Fälligkeitsdatum muss ein gültiges Datum sein' })
   dueDate!: string;
 }

--- a/apps/api/src/fees/dto/billing-run-confirm.dto.ts
+++ b/apps/api/src/fees/dto/billing-run-confirm.dto.ts
@@ -1,0 +1,33 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsDateString, IsEnum } from 'class-validator';
+import { BillingInterval } from '../../../../../prisma/generated/client/index.js';
+
+export class BillingRunConfirmDto {
+  @ApiProperty({
+    description: 'Start of the billing period (ISO date string)',
+    example: '2026-01-01',
+  })
+  @IsDateString({}, { message: 'Periodenbeginn muss ein gueltiges Datum sein' })
+  periodStart!: string;
+
+  @ApiProperty({
+    description: 'End of the billing period (ISO date string)',
+    example: '2026-12-31',
+  })
+  @IsDateString({}, { message: 'Periodenende muss ein gueltiges Datum sein' })
+  periodEnd!: string;
+
+  @ApiProperty({
+    description: 'Billing interval to generate charges for',
+    enum: BillingInterval,
+  })
+  @IsEnum(BillingInterval, { message: 'Ungueltiger Abrechnungszeitraum' })
+  billingInterval!: BillingInterval;
+
+  @ApiProperty({
+    description: 'Due date for all generated charges (ISO date string)',
+    example: '2026-02-15',
+  })
+  @IsDateString({}, { message: 'Faelligkeitsdatum muss ein gueltiges Datum sein' })
+  dueDate!: string;
+}

--- a/apps/api/src/fees/dto/billing-run-preview.dto.ts
+++ b/apps/api/src/fees/dto/billing-run-preview.dto.ts
@@ -7,20 +7,20 @@ export class BillingRunPreviewDto {
     description: 'Start of the billing period (ISO date string)',
     example: '2026-01-01',
   })
-  @IsDateString({}, { message: 'Periodenbeginn muss ein gueltiges Datum sein' })
+  @IsDateString({}, { message: 'Periodenbeginn muss ein gültiges Datum sein' })
   periodStart!: string;
 
   @ApiProperty({
     description: 'End of the billing period (ISO date string)',
     example: '2026-12-31',
   })
-  @IsDateString({}, { message: 'Periodenende muss ein gueltiges Datum sein' })
+  @IsDateString({}, { message: 'Periodenende muss ein gültiges Datum sein' })
   periodEnd!: string;
 
   @ApiProperty({
     description: 'Billing interval to generate charges for',
     enum: BillingInterval,
   })
-  @IsEnum(BillingInterval, { message: 'Ungueltiger Abrechnungszeitraum' })
+  @IsEnum(BillingInterval, { message: 'Ungültiger Abrechnungszeitraum' })
   billingInterval!: BillingInterval;
 }

--- a/apps/api/src/fees/dto/billing-run-preview.dto.ts
+++ b/apps/api/src/fees/dto/billing-run-preview.dto.ts
@@ -1,0 +1,26 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsDateString, IsEnum } from 'class-validator';
+import { BillingInterval } from '../../../../../prisma/generated/client/index.js';
+
+export class BillingRunPreviewDto {
+  @ApiProperty({
+    description: 'Start of the billing period (ISO date string)',
+    example: '2026-01-01',
+  })
+  @IsDateString({}, { message: 'Periodenbeginn muss ein gueltiges Datum sein' })
+  periodStart!: string;
+
+  @ApiProperty({
+    description: 'End of the billing period (ISO date string)',
+    example: '2026-12-31',
+  })
+  @IsDateString({}, { message: 'Periodenende muss ein gueltiges Datum sein' })
+  periodEnd!: string;
+
+  @ApiProperty({
+    description: 'Billing interval to generate charges for',
+    enum: BillingInterval,
+  })
+  @IsEnum(BillingInterval, { message: 'Ungueltiger Abrechnungszeitraum' })
+  billingInterval!: BillingInterval;
+}

--- a/apps/api/src/fees/dto/create-fee-category.dto.ts
+++ b/apps/api/src/fees/dto/create-fee-category.dto.ts
@@ -1,0 +1,70 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsString,
+  IsOptional,
+  IsBoolean,
+  IsInt,
+  IsEnum,
+  Min,
+  MinLength,
+  MaxLength,
+  Matches,
+} from 'class-validator';
+import { BillingInterval } from '../../../../prisma/generated/client/index.js';
+
+export class CreateFeeCategoryDto {
+  @ApiProperty({
+    description: 'Category name (e.g., "Aufnahmegebuehr", "Tennisabteilung")',
+    example: 'Aufnahmegebuehr',
+  })
+  @IsString()
+  @MinLength(1, { message: 'Name darf nicht leer sein' })
+  @MaxLength(100, { message: 'Name darf maximal 100 Zeichen lang sein' })
+  name!: string;
+
+  @ApiPropertyOptional({
+    description: 'Optional description',
+    example: 'Einmalige Aufnahmegebuehr fuer neue Mitglieder',
+  })
+  @IsString()
+  @IsOptional()
+  @MaxLength(500, { message: 'Beschreibung darf maximal 500 Zeichen lang sein' })
+  description?: string;
+
+  @ApiProperty({
+    description: 'Fee amount as decimal string (e.g., "120.00")',
+    example: '120.00',
+  })
+  @IsString()
+  @Matches(/^\d+(\.\d{1,2})?$/, {
+    message: 'Betrag muss ein gueltiges Dezimalformat haben (z.B. "120.00")',
+  })
+  amount!: string;
+
+  @ApiPropertyOptional({
+    description: 'Billing frequency',
+    enum: BillingInterval,
+    default: 'ANNUALLY',
+  })
+  @IsEnum(BillingInterval, { message: 'Ungueltiger Abrechnungszeitraum' })
+  @IsOptional()
+  billingInterval?: BillingInterval;
+
+  @ApiPropertyOptional({
+    description: 'Whether this is a one-time fee (e.g., enrollment fee)',
+    default: false,
+  })
+  @IsBoolean()
+  @IsOptional()
+  isOneTime?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Display order in lists',
+    default: 0,
+    minimum: 0,
+  })
+  @IsInt()
+  @IsOptional()
+  @Min(0, { message: 'Sortierung muss mindestens 0 sein' })
+  sortOrder?: number;
+}

--- a/apps/api/src/fees/dto/create-fee-category.dto.ts
+++ b/apps/api/src/fees/dto/create-fee-category.dto.ts
@@ -36,8 +36,8 @@ export class CreateFeeCategoryDto {
     example: '120.00',
   })
   @IsString()
-  @Matches(/^\d+(\.\d{1,2})?$/, {
-    message: 'Betrag muss ein gueltiges Dezimalformat haben (z.B. "120.00")',
+  @Matches(/^\d{1,8}(\.\d{1,2})?$/, {
+    message: 'Betrag muss ein gueltiges Dezimalformat haben (z.B. "120.00", max 8 Vorkommastellen)',
   })
   amount!: string;
 

--- a/apps/api/src/fees/dto/create-fee-category.dto.ts
+++ b/apps/api/src/fees/dto/create-fee-category.dto.ts
@@ -37,7 +37,7 @@ export class CreateFeeCategoryDto {
   })
   @IsString()
   @Matches(/^\d{1,8}(\.\d{1,2})?$/, {
-    message: 'Betrag muss ein gueltiges Dezimalformat haben (z.B. "120.00", max 8 Vorkommastellen)',
+    message: 'Betrag muss ein gültiges Dezimalformat haben (z.B. „120.00", max 8 Vorkommastellen)',
   })
   amount!: string;
 
@@ -46,7 +46,7 @@ export class CreateFeeCategoryDto {
     enum: BillingInterval,
     default: 'ANNUALLY',
   })
-  @IsEnum(BillingInterval, { message: 'Ungueltiger Abrechnungszeitraum' })
+  @IsEnum(BillingInterval, { message: 'Ungültiger Abrechnungszeitraum' })
   @IsOptional()
   billingInterval?: BillingInterval;
 

--- a/apps/api/src/fees/dto/create-fee-category.dto.ts
+++ b/apps/api/src/fees/dto/create-fee-category.dto.ts
@@ -10,7 +10,7 @@ import {
   MaxLength,
   Matches,
 } from 'class-validator';
-import { BillingInterval } from '../../../../prisma/generated/client/index.js';
+import { BillingInterval } from '../../../../../prisma/generated/client/index.js';
 
 export class CreateFeeCategoryDto {
   @ApiProperty({

--- a/apps/api/src/fees/dto/create-member-fee-override.dto.ts
+++ b/apps/api/src/fees/dto/create-member-fee-override.dto.ts
@@ -1,0 +1,52 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsString, IsOptional, IsBoolean, IsEnum, Matches } from 'class-validator';
+import { FeeOverrideType } from '../../../../prisma/generated/client/index.js';
+
+export class CreateMemberFeeOverrideDto {
+  @ApiProperty({
+    description: 'Member ID to create override for',
+  })
+  @IsString()
+  memberId!: string;
+
+  @ApiPropertyOptional({
+    description: 'Fee category ID (null if overriding base membership fee)',
+  })
+  @IsString()
+  @IsOptional()
+  feeCategoryId?: string;
+
+  @ApiProperty({
+    description: 'Type of override (EXEMPT, CUSTOM_AMOUNT, ADDITIONAL)',
+    enum: FeeOverrideType,
+  })
+  @IsEnum(FeeOverrideType, { message: 'Ungueltiger Override-Typ' })
+  overrideType!: FeeOverrideType;
+
+  @ApiPropertyOptional({
+    description: 'Custom amount for CUSTOM_AMOUNT and ADDITIONAL types',
+    example: '50.00',
+  })
+  @IsString()
+  @IsOptional()
+  @Matches(/^\d+(\.\d{1,2})?$/, {
+    message: 'Betrag muss ein gueltiges Dezimalformat haben (z.B. "50.00")',
+  })
+  customAmount?: string;
+
+  @ApiPropertyOptional({
+    description: 'Reason for the override',
+    example: 'Soziale Haertefallregelung',
+  })
+  @IsString()
+  @IsOptional()
+  reason?: string;
+
+  @ApiPropertyOptional({
+    description: 'Whether this override applies to the base membership fee',
+    default: false,
+  })
+  @IsBoolean()
+  @IsOptional()
+  isBaseFee?: boolean;
+}

--- a/apps/api/src/fees/dto/create-member-fee-override.dto.ts
+++ b/apps/api/src/fees/dto/create-member-fee-override.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsString, IsOptional, IsBoolean, IsEnum, Matches } from 'class-validator';
-import { FeeOverrideType } from '../../../../prisma/generated/client/index.js';
+import { FeeOverrideType } from '../../../../../prisma/generated/client/index.js';
 
 export class CreateMemberFeeOverrideDto {
   @ApiProperty({

--- a/apps/api/src/fees/dto/create-member-fee-override.dto.ts
+++ b/apps/api/src/fees/dto/create-member-fee-override.dto.ts
@@ -29,8 +29,8 @@ export class CreateMemberFeeOverrideDto {
   })
   @IsString()
   @IsOptional()
-  @Matches(/^\d+(\.\d{1,2})?$/, {
-    message: 'Betrag muss ein gueltiges Dezimalformat haben (z.B. "50.00")',
+  @Matches(/^\d{1,8}(\.\d{1,2})?$/, {
+    message: 'Betrag muss ein gueltiges Dezimalformat haben (z.B. "50.00", max 8 Vorkommastellen)',
   })
   customAmount?: string;
 

--- a/apps/api/src/fees/dto/create-member-fee-override.dto.ts
+++ b/apps/api/src/fees/dto/create-member-fee-override.dto.ts
@@ -20,7 +20,7 @@ export class CreateMemberFeeOverrideDto {
     description: 'Type of override (EXEMPT, CUSTOM_AMOUNT, ADDITIONAL)',
     enum: FeeOverrideType,
   })
-  @IsEnum(FeeOverrideType, { message: 'Ungueltiger Override-Typ' })
+  @IsEnum(FeeOverrideType, { message: 'Ungültiger Override-Typ' })
   overrideType!: FeeOverrideType;
 
   @ApiPropertyOptional({
@@ -30,7 +30,7 @@ export class CreateMemberFeeOverrideDto {
   @IsString()
   @IsOptional()
   @Matches(/^\d{1,8}(\.\d{1,2})?$/, {
-    message: 'Betrag muss ein gueltiges Dezimalformat haben (z.B. "50.00", max 8 Vorkommastellen)',
+    message: 'Betrag muss ein gültiges Dezimalformat haben (z.B. „50.00", max 8 Vorkommastellen)',
   })
   customAmount?: string;
 

--- a/apps/api/src/fees/dto/fee-charge-query.dto.ts
+++ b/apps/api/src/fees/dto/fee-charge-query.dto.ts
@@ -1,5 +1,5 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsDateString, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+import { IsDateString, IsIn, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
 import { Transform } from 'class-transformer';
 
 export class FeeChargeQueryDto {
@@ -8,8 +8,10 @@ export class FeeChargeQueryDto {
     enum: ['OPEN', 'PARTIAL', 'PAID', 'OVERDUE'],
   })
   @IsOptional()
-  @IsString()
-  status?: string;
+  @IsIn(['OPEN', 'PARTIAL', 'PAID', 'OVERDUE'], {
+    message: 'Status muss OPEN, PARTIAL, PAID oder OVERDUE sein',
+  })
+  status?: 'OPEN' | 'PARTIAL' | 'PAID' | 'OVERDUE';
 
   @ApiPropertyOptional({
     description: 'Filter by specific member ID',

--- a/apps/api/src/fees/dto/fee-charge-query.dto.ts
+++ b/apps/api/src/fees/dto/fee-charge-query.dto.ts
@@ -23,7 +23,7 @@ export class FeeChargeQueryDto {
     example: '2026-01-01',
   })
   @IsOptional()
-  @IsDateString({}, { message: 'Periodenbeginn muss ein gueltiges Datum sein' })
+  @IsDateString({}, { message: 'Periodenbeginn muss ein gültiges Datum sein' })
   periodStart?: string;
 
   @ApiPropertyOptional({
@@ -31,7 +31,7 @@ export class FeeChargeQueryDto {
     example: '2026-12-31',
   })
   @IsOptional()
-  @IsDateString({}, { message: 'Periodenende muss ein gueltiges Datum sein' })
+  @IsDateString({}, { message: 'Periodenende muss ein gültiges Datum sein' })
   periodEnd?: string;
 
   @ApiPropertyOptional({

--- a/apps/api/src/fees/dto/fee-charge-query.dto.ts
+++ b/apps/api/src/fees/dto/fee-charge-query.dto.ts
@@ -1,5 +1,5 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsDateString, IsEnum, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+import { IsDateString, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
 import { Transform } from 'class-transformer';
 
 export class FeeChargeQueryDto {

--- a/apps/api/src/fees/dto/fee-charge-query.dto.ts
+++ b/apps/api/src/fees/dto/fee-charge-query.dto.ts
@@ -1,0 +1,57 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsDateString, IsEnum, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+import { Transform } from 'class-transformer';
+
+export class FeeChargeQueryDto {
+  @ApiPropertyOptional({
+    description: 'Filter by derived payment status',
+    enum: ['OPEN', 'PARTIAL', 'PAID', 'OVERDUE'],
+  })
+  @IsOptional()
+  @IsString()
+  status?: string;
+
+  @ApiPropertyOptional({
+    description: 'Filter by specific member ID',
+  })
+  @IsOptional()
+  @IsString()
+  memberId?: string;
+
+  @ApiPropertyOptional({
+    description: 'Filter by period start (inclusive)',
+    example: '2026-01-01',
+  })
+  @IsOptional()
+  @IsDateString({}, { message: 'Periodenbeginn muss ein gueltiges Datum sein' })
+  periodStart?: string;
+
+  @ApiPropertyOptional({
+    description: 'Filter by period end (inclusive)',
+    example: '2026-12-31',
+  })
+  @IsOptional()
+  @IsDateString({}, { message: 'Periodenende muss ein gueltiges Datum sein' })
+  periodEnd?: string;
+
+  @ApiPropertyOptional({
+    description: 'Page number (1-based)',
+    default: 1,
+  })
+  @IsOptional()
+  @Transform(({ value }) => parseInt(value as string, 10))
+  @IsInt()
+  @Min(1)
+  page?: number;
+
+  @ApiPropertyOptional({
+    description: 'Items per page (max 100)',
+    default: 20,
+  })
+  @IsOptional()
+  @Transform(({ value }) => parseInt(value as string, 10))
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number;
+}

--- a/apps/api/src/fees/dto/index.ts
+++ b/apps/api/src/fees/dto/index.ts
@@ -1,0 +1,3 @@
+export { CreateFeeCategoryDto } from './create-fee-category.dto.js';
+export { UpdateFeeCategoryDto } from './update-fee-category.dto.js';
+export { CreateMemberFeeOverrideDto } from './create-member-fee-override.dto.js';

--- a/apps/api/src/fees/dto/index.ts
+++ b/apps/api/src/fees/dto/index.ts
@@ -1,3 +1,7 @@
 export { CreateFeeCategoryDto } from './create-fee-category.dto.js';
 export { UpdateFeeCategoryDto } from './update-fee-category.dto.js';
 export { CreateMemberFeeOverrideDto } from './create-member-fee-override.dto.js';
+export { BillingRunPreviewDto } from './billing-run-preview.dto.js';
+export { BillingRunConfirmDto } from './billing-run-confirm.dto.js';
+export { FeeChargeQueryDto } from './fee-charge-query.dto.js';
+export { RecordPaymentDto } from './record-payment.dto.js';

--- a/apps/api/src/fees/dto/record-payment.dto.ts
+++ b/apps/api/src/fees/dto/record-payment.dto.ts
@@ -14,8 +14,8 @@ export class RecordPaymentDto {
     example: '50.00',
   })
   @IsString()
-  @Matches(/^\d+(\.\d{1,2})?$/, {
-    message: 'Betrag muss ein gueltiges Dezimalformat haben (z.B. "50.00")',
+  @Matches(/^(?!0+(\.0{1,2})?$)\d{1,8}(\.\d{1,2})?$/, {
+    message: 'Betrag muss groesser als 0 sein und ein gueltiges Dezimalformat haben (z.B. "50.00")',
   })
   amount!: string;
 

--- a/apps/api/src/fees/dto/record-payment.dto.ts
+++ b/apps/api/src/fees/dto/record-payment.dto.ts
@@ -1,0 +1,37 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsDateString, IsOptional, IsString, Matches, MaxLength } from 'class-validator';
+
+export class RecordPaymentDto {
+  @ApiProperty({
+    description: 'The fee charge this payment is for',
+    example: 'clxyz123...',
+  })
+  @IsString()
+  feeChargeId!: string;
+
+  @ApiProperty({
+    description: 'Payment amount as decimal string (e.g., "50.00")',
+    example: '50.00',
+  })
+  @IsString()
+  @Matches(/^\d+(\.\d{1,2})?$/, {
+    message: 'Betrag muss ein gueltiges Dezimalformat haben (z.B. "50.00")',
+  })
+  amount!: string;
+
+  @ApiProperty({
+    description: 'Date the payment was made (ISO date string)',
+    example: '2026-01-20',
+  })
+  @IsDateString({}, { message: 'Zahlungsdatum muss ein gueltiges Datum sein' })
+  paidAt!: string;
+
+  @ApiPropertyOptional({
+    description: 'Optional notes about this payment',
+    example: 'Barbezahlung',
+  })
+  @IsString()
+  @IsOptional()
+  @MaxLength(500, { message: 'Notizen duerfen maximal 500 Zeichen lang sein' })
+  notes?: string;
+}

--- a/apps/api/src/fees/dto/record-payment.dto.ts
+++ b/apps/api/src/fees/dto/record-payment.dto.ts
@@ -15,7 +15,7 @@ export class RecordPaymentDto {
   })
   @IsString()
   @Matches(/^(?!0+(\.0{1,2})?$)\d{1,8}(\.\d{1,2})?$/, {
-    message: 'Betrag muss groesser als 0 sein und ein gueltiges Dezimalformat haben (z.B. "50.00")',
+    message: 'Betrag muss größer als 0 sein und ein gültiges Dezimalformat haben (z.B. "50.00")',
   })
   amount!: string;
 
@@ -23,7 +23,7 @@ export class RecordPaymentDto {
     description: 'Date the payment was made (ISO date string)',
     example: '2026-01-20',
   })
-  @IsDateString({}, { message: 'Zahlungsdatum muss ein gueltiges Datum sein' })
+  @IsDateString({}, { message: 'Zahlungsdatum muss ein gültiges Datum sein' })
   paidAt!: string;
 
   @ApiPropertyOptional({
@@ -32,6 +32,6 @@ export class RecordPaymentDto {
   })
   @IsString()
   @IsOptional()
-  @MaxLength(500, { message: 'Notizen duerfen maximal 500 Zeichen lang sein' })
+  @MaxLength(500, { message: 'Notizen dürfen maximal 500 Zeichen lang sein' })
   notes?: string;
 }

--- a/apps/api/src/fees/dto/update-fee-category.dto.ts
+++ b/apps/api/src/fees/dto/update-fee-category.dto.ts
@@ -10,7 +10,7 @@ import {
   MaxLength,
   Matches,
 } from 'class-validator';
-import { BillingInterval } from '../../../../prisma/generated/client/index.js';
+import { BillingInterval } from '../../../../../prisma/generated/client/index.js';
 
 export class UpdateFeeCategoryDto {
   @ApiPropertyOptional({

--- a/apps/api/src/fees/dto/update-fee-category.dto.ts
+++ b/apps/api/src/fees/dto/update-fee-category.dto.ts
@@ -1,0 +1,75 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsString,
+  IsOptional,
+  IsBoolean,
+  IsInt,
+  IsEnum,
+  Min,
+  MinLength,
+  MaxLength,
+  Matches,
+} from 'class-validator';
+import { BillingInterval } from '../../../../prisma/generated/client/index.js';
+
+export class UpdateFeeCategoryDto {
+  @ApiPropertyOptional({
+    description: 'Category name (e.g., "Aufnahmegebuehr", "Tennisabteilung")',
+    example: 'Aufnahmegebuehr',
+  })
+  @IsString()
+  @IsOptional()
+  @MinLength(1, { message: 'Name darf nicht leer sein' })
+  @MaxLength(100, { message: 'Name darf maximal 100 Zeichen lang sein' })
+  name?: string;
+
+  @ApiPropertyOptional({
+    description: 'Optional description',
+  })
+  @IsString()
+  @IsOptional()
+  @MaxLength(500, { message: 'Beschreibung darf maximal 500 Zeichen lang sein' })
+  description?: string;
+
+  @ApiPropertyOptional({
+    description: 'Fee amount as decimal string (e.g., "120.00")',
+    example: '120.00',
+  })
+  @IsString()
+  @IsOptional()
+  @Matches(/^\d+(\.\d{1,2})?$/, {
+    message: 'Betrag muss ein gueltiges Dezimalformat haben (z.B. "120.00")',
+  })
+  amount?: string;
+
+  @ApiPropertyOptional({
+    description: 'Billing frequency',
+    enum: BillingInterval,
+  })
+  @IsEnum(BillingInterval, { message: 'Ungueltiger Abrechnungszeitraum' })
+  @IsOptional()
+  billingInterval?: BillingInterval;
+
+  @ApiPropertyOptional({
+    description: 'Whether this is a one-time fee',
+  })
+  @IsBoolean()
+  @IsOptional()
+  isOneTime?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Whether this category is active',
+  })
+  @IsBoolean()
+  @IsOptional()
+  isActive?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Display order in lists',
+    minimum: 0,
+  })
+  @IsInt()
+  @IsOptional()
+  @Min(0, { message: 'Sortierung muss mindestens 0 sein' })
+  sortOrder?: number;
+}

--- a/apps/api/src/fees/dto/update-fee-category.dto.ts
+++ b/apps/api/src/fees/dto/update-fee-category.dto.ts
@@ -37,8 +37,8 @@ export class UpdateFeeCategoryDto {
   })
   @IsString()
   @IsOptional()
-  @Matches(/^\d+(\.\d{1,2})?$/, {
-    message: 'Betrag muss ein gültiges Dezimalformat haben (z.B. „120.00")',
+  @Matches(/^\d{1,8}(\.\d{1,2})?$/, {
+    message: 'Betrag muss ein gültiges Dezimalformat haben (z.B. „120.00", max 8 Vorkommastellen)',
   })
   amount?: string;
 

--- a/apps/api/src/fees/dto/update-fee-category.dto.ts
+++ b/apps/api/src/fees/dto/update-fee-category.dto.ts
@@ -38,7 +38,7 @@ export class UpdateFeeCategoryDto {
   @IsString()
   @IsOptional()
   @Matches(/^\d+(\.\d{1,2})?$/, {
-    message: 'Betrag muss ein gueltiges Dezimalformat haben (z.B. "120.00")',
+    message: 'Betrag muss ein gültiges Dezimalformat haben (z.B. „120.00")',
   })
   amount?: string;
 
@@ -46,7 +46,7 @@ export class UpdateFeeCategoryDto {
     description: 'Billing frequency',
     enum: BillingInterval,
   })
-  @IsEnum(BillingInterval, { message: 'Ungueltiger Abrechnungszeitraum' })
+  @IsEnum(BillingInterval, { message: 'Ungültiger Abrechnungszeitraum' })
   @IsOptional()
   billingInterval?: BillingInterval;
 

--- a/apps/api/src/fees/fee-charges.controller.ts
+++ b/apps/api/src/fees/fee-charges.controller.ts
@@ -1,0 +1,55 @@
+import { Controller, Get, Post, Param, Body, Query } from '@nestjs/common';
+import { ApiTags, ApiBearerAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { RequireClubContext, GetClubContext } from '../common/decorators/club-context.decorator.js';
+import { RequirePermissions } from '../common/decorators/permissions.decorator.js';
+import { Permission } from '../common/permissions/permissions.enum.js';
+import { CurrentUser } from '../auth/decorators/current-user.decorator.js';
+import { FeeChargesService } from './fee-charges.service.js';
+import { BillingRunPreviewDto } from './dto/billing-run-preview.dto.js';
+import { BillingRunConfirmDto } from './dto/billing-run-confirm.dto.js';
+import { FeeChargeQueryDto } from './dto/fee-charge-query.dto.js';
+import type { ClubContext } from '../common/decorators/club-context.decorator.js';
+
+@ApiTags('Fee Charges')
+@ApiBearerAuth()
+@Controller('clubs/:slug/fees/charges')
+@RequireClubContext()
+export class FeeChargesController {
+  constructor(private feeChargesService: FeeChargesService) {}
+
+  @Post('billing-run/preview')
+  @RequirePermissions([Permission.FINANCE_CREATE])
+  @ApiOperation({ summary: 'Preview billing run (no side effects)' })
+  @ApiResponse({ status: 200, description: 'Billing run preview with counts and totals' })
+  async previewBillingRun(@GetClubContext() ctx: ClubContext, @Body() dto: BillingRunPreviewDto) {
+    return this.feeChargesService.previewBillingRun(ctx.clubId, dto);
+  }
+
+  @Post('billing-run/confirm')
+  @RequirePermissions([Permission.FINANCE_CREATE])
+  @ApiOperation({ summary: 'Execute billing run and create fee charges' })
+  @ApiResponse({ status: 201, description: 'Billing run executed, charges created' })
+  async confirmBillingRun(
+    @GetClubContext() ctx: ClubContext,
+    @Body() dto: BillingRunConfirmDto,
+    @CurrentUser('id') userId: string
+  ) {
+    return this.feeChargesService.executeBillingRun(ctx.clubId, dto, userId);
+  }
+
+  @Get()
+  @RequirePermissions([Permission.FINANCE_READ])
+  @ApiOperation({ summary: 'List fee charges with computed payment status' })
+  @ApiResponse({ status: 200, description: 'Paginated list of fee charges with status' })
+  async findAll(@GetClubContext() ctx: ClubContext, @Query() query: FeeChargeQueryDto) {
+    return this.feeChargesService.findAllWithStatus(ctx.clubId, query);
+  }
+
+  @Get('member/:memberId')
+  @RequirePermissions([Permission.FINANCE_READ])
+  @ApiOperation({ summary: 'List fee charges for a specific member' })
+  @ApiResponse({ status: 200, description: 'Member fee charges with status' })
+  async findByMember(@GetClubContext() ctx: ClubContext, @Param('memberId') memberId: string) {
+    return this.feeChargesService.findByMember(ctx.clubId, memberId);
+  }
+}

--- a/apps/api/src/fees/fee-charges.controller.ts
+++ b/apps/api/src/fees/fee-charges.controller.ts
@@ -3,7 +3,7 @@ import { ApiTags, ApiBearerAuth, ApiOperation, ApiResponse } from '@nestjs/swagg
 import { RequireClubContext, GetClubContext } from '../common/decorators/club-context.decorator.js';
 import { RequirePermissions } from '../common/decorators/permissions.decorator.js';
 import { Permission } from '../common/permissions/permissions.enum.js';
-import { CurrentUser } from '../auth/decorators/current-user.decorator.js';
+
 import { FeeChargesService } from './fee-charges.service.js';
 import { BillingRunPreviewDto } from './dto/billing-run-preview.dto.js';
 import { BillingRunConfirmDto } from './dto/billing-run-confirm.dto.js';
@@ -29,12 +29,8 @@ export class FeeChargesController {
   @RequirePermissions([Permission.FINANCE_CREATE])
   @ApiOperation({ summary: 'Execute billing run and create fee charges' })
   @ApiResponse({ status: 201, description: 'Billing run executed, charges created' })
-  async confirmBillingRun(
-    @GetClubContext() ctx: ClubContext,
-    @Body() dto: BillingRunConfirmDto,
-    @CurrentUser('id') userId: string
-  ) {
-    return this.feeChargesService.executeBillingRun(ctx.clubId, dto, userId);
+  async confirmBillingRun(@GetClubContext() ctx: ClubContext, @Body() dto: BillingRunConfirmDto) {
+    return this.feeChargesService.executeBillingRun(ctx.clubId, dto);
   }
 
   @Get()

--- a/apps/api/src/fees/fee-charges.service.spec.ts
+++ b/apps/api/src/fees/fee-charges.service.spec.ts
@@ -222,14 +222,16 @@ describe('FeeChargesService', () => {
       (mockPrisma.club.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeClub());
       (mockPrisma.member.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(members);
       (mockDb.feeCategory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
-      (mockPrisma.$transaction as ReturnType<typeof vi.fn>).mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
-        const txClient = {
-          feeCharge: {
-            createMany: vi.fn().mockResolvedValue({ count: 2 }),
-          },
-        };
-        return fn(txClient);
-      });
+      (mockPrisma.$transaction as ReturnType<typeof vi.fn>).mockImplementation(
+        async (fn: (tx: unknown) => Promise<unknown>) => {
+          const txClient = {
+            feeCharge: {
+              createMany: vi.fn().mockResolvedValue({ count: 2 }),
+            },
+          };
+          return fn(txClient);
+        }
+      );
 
       const result = await service.executeBillingRun(CLUB_ID, confirmDto, USER_ID);
 
@@ -267,17 +269,19 @@ describe('FeeChargesService', () => {
       (mockDb.feeCategory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
 
       let capturedData: unknown[] = [];
-      (mockPrisma.$transaction as ReturnType<typeof vi.fn>).mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
-        const txClient = {
-          feeCharge: {
-            createMany: vi.fn().mockImplementation(({ data }: { data: unknown[] }) => {
-              capturedData = data;
-              return { count: data.length };
-            }),
-          },
-        };
-        return fn(txClient);
-      });
+      (mockPrisma.$transaction as ReturnType<typeof vi.fn>).mockImplementation(
+        async (fn: (tx: unknown) => Promise<unknown>) => {
+          const txClient = {
+            feeCharge: {
+              createMany: vi.fn().mockImplementation(({ data }: { data: unknown[] }) => {
+                capturedData = data;
+                return { count: data.length };
+              }),
+            },
+          };
+          return fn(txClient);
+        }
+      );
 
       const result = await service.executeBillingRun(CLUB_ID, confirmDto, USER_ID);
 
@@ -300,17 +304,19 @@ describe('FeeChargesService', () => {
       (mockDb.feeCategory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
 
       let capturedData: unknown[] = [];
-      (mockPrisma.$transaction as ReturnType<typeof vi.fn>).mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
-        const txClient = {
-          feeCharge: {
-            createMany: vi.fn().mockImplementation(({ data }: { data: unknown[] }) => {
-              capturedData = data;
-              return { count: data.length };
-            }),
-          },
-        };
-        return fn(txClient);
-      });
+      (mockPrisma.$transaction as ReturnType<typeof vi.fn>).mockImplementation(
+        async (fn: (tx: unknown) => Promise<unknown>) => {
+          const txClient = {
+            feeCharge: {
+              createMany: vi.fn().mockImplementation(({ data }: { data: unknown[] }) => {
+                capturedData = data;
+                return { count: data.length };
+              }),
+            },
+          };
+          return fn(txClient);
+        }
+      );
 
       await service.executeBillingRun(CLUB_ID, confirmDto, USER_ID);
 
@@ -353,17 +359,19 @@ describe('FeeChargesService', () => {
       (mockDb.feeCategory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
 
       let capturedData: unknown[] = [];
-      (mockPrisma.$transaction as ReturnType<typeof vi.fn>).mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
-        const txClient = {
-          feeCharge: {
-            createMany: vi.fn().mockImplementation(({ data }: { data: unknown[] }) => {
-              capturedData = data;
-              return { count: data.length };
-            }),
-          },
-        };
-        return fn(txClient);
-      });
+      (mockPrisma.$transaction as ReturnType<typeof vi.fn>).mockImplementation(
+        async (fn: (tx: unknown) => Promise<unknown>) => {
+          const txClient = {
+            feeCharge: {
+              createMany: vi.fn().mockImplementation(({ data }: { data: unknown[] }) => {
+                capturedData = data;
+                return { count: data.length };
+              }),
+            },
+          };
+          return fn(txClient);
+        }
+      );
 
       await service.executeBillingRun(CLUB_ID, confirmDto, USER_ID);
 
@@ -390,17 +398,21 @@ describe('FeeChargesService', () => {
       (mockDb.feeCategory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
 
       let skipDuplicatesUsed = false;
-      (mockPrisma.$transaction as ReturnType<typeof vi.fn>).mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
-        const txClient = {
-          feeCharge: {
-            createMany: vi.fn().mockImplementation(({ skipDuplicates }: { skipDuplicates: boolean }) => {
-              skipDuplicatesUsed = skipDuplicates;
-              return { count: 1 };
-            }),
-          },
-        };
-        return fn(txClient);
-      });
+      (mockPrisma.$transaction as ReturnType<typeof vi.fn>).mockImplementation(
+        async (fn: (tx: unknown) => Promise<unknown>) => {
+          const txClient = {
+            feeCharge: {
+              createMany: vi
+                .fn()
+                .mockImplementation(({ skipDuplicates }: { skipDuplicates: boolean }) => {
+                  skipDuplicatesUsed = skipDuplicates;
+                  return { count: 1 };
+                }),
+            },
+          };
+          return fn(txClient);
+        }
+      );
 
       await service.executeBillingRun(CLUB_ID, confirmDto, USER_ID);
 

--- a/apps/api/src/fees/fee-charges.service.spec.ts
+++ b/apps/api/src/fees/fee-charges.service.spec.ts
@@ -1,0 +1,496 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { FeeChargesService } from './fee-charges.service.js';
+import type { PrismaService } from '../prisma/prisma.service.js';
+import { Prisma } from '../../../../prisma/generated/client/index.js';
+
+const { Decimal } = Prisma;
+
+// ─── Mock Data Factories ────────────────────────────────────────────────────
+
+const CLUB_ID = 'club-1';
+const USER_ID = 'user-1';
+
+function makeMember(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'member-1',
+    clubId: CLUB_ID,
+    firstName: 'Max',
+    lastName: 'Mustermann',
+    memberNumber: 'TSV-001',
+    status: 'ACTIVE',
+    householdId: null,
+    householdRole: null,
+    deletedAt: null,
+    membershipPeriods: [
+      {
+        id: 'mp-1',
+        joinDate: new Date('2020-01-01'),
+        leaveDate: null,
+        membershipTypeId: 'mt-1',
+        membershipType: {
+          id: 'mt-1',
+          name: 'Ordentliches Mitglied',
+          feeAmount: new Decimal('120.00'),
+          billingInterval: 'ANNUALLY',
+        },
+      },
+    ],
+    memberFeeOverrides: [],
+    ...overrides,
+  };
+}
+
+function makeMemberWithOverride(overrideType: string, overrides: Record<string, unknown> = {}) {
+  return makeMember({
+    id: 'member-exempt',
+    firstName: 'Exempt',
+    lastName: 'User',
+    memberNumber: 'TSV-003',
+    memberFeeOverrides: [
+      {
+        id: 'override-1',
+        overrideType,
+        customAmount: overrideType === 'CUSTOM_AMOUNT' ? new Decimal('60.00') : null,
+        reason: overrideType === 'EXEMPT' ? 'Ehrenmitglied' : 'Sozialtarif',
+        isBaseFee: true,
+        feeCategoryId: null,
+      },
+    ],
+    ...overrides,
+  });
+}
+
+function makeClub(overrides: Record<string, unknown> = {}) {
+  return {
+    id: CLUB_ID,
+    proRataMode: 'FULL',
+    householdFeeMode: 'NONE',
+    householdDiscountPercent: null,
+    householdFlatAmount: null,
+    ...overrides,
+  };
+}
+
+function makeFeeCharge(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'fc-1',
+    clubId: CLUB_ID,
+    memberId: 'member-1',
+    feeCategoryId: null,
+    membershipTypeId: 'mt-1',
+    description: 'Grundbeitrag 2026',
+    periodStart: new Date('2026-01-01'),
+    periodEnd: new Date('2026-12-31'),
+    amount: new Decimal('120.00'),
+    dueDate: new Date('2026-02-15'),
+    discountAmount: null,
+    discountReason: null,
+    deletedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    member: {
+      id: 'member-1',
+      firstName: 'Max',
+      lastName: 'Mustermann',
+      memberNumber: 'TSV-001',
+    },
+    ...overrides,
+  };
+}
+
+// ─── Mock Prisma ────────────────────────────────────────────────────────────
+
+const mockDb = {
+  feeCategory: {
+    findMany: vi.fn(),
+  },
+  feeCharge: {
+    findMany: vi.fn(),
+    count: vi.fn(),
+    createMany: vi.fn(),
+  },
+};
+
+const mockPrisma = {
+  forClub: vi.fn(() => mockDb),
+  club: {
+    findFirst: vi.fn(),
+  },
+  member: {
+    findMany: vi.fn(),
+  },
+  feeCharge: {
+    findMany: vi.fn(),
+    count: vi.fn(),
+    createMany: vi.fn(),
+  },
+  payment: {
+    groupBy: vi.fn(),
+  },
+  $transaction: vi.fn(),
+} as unknown as PrismaService;
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('FeeChargesService', () => {
+  let service: FeeChargesService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (mockPrisma.forClub as ReturnType<typeof vi.fn>).mockReturnValue(mockDb);
+    service = new FeeChargesService(mockPrisma);
+  });
+
+  // ─── Preview Billing Run ────────────────────────────────────────────
+
+  describe('previewBillingRun()', () => {
+    const previewDto = {
+      periodStart: '2026-01-01',
+      periodEnd: '2026-12-31',
+      billingInterval: 'ANNUALLY' as const,
+    };
+
+    it('should return memberCount=3 and correct totalAmount for 3 active members with annual interval', async () => {
+      const members = [
+        makeMember({ id: 'member-1', memberNumber: 'TSV-001' }),
+        makeMember({ id: 'member-2', firstName: 'Anna', memberNumber: 'TSV-002' }),
+        makeMember({ id: 'member-3', firstName: 'Peter', memberNumber: 'TSV-003' }),
+      ];
+
+      (mockPrisma.club.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeClub());
+      (mockPrisma.member.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(members);
+      (mockDb.feeCategory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+      (mockDb.feeCharge.count as ReturnType<typeof vi.fn>).mockResolvedValue(0);
+
+      const result = await service.previewBillingRun(CLUB_ID, previewDto);
+
+      expect(result.memberCount).toBe(3);
+      expect(result.totalAmount).toBe('360.00');
+      expect(result.exemptions).toBe(0);
+      expect(result.existingCharges).toBe(0);
+    });
+
+    it('should exclude exempt member: memberCount=2, exemptions=1', async () => {
+      const members = [
+        makeMember({ id: 'member-1', memberNumber: 'TSV-001' }),
+        makeMember({ id: 'member-2', firstName: 'Anna', memberNumber: 'TSV-002' }),
+        makeMemberWithOverride('EXEMPT', { id: 'member-3', memberNumber: 'TSV-003' }),
+      ];
+
+      (mockPrisma.club.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeClub());
+      (mockPrisma.member.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(members);
+      (mockDb.feeCategory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+      (mockDb.feeCharge.count as ReturnType<typeof vi.fn>).mockResolvedValue(0);
+
+      const result = await service.previewBillingRun(CLUB_ID, previewDto);
+
+      expect(result.memberCount).toBe(2);
+      expect(result.exemptions).toBe(1);
+      expect(result.totalAmount).toBe('240.00');
+    });
+
+    it('should detect existing charges for same period and report existingCharges count', async () => {
+      const members = [makeMember()];
+
+      (mockPrisma.club.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeClub());
+      (mockPrisma.member.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(members);
+      (mockDb.feeCategory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+      (mockDb.feeCharge.count as ReturnType<typeof vi.fn>).mockResolvedValue(5);
+
+      const result = await service.previewBillingRun(CLUB_ID, previewDto);
+
+      expect(result.existingCharges).toBe(5);
+    });
+  });
+
+  // ─── Execute Billing Run ────────────────────────────────────────────
+
+  describe('executeBillingRun()', () => {
+    const confirmDto = {
+      periodStart: '2026-01-01',
+      periodEnd: '2026-12-31',
+      billingInterval: 'ANNUALLY' as const,
+      dueDate: '2026-02-15',
+    };
+
+    it('should create FeeCharge records for each member in a transaction', async () => {
+      const members = [
+        makeMember({ id: 'member-1', memberNumber: 'TSV-001' }),
+        makeMember({ id: 'member-2', firstName: 'Anna', memberNumber: 'TSV-002' }),
+      ];
+
+      (mockPrisma.club.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeClub());
+      (mockPrisma.member.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(members);
+      (mockDb.feeCategory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+      (mockPrisma.$transaction as ReturnType<typeof vi.fn>).mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+        const txClient = {
+          feeCharge: {
+            createMany: vi.fn().mockResolvedValue({ count: 2 }),
+          },
+        };
+        return fn(txClient);
+      });
+
+      const result = await service.executeBillingRun(CLUB_ID, confirmDto, USER_ID);
+
+      expect(result.chargesCreated).toBe(2);
+      expect(result.totalAmount).toBe('240.00');
+      expect(mockPrisma.$transaction).toHaveBeenCalled();
+    });
+
+    it('should apply MONTHLY_PRO_RATA with mid-year join using HALF_UP rounding', async () => {
+      // Member joined July 1st = 6 months remaining out of 12, so 120 * 6/12 = 60.00
+      const members = [
+        makeMember({
+          id: 'member-prorata',
+          membershipPeriods: [
+            {
+              id: 'mp-prorata',
+              joinDate: new Date('2026-07-01'),
+              leaveDate: null,
+              membershipTypeId: 'mt-1',
+              membershipType: {
+                id: 'mt-1',
+                name: 'Ordentliches Mitglied',
+                feeAmount: new Decimal('120.00'),
+                billingInterval: 'ANNUALLY',
+              },
+            },
+          ],
+        }),
+      ];
+
+      (mockPrisma.club.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(
+        makeClub({ proRataMode: 'MONTHLY_PRO_RATA' })
+      );
+      (mockPrisma.member.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(members);
+      (mockDb.feeCategory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+      let capturedData: unknown[] = [];
+      (mockPrisma.$transaction as ReturnType<typeof vi.fn>).mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+        const txClient = {
+          feeCharge: {
+            createMany: vi.fn().mockImplementation(({ data }: { data: unknown[] }) => {
+              capturedData = data;
+              return { count: data.length };
+            }),
+          },
+        };
+        return fn(txClient);
+      });
+
+      const result = await service.executeBillingRun(CLUB_ID, confirmDto, USER_ID);
+
+      expect(result.chargesCreated).toBe(1);
+      // 120 * 6/12 = 60.00
+      expect(result.totalAmount).toBe('60.00');
+      expect((capturedData[0] as { amount: Prisma.Decimal }).amount.toFixed(2)).toBe('60.00');
+    });
+
+    it('should store discountAmount and discountReason on charges with CUSTOM_AMOUNT overrides', async () => {
+      const members = [
+        makeMemberWithOverride('CUSTOM_AMOUNT', {
+          id: 'member-custom',
+          memberNumber: 'TSV-010',
+        }),
+      ];
+
+      (mockPrisma.club.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeClub());
+      (mockPrisma.member.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(members);
+      (mockDb.feeCategory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+      let capturedData: unknown[] = [];
+      (mockPrisma.$transaction as ReturnType<typeof vi.fn>).mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+        const txClient = {
+          feeCharge: {
+            createMany: vi.fn().mockImplementation(({ data }: { data: unknown[] }) => {
+              capturedData = data;
+              return { count: data.length };
+            }),
+          },
+        };
+        return fn(txClient);
+      });
+
+      await service.executeBillingRun(CLUB_ID, confirmDto, USER_ID);
+
+      const charge = capturedData[0] as {
+        amount: Prisma.Decimal;
+        discountAmount: Prisma.Decimal;
+        discountReason: string;
+      };
+      // Original 120, custom 60 => discount = 60
+      expect(charge.amount.toFixed(2)).toBe('60.00');
+      expect(charge.discountAmount.toFixed(2)).toBe('60.00');
+      expect(charge.discountReason).toContain('Individueller Betrag');
+    });
+
+    it('should apply household PERCENTAGE discount and populate discountAmount', async () => {
+      const headMember = makeMember({
+        id: 'member-head',
+        memberNumber: 'TSV-020',
+        householdId: 'hh-1',
+        householdRole: 'HEAD',
+      });
+      const spouseMember = makeMember({
+        id: 'member-spouse',
+        firstName: 'Anna',
+        memberNumber: 'TSV-021',
+        householdId: 'hh-1',
+        householdRole: 'SPOUSE',
+      });
+
+      (mockPrisma.club.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(
+        makeClub({
+          householdFeeMode: 'PERCENTAGE',
+          householdDiscountPercent: 50,
+        })
+      );
+      (mockPrisma.member.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
+        headMember,
+        spouseMember,
+      ]);
+      (mockDb.feeCategory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+      let capturedData: unknown[] = [];
+      (mockPrisma.$transaction as ReturnType<typeof vi.fn>).mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+        const txClient = {
+          feeCharge: {
+            createMany: vi.fn().mockImplementation(({ data }: { data: unknown[] }) => {
+              capturedData = data;
+              return { count: data.length };
+            }),
+          },
+        };
+        return fn(txClient);
+      });
+
+      await service.executeBillingRun(CLUB_ID, confirmDto, USER_ID);
+
+      // HEAD pays full 120, SPOUSE pays 60 (50% discount)
+      const headCharge = capturedData.find(
+        (c: unknown) => (c as { memberId: string }).memberId === 'member-head'
+      ) as { amount: Prisma.Decimal; discountAmount: Prisma.Decimal | null };
+      const spouseCharge = capturedData.find(
+        (c: unknown) => (c as { memberId: string }).memberId === 'member-spouse'
+      ) as { amount: Prisma.Decimal; discountAmount: Prisma.Decimal; discountReason: string };
+
+      expect(headCharge.amount.toFixed(2)).toBe('120.00');
+      expect(headCharge.discountAmount).toBeNull();
+      expect(spouseCharge.amount.toFixed(2)).toBe('60.00');
+      expect(spouseCharge.discountAmount.toFixed(2)).toBe('60.00');
+      expect(spouseCharge.discountReason).toContain('Haushaltsrabatt');
+    });
+
+    it('should skip duplicates via createMany skipDuplicates (idempotent)', async () => {
+      const members = [makeMember()];
+
+      (mockPrisma.club.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeClub());
+      (mockPrisma.member.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(members);
+      (mockDb.feeCategory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+      let skipDuplicatesUsed = false;
+      (mockPrisma.$transaction as ReturnType<typeof vi.fn>).mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+        const txClient = {
+          feeCharge: {
+            createMany: vi.fn().mockImplementation(({ skipDuplicates }: { skipDuplicates: boolean }) => {
+              skipDuplicatesUsed = skipDuplicates;
+              return { count: 1 };
+            }),
+          },
+        };
+        return fn(txClient);
+      });
+
+      await service.executeBillingRun(CLUB_ID, confirmDto, USER_ID);
+
+      expect(skipDuplicatesUsed).toBe(true);
+    });
+  });
+
+  // ─── findAllWithStatus ──────────────────────────────────────────────
+
+  describe('findAllWithStatus()', () => {
+    it('should return OPEN status when no payments exist', async () => {
+      const charges = [makeFeeCharge()];
+      (mockDb.feeCharge.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(charges);
+      (mockDb.feeCharge.count as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+      (mockPrisma.payment.groupBy as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+      const result = await service.findAllWithStatus(CLUB_ID, {});
+
+      expect(result.data[0]!.status).toBe('OPEN');
+      expect(result.data[0]!.paidAmount).toBe('0.00');
+      expect(result.data[0]!.remainingAmount).toBe('120.00');
+    });
+
+    it('should return PARTIAL status when sum(payments) < amount', async () => {
+      const charges = [makeFeeCharge()];
+      (mockDb.feeCharge.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(charges);
+      (mockDb.feeCharge.count as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+      (mockPrisma.payment.groupBy as ReturnType<typeof vi.fn>).mockResolvedValue([
+        { feeChargeId: 'fc-1', _sum: { amount: new Decimal('50.00') } },
+      ]);
+
+      const result = await service.findAllWithStatus(CLUB_ID, {});
+
+      expect(result.data[0]!.status).toBe('PARTIAL');
+      expect(result.data[0]!.paidAmount).toBe('50.00');
+      expect(result.data[0]!.remainingAmount).toBe('70.00');
+    });
+
+    it('should return PAID status when sum(payments) >= amount', async () => {
+      const charges = [makeFeeCharge()];
+      (mockDb.feeCharge.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(charges);
+      (mockDb.feeCharge.count as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+      (mockPrisma.payment.groupBy as ReturnType<typeof vi.fn>).mockResolvedValue([
+        { feeChargeId: 'fc-1', _sum: { amount: new Decimal('120.00') } },
+      ]);
+
+      const result = await service.findAllWithStatus(CLUB_ID, {});
+
+      expect(result.data[0]!.status).toBe('PAID');
+      expect(result.data[0]!.paidAmount).toBe('120.00');
+      expect(result.data[0]!.remainingAmount).toBe('0.00');
+    });
+
+    it('should set isOverdue=true when dueDate < today and status != PAID', async () => {
+      const pastDueCharge = makeFeeCharge({
+        dueDate: new Date('2020-01-01'), // Well in the past
+      });
+      (mockDb.feeCharge.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([pastDueCharge]);
+      (mockDb.feeCharge.count as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+      (mockPrisma.payment.groupBy as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+      const result = await service.findAllWithStatus(CLUB_ID, {});
+
+      expect(result.data[0]!.isOverdue).toBe(true);
+    });
+
+    it('should filter by status, memberId, and period', async () => {
+      const charges = [
+        makeFeeCharge({ id: 'fc-1', memberId: 'member-1' }),
+        makeFeeCharge({ id: 'fc-2', memberId: 'member-2' }),
+      ];
+      (mockDb.feeCharge.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([charges[0]!]);
+      (mockDb.feeCharge.count as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+      (mockPrisma.payment.groupBy as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+      const result = await service.findAllWithStatus(CLUB_ID, {
+        memberId: 'member-1',
+        periodStart: '2026-01-01',
+        periodEnd: '2026-12-31',
+      });
+
+      expect(result.data).toHaveLength(1);
+      // Check that findMany was called with the correct filters
+      expect(mockDb.feeCharge.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            memberId: 'member-1',
+          }),
+        })
+      );
+    });
+  });
+});

--- a/apps/api/src/fees/fee-charges.service.spec.ts
+++ b/apps/api/src/fees/fee-charges.service.spec.ts
@@ -8,7 +8,6 @@ const { Decimal } = Prisma;
 // ─── Mock Data Factories ────────────────────────────────────────────────────
 
 const CLUB_ID = 'club-1';
-const USER_ID = 'user-1';
 
 function makeMember(overrides: Record<string, unknown> = {}) {
   return {
@@ -233,7 +232,7 @@ describe('FeeChargesService', () => {
         }
       );
 
-      const result = await service.executeBillingRun(CLUB_ID, confirmDto, USER_ID);
+      const result = await service.executeBillingRun(CLUB_ID, confirmDto);
 
       expect(result.chargesCreated).toBe(2);
       expect(result.totalAmount).toBe('240.00');
@@ -283,7 +282,7 @@ describe('FeeChargesService', () => {
         }
       );
 
-      const result = await service.executeBillingRun(CLUB_ID, confirmDto, USER_ID);
+      const result = await service.executeBillingRun(CLUB_ID, confirmDto);
 
       expect(result.chargesCreated).toBe(1);
       // 120 * 6/12 = 60.00
@@ -318,7 +317,7 @@ describe('FeeChargesService', () => {
         }
       );
 
-      await service.executeBillingRun(CLUB_ID, confirmDto, USER_ID);
+      await service.executeBillingRun(CLUB_ID, confirmDto);
 
       const charge = capturedData[0] as {
         amount: Prisma.Decimal;
@@ -373,7 +372,7 @@ describe('FeeChargesService', () => {
         }
       );
 
-      await service.executeBillingRun(CLUB_ID, confirmDto, USER_ID);
+      await service.executeBillingRun(CLUB_ID, confirmDto);
 
       // HEAD pays full 120, SPOUSE pays 60 (50% discount)
       const headCharge = capturedData.find(
@@ -414,7 +413,7 @@ describe('FeeChargesService', () => {
         }
       );
 
-      await service.executeBillingRun(CLUB_ID, confirmDto, USER_ID);
+      await service.executeBillingRun(CLUB_ID, confirmDto);
 
       expect(skipDuplicatesUsed).toBe(true);
     });

--- a/apps/api/src/fees/fee-charges.service.spec.ts
+++ b/apps/api/src/fees/fee-charges.service.spec.ts
@@ -503,5 +503,118 @@ describe('FeeChargesService', () => {
         })
       );
     });
+
+    it('should return correct total when filtering by status (two-pass)', async () => {
+      // 3 charges: 1 OPEN (no payments), 1 PAID (fully paid), 1 OVERDUE (past due, no payments)
+      const openCharge = makeFeeCharge({ id: 'fc-open', dueDate: new Date('2099-12-31') });
+
+      // Pass 1: lightweight query returns all 3 charges (select: id, amount, dueDate)
+      (mockDb.feeCharge.findMany as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce([
+          { id: 'fc-open', amount: new Decimal('120.00'), dueDate: new Date('2099-12-31') },
+          { id: 'fc-paid', amount: new Decimal('120.00'), dueDate: new Date('2099-12-31') },
+          { id: 'fc-overdue', amount: new Decimal('120.00'), dueDate: new Date('2020-01-01') },
+        ])
+        // Pass 2: full data for filtered page (only the OPEN charge)
+        .mockResolvedValueOnce([openCharge]);
+
+      // Payment aggregates: only fc-paid is fully paid
+      (mockPrisma.payment.groupBy as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce([
+          { feeChargeId: 'fc-paid', _sum: { amount: new Decimal('120.00') } },
+        ])
+        // Second call for enrichChargesWithStatus
+        .mockResolvedValueOnce([]);
+
+      const result = await service.findAllWithStatus(CLUB_ID, { status: 'OPEN' });
+
+      // Only fc-open matches OPEN (fc-overdue is OPEN but overdue, not "OPEN" status-wise — it IS open but also overdue)
+      // Actually OPEN means: not paid, not overdue. fc-open is OPEN (future due), fc-overdue has status OPEN but isOverdue=true.
+      // The filter `status === 'OPEN'` matches both since computeChargeStatus returns status='OPEN' for both.
+      // But the status filter checks `status === query.status`, so both fc-open and fc-overdue match 'OPEN'.
+      expect(result.total).toBe(2);
+      expect(result.page).toBe(1);
+    });
+
+    it('should paginate correctly with status filter', async () => {
+      // Create 25 OPEN charges + 5 PAID charges
+      const openChargesLight = Array.from({ length: 25 }, (_, i) => ({
+        id: `fc-open-${i}`,
+        amount: new Decimal('10.00'),
+        dueDate: new Date('2099-12-31'),
+      }));
+      const paidChargesLight = Array.from({ length: 5 }, (_, i) => ({
+        id: `fc-paid-${i}`,
+        amount: new Decimal('10.00'),
+        dueDate: new Date('2099-12-31'),
+      }));
+
+      // Pass 1: all 30 charges
+      (mockDb.feeCharge.findMany as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce([...openChargesLight, ...paidChargesLight])
+        // Pass 2: 5 charges for page 2 (ids fc-open-20 through fc-open-24)
+        .mockResolvedValueOnce(
+          Array.from({ length: 5 }, (_, i) =>
+            makeFeeCharge({
+              id: `fc-open-${20 + i}`,
+              amount: new Decimal('10.00'),
+              dueDate: new Date('2099-12-31'),
+            })
+          )
+        );
+
+      // Payment sums: only paid charges have payments
+      const paidAggregates = Array.from({ length: 5 }, (_, i) => ({
+        feeChargeId: `fc-paid-${i}`,
+        _sum: { amount: new Decimal('10.00') },
+      }));
+
+      (mockPrisma.payment.groupBy as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(paidAggregates)
+        // Second call for enrichChargesWithStatus on page 2 data
+        .mockResolvedValueOnce([]);
+
+      const result = await service.findAllWithStatus(CLUB_ID, {
+        status: 'OPEN',
+        page: 2,
+        limit: 20,
+      });
+
+      expect(result.total).toBe(25);
+      expect(result.data).toHaveLength(5);
+      expect(result.page).toBe(2);
+      expect(result.limit).toBe(20);
+    });
+
+    it('should return correct total when filtering by OVERDUE', async () => {
+      // 2 overdue (past due, unpaid), 1 future OPEN
+      (mockDb.feeCharge.findMany as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce([
+          { id: 'fc-overdue-1', amount: new Decimal('50.00'), dueDate: new Date('2020-01-01') },
+          { id: 'fc-overdue-2', amount: new Decimal('50.00'), dueDate: new Date('2020-06-01') },
+          { id: 'fc-future', amount: new Decimal('50.00'), dueDate: new Date('2099-12-31') },
+        ])
+        .mockResolvedValueOnce([
+          makeFeeCharge({
+            id: 'fc-overdue-1',
+            amount: new Decimal('50.00'),
+            dueDate: new Date('2020-01-01'),
+          }),
+          makeFeeCharge({
+            id: 'fc-overdue-2',
+            amount: new Decimal('50.00'),
+            dueDate: new Date('2020-06-01'),
+          }),
+        ]);
+
+      (mockPrisma.payment.groupBy as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([]);
+
+      const result = await service.findAllWithStatus(CLUB_ID, { status: 'OVERDUE' });
+
+      expect(result.total).toBe(2);
+      expect(result.data).toHaveLength(2);
+    });
   });
 });

--- a/apps/api/src/fees/fee-charges.service.ts
+++ b/apps/api/src/fees/fee-charges.service.ts
@@ -89,7 +89,7 @@ export class FeeChargesService {
    * Execute billing run and create FeeCharge records in a transaction.
    * Uses createMany with skipDuplicates for idempotency.
    */
-  async executeBillingRun(clubId: string, dto: BillingRunConfirmDto, _userId: string) {
+  async executeBillingRun(clubId: string, dto: BillingRunConfirmDto) {
     if (new Date(dto.periodStart) >= new Date(dto.periodEnd)) {
       throw new BadRequestException('Periodenbeginn muss vor dem Periodenende liegen');
     }
@@ -130,6 +130,11 @@ export class FeeChargesService {
   /**
    * Find all fee charges with computed payment status using SQL-level aggregation.
    * Returns paginated results with OPEN/PARTIAL/PAID status and overdue flag.
+   *
+   * Note: OVERDUE is a computed status (dueDate < today && not fully paid), so
+   * filtering by OVERDUE happens post-query. This means `total` reflects the
+   * unfiltered count and pages may appear partially empty when the OVERDUE filter
+   * is active. A proper fix requires SQL-level status computation.
    */
   async findAllWithStatus(clubId: string, query: FeeChargeQueryDto) {
     const db = this.prisma.forClub(clubId);

--- a/apps/api/src/fees/fee-charges.service.ts
+++ b/apps/api/src/fees/fee-charges.service.ts
@@ -96,7 +96,14 @@ export class FeeChargesService {
     const totalAmount = chargeDataArray.reduce((sum, c) => sum.plus(c.amount), ZERO);
 
     const result = await this.prisma.$transaction(
-      async (tx: { feeCharge: { createMany: (args: { data: ChargeData[]; skipDuplicates: boolean }) => Promise<{ count: number }> } }) => {
+      async (tx: {
+        feeCharge: {
+          createMany: (args: {
+            data: ChargeData[];
+            skipDuplicates: boolean;
+          }) => Promise<{ count: number }>;
+        };
+      }) => {
         return tx.feeCharge.createMany({
           data: chargeDataArray,
           skipDuplicates: true,
@@ -161,10 +168,12 @@ export class FeeChargesService {
         : [];
 
     const paymentSumMap = new Map(
-      paymentAggregates.map((pa: { feeChargeId: string; _sum: { amount: Prisma.Decimal | null } }) => [
-        pa.feeChargeId,
-        pa._sum.amount ?? ZERO,
-      ])
+      paymentAggregates.map(
+        (pa: { feeChargeId: string; _sum: { amount: Prisma.Decimal | null } }) => [
+          pa.feeChargeId,
+          pa._sum.amount ?? ZERO,
+        ]
+      )
     );
 
     const today = new Date();
@@ -173,7 +182,10 @@ export class FeeChargesService {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let enrichedCharges = charges.map((charge: any) => {
       const paidAmount = paymentSumMap.get(charge.id) ?? ZERO;
-      const amount = charge.amount instanceof Prisma.Decimal ? charge.amount : new Prisma.Decimal(String(charge.amount));
+      const amount =
+        charge.amount instanceof Prisma.Decimal
+          ? charge.amount
+          : new Prisma.Decimal(String(charge.amount));
       const status = paidAmount.gte(amount) ? 'PAID' : paidAmount.gt(ZERO) ? 'PARTIAL' : 'OPEN';
       const dueDate = new Date(charge.dueDate);
       dueDate.setHours(0, 0, 0, 0);
@@ -194,11 +206,22 @@ export class FeeChargesService {
         remainingAmount: roundMoney(remainingAmount).toFixed(DECIMAL_PLACES),
         status,
         isOverdue,
-        periodStart: charge.periodStart instanceof Date ? charge.periodStart.toISOString().split('T')[0] : charge.periodStart,
-        periodEnd: charge.periodEnd instanceof Date ? charge.periodEnd.toISOString().split('T')[0] : charge.periodEnd,
-        dueDate: charge.dueDate instanceof Date ? charge.dueDate.toISOString().split('T')[0] : charge.dueDate,
-        createdAt: charge.createdAt instanceof Date ? charge.createdAt.toISOString() : charge.createdAt,
-        updatedAt: charge.updatedAt instanceof Date ? charge.updatedAt.toISOString() : charge.updatedAt,
+        periodStart:
+          charge.periodStart instanceof Date
+            ? charge.periodStart.toISOString().split('T')[0]
+            : charge.periodStart,
+        periodEnd:
+          charge.periodEnd instanceof Date
+            ? charge.periodEnd.toISOString().split('T')[0]
+            : charge.periodEnd,
+        dueDate:
+          charge.dueDate instanceof Date
+            ? charge.dueDate.toISOString().split('T')[0]
+            : charge.dueDate,
+        createdAt:
+          charge.createdAt instanceof Date ? charge.createdAt.toISOString() : charge.createdAt,
+        updatedAt:
+          charge.updatedAt instanceof Date ? charge.updatedAt.toISOString() : charge.updatedAt,
       };
     });
 
@@ -206,10 +229,13 @@ export class FeeChargesService {
     if (query.status) {
       if (query.status === 'OVERDUE') {
         enrichedCharges = enrichedCharges.filter(
-          (c: { isOverdue: boolean; status: string }) => c.isOverdue && (c.status === 'OPEN' || c.status === 'PARTIAL')
+          (c: { isOverdue: boolean; status: string }) =>
+            c.isOverdue && (c.status === 'OPEN' || c.status === 'PARTIAL')
         );
       } else {
-        enrichedCharges = enrichedCharges.filter((c: { status: string }) => c.status === query.status);
+        enrichedCharges = enrichedCharges.filter(
+          (c: { status: string }) => c.status === query.status
+        );
       }
     }
 
@@ -390,7 +416,12 @@ export class FeeChargesService {
         baseFee = roundMoney(baseFee);
 
         const typeName = membershipType.name;
-        const description = this.generateChargeDescription(typeName, periodStart, periodEnd, dto.billingInterval);
+        const description = this.generateChargeDescription(
+          typeName,
+          periodStart,
+          periodEnd,
+          dto.billingInterval
+        );
 
         charges.push({
           clubId,
@@ -480,7 +511,7 @@ export class FeeChargesService {
     joinDate: Date,
     periodStart: Date,
     periodEnd: Date,
-    billingInterval: string
+    _billingInterval: string
   ): Prisma.Decimal {
     const join = new Date(joinDate);
 
@@ -507,9 +538,7 @@ export class FeeChargesService {
 
     // Pro-rata: feeAmount * remainingMonths / totalMonths
     return roundMoney(
-      feeAmount
-        .mul(new Prisma.Decimal(remainingMonths))
-        .div(new Prisma.Decimal(totalMonths))
+      feeAmount.mul(new Prisma.Decimal(remainingMonths)).div(new Prisma.Decimal(totalMonths))
     );
   }
 

--- a/apps/api/src/fees/fee-charges.service.ts
+++ b/apps/api/src/fees/fee-charges.service.ts
@@ -1,0 +1,551 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { Prisma } from '../../../../prisma/generated/client/index.js';
+import type { BillingRunPreviewDto } from './dto/billing-run-preview.dto.js';
+import type { BillingRunConfirmDto } from './dto/billing-run-confirm.dto.js';
+import type { FeeChargeQueryDto } from './dto/fee-charge-query.dto.js';
+
+// Explicit rounding strategy for all money calculations
+// HALF_UP is the standard banker's rounding: 0.5 rounds up to 1
+const ROUNDING_MODE = Prisma.Decimal.ROUND_HALF_UP;
+const DECIMAL_PLACES = 2;
+
+function roundMoney(value: Prisma.Decimal): Prisma.Decimal {
+  return value.toDecimalPlaces(DECIMAL_PLACES, ROUNDING_MODE);
+}
+
+const ZERO = new Prisma.Decimal(0);
+
+/** Charge data prepared from billing calculation */
+interface ChargeData {
+  clubId: string;
+  memberId: string;
+  feeCategoryId: string | null;
+  membershipTypeId: string | null;
+  description: string;
+  periodStart: Date;
+  periodEnd: Date;
+  amount: Prisma.Decimal;
+  dueDate: Date;
+  discountAmount: Prisma.Decimal | null;
+  discountReason: string | null;
+}
+
+/** Breakdown entry per membership type for preview */
+interface BreakdownEntry {
+  membershipType: string;
+  count: number;
+  subtotal: Prisma.Decimal;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type MemberWithRelations = any;
+
+@Injectable()
+export class FeeChargesService {
+  constructor(private prisma: PrismaService) {}
+
+  // ─── Billing Run: Preview ───────────────────────────────────────────
+
+  /**
+   * Preview billing run without side effects.
+   * Calculates what each active member owes for the specified period.
+   */
+  async previewBillingRun(clubId: string, dto: BillingRunPreviewDto) {
+    const { charges, exemptions, breakdown } = await this.calculateBillingCharges(clubId, dto);
+
+    // Check for existing charges for duplicate detection
+    const db = this.prisma.forClub(clubId);
+    const existingCharges = await db.feeCharge.count({
+      where: {
+        deletedAt: null,
+        periodStart: new Date(dto.periodStart),
+        periodEnd: new Date(dto.periodEnd),
+      },
+    });
+
+    const totalAmount = charges.reduce((sum, c) => sum.plus(c.amount), ZERO);
+
+    return {
+      memberCount: charges.length,
+      totalAmount: roundMoney(totalAmount).toFixed(DECIMAL_PLACES),
+      exemptions,
+      breakdown: breakdown.map((b) => ({
+        membershipType: b.membershipType,
+        count: b.count,
+        subtotal: roundMoney(b.subtotal).toFixed(DECIMAL_PLACES),
+      })),
+      existingCharges,
+    };
+  }
+
+  // ─── Billing Run: Execute ───────────────────────────────────────────
+
+  /**
+   * Execute billing run and create FeeCharge records in a transaction.
+   * Uses createMany with skipDuplicates for idempotency.
+   */
+  async executeBillingRun(clubId: string, dto: BillingRunConfirmDto, _userId: string) {
+    const { charges } = await this.calculateBillingCharges(clubId, dto);
+
+    const chargeDataArray: ChargeData[] = charges.map((c) => ({
+      ...c,
+      dueDate: new Date(dto.dueDate),
+    }));
+
+    const totalAmount = chargeDataArray.reduce((sum, c) => sum.plus(c.amount), ZERO);
+
+    const result = await this.prisma.$transaction(
+      async (tx: { feeCharge: { createMany: (args: { data: ChargeData[]; skipDuplicates: boolean }) => Promise<{ count: number }> } }) => {
+        return tx.feeCharge.createMany({
+          data: chargeDataArray,
+          skipDuplicates: true,
+        });
+      }
+    );
+
+    return {
+      chargesCreated: result.count,
+      totalAmount: roundMoney(totalAmount).toFixed(DECIMAL_PLACES),
+    };
+  }
+
+  // ─── FeeCharge Queries ──────────────────────────────────────────────
+
+  /**
+   * Find all fee charges with computed payment status using SQL-level aggregation.
+   * Returns paginated results with OPEN/PARTIAL/PAID status and overdue flag.
+   */
+  async findAllWithStatus(clubId: string, query: FeeChargeQueryDto) {
+    const db = this.prisma.forClub(clubId);
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 20;
+    const skip = (page - 1) * limit;
+
+    // Build filter conditions
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const where: any = {
+      deletedAt: null,
+      ...(query.memberId && { memberId: query.memberId }),
+      ...(query.periodStart && { periodStart: { gte: new Date(query.periodStart) } }),
+      ...(query.periodEnd && { periodEnd: { lte: new Date(query.periodEnd) } }),
+    };
+
+    const [charges, total] = await Promise.all([
+      db.feeCharge.findMany({
+        where,
+        include: {
+          member: {
+            select: { id: true, firstName: true, lastName: true, memberNumber: true },
+          },
+        },
+        orderBy: { dueDate: 'desc' },
+        skip,
+        take: limit,
+      }),
+      db.feeCharge.count({ where }),
+    ]);
+
+    // Batch-fetch payment aggregates for all charge IDs (SQL-level aggregation)
+    const chargeIds = charges.map((c: { id: string }) => c.id);
+    const paymentAggregates =
+      chargeIds.length > 0
+        ? await this.prisma.payment.groupBy({
+            by: ['feeChargeId'],
+            where: {
+              feeChargeId: { in: chargeIds },
+              deletedAt: null,
+            },
+            _sum: { amount: true },
+          })
+        : [];
+
+    const paymentSumMap = new Map(
+      paymentAggregates.map((pa: { feeChargeId: string; _sum: { amount: Prisma.Decimal | null } }) => [
+        pa.feeChargeId,
+        pa._sum.amount ?? ZERO,
+      ])
+    );
+
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let enrichedCharges = charges.map((charge: any) => {
+      const paidAmount = paymentSumMap.get(charge.id) ?? ZERO;
+      const amount = charge.amount instanceof Prisma.Decimal ? charge.amount : new Prisma.Decimal(String(charge.amount));
+      const status = paidAmount.gte(amount) ? 'PAID' : paidAmount.gt(ZERO) ? 'PARTIAL' : 'OPEN';
+      const dueDate = new Date(charge.dueDate);
+      dueDate.setHours(0, 0, 0, 0);
+      const isOverdue = status !== 'PAID' && dueDate < today;
+      const remaining = amount.minus(paidAmount);
+      const remainingAmount = remaining.lt(ZERO) ? ZERO : remaining;
+
+      return {
+        ...charge,
+        amount: amount.toFixed(DECIMAL_PLACES),
+        discountAmount: charge.discountAmount
+          ? (charge.discountAmount instanceof Prisma.Decimal
+              ? charge.discountAmount
+              : new Prisma.Decimal(String(charge.discountAmount))
+            ).toFixed(DECIMAL_PLACES)
+          : null,
+        paidAmount: paidAmount.toFixed(DECIMAL_PLACES),
+        remainingAmount: roundMoney(remainingAmount).toFixed(DECIMAL_PLACES),
+        status,
+        isOverdue,
+        periodStart: charge.periodStart instanceof Date ? charge.periodStart.toISOString().split('T')[0] : charge.periodStart,
+        periodEnd: charge.periodEnd instanceof Date ? charge.periodEnd.toISOString().split('T')[0] : charge.periodEnd,
+        dueDate: charge.dueDate instanceof Date ? charge.dueDate.toISOString().split('T')[0] : charge.dueDate,
+        createdAt: charge.createdAt instanceof Date ? charge.createdAt.toISOString() : charge.createdAt,
+        updatedAt: charge.updatedAt instanceof Date ? charge.updatedAt.toISOString() : charge.updatedAt,
+      };
+    });
+
+    // Post-query status filter (OVERDUE is a special computed status)
+    if (query.status) {
+      if (query.status === 'OVERDUE') {
+        enrichedCharges = enrichedCharges.filter(
+          (c: { isOverdue: boolean; status: string }) => c.isOverdue && (c.status === 'OPEN' || c.status === 'PARTIAL')
+        );
+      } else {
+        enrichedCharges = enrichedCharges.filter((c: { status: string }) => c.status === query.status);
+      }
+    }
+
+    return {
+      data: enrichedCharges,
+      total,
+      page,
+      limit,
+    };
+  }
+
+  // ─── findByMember ───────────────────────────────────────────────────
+
+  /**
+   * Find charges for a specific member with computed status.
+   * Used for member detail section.
+   */
+  async findByMember(clubId: string, memberId: string, options?: { limit?: number }) {
+    return this.findAllWithStatus(clubId, {
+      memberId,
+      limit: options?.limit ?? 20,
+    });
+  }
+
+  // ─── Private: Billing Calculation Logic ─────────────────────────────
+
+  /**
+   * Core billing calculation used by both preview and confirm.
+   * Returns charge data, exemption count, and breakdown by membership type.
+   */
+  private async calculateBillingCharges(
+    clubId: string,
+    dto: BillingRunPreviewDto
+  ): Promise<{
+    charges: Omit<ChargeData, 'dueDate'>[];
+    exemptions: number;
+    breakdown: BreakdownEntry[];
+  }> {
+    const db = this.prisma.forClub(clubId);
+
+    // 1. Get club settings
+    const club = await this.prisma.club.findFirst({
+      where: { id: clubId },
+      select: {
+        proRataMode: true,
+        householdFeeMode: true,
+        householdDiscountPercent: true,
+        householdFlatAmount: true,
+      },
+    });
+
+    // 2. Get active members with membership info and overrides
+    const members = await this.prisma.member.findMany({
+      where: {
+        clubId,
+        status: 'ACTIVE',
+        deletedAt: null,
+      },
+      include: {
+        membershipPeriods: {
+          where: { leaveDate: null },
+          include: {
+            membershipType: {
+              select: {
+                id: true,
+                name: true,
+                feeAmount: true,
+                billingInterval: true,
+              },
+            },
+          },
+          orderBy: { joinDate: 'desc' },
+          take: 1,
+        },
+        memberFeeOverrides: true,
+      },
+    });
+
+    // 3. Get active fee categories matching the billing interval
+    const feeCategories = await db.feeCategory.findMany({
+      where: {
+        deletedAt: null,
+        isActive: true,
+        billingInterval: dto.billingInterval,
+      },
+    });
+
+    const periodStart = new Date(dto.periodStart);
+    const periodEnd = new Date(dto.periodEnd);
+
+    const charges: Omit<ChargeData, 'dueDate'>[] = [];
+    let exemptions = 0;
+    const breakdownMap = new Map<string, BreakdownEntry>();
+
+    for (const member of members) {
+      const currentPeriod = member.membershipPeriods[0];
+      if (!currentPeriod?.membershipType) continue;
+
+      const membershipType = currentPeriod.membershipType;
+      const baseFeeOverrides = member.memberFeeOverrides.filter(
+        (o: MemberWithRelations) => o.isBaseFee && !o.feeCategoryId
+      );
+
+      // Check for base fee exemption
+      const isExempt = baseFeeOverrides.some(
+        (o: MemberWithRelations) => o.overrideType === 'EXEMPT'
+      );
+
+      if (isExempt) {
+        exemptions++;
+        continue;
+      }
+
+      // Calculate base fee if membership type has a fee and matches interval
+      if (membershipType.feeAmount && membershipType.billingInterval === dto.billingInterval) {
+        let baseFee = new Prisma.Decimal(membershipType.feeAmount.toString());
+        let discountAmount: Prisma.Decimal | null = null;
+        let discountReason: string | null = null;
+
+        // Check for CUSTOM_AMOUNT override
+        const customOverride = baseFeeOverrides.find(
+          (o: MemberWithRelations) => o.overrideType === 'CUSTOM_AMOUNT'
+        );
+        if (customOverride?.customAmount) {
+          const originalFee = baseFee;
+          baseFee = new Prisma.Decimal(customOverride.customAmount.toString());
+          discountAmount = roundMoney(originalFee.minus(baseFee));
+          discountReason = `Individueller Betrag: ${customOverride.reason ?? ''}`.trim();
+        }
+
+        // Apply pro-rata if configured
+        if (club?.proRataMode === 'MONTHLY_PRO_RATA') {
+          baseFee = this.calculateProRata(
+            baseFee,
+            currentPeriod.joinDate,
+            periodStart,
+            periodEnd,
+            dto.billingInterval
+          );
+          // Recalculate discount if pro-rata was applied and there was a custom override
+          if (customOverride?.customAmount) {
+            const originalProRata = this.calculateProRata(
+              new Prisma.Decimal(membershipType.feeAmount.toString()),
+              currentPeriod.joinDate,
+              periodStart,
+              periodEnd,
+              dto.billingInterval
+            );
+            discountAmount = roundMoney(originalProRata.minus(baseFee));
+          }
+        }
+
+        // Apply household discount
+        if (
+          club?.householdFeeMode === 'PERCENTAGE' &&
+          member.householdId &&
+          member.householdRole &&
+          member.householdRole !== 'HEAD' &&
+          club.householdDiscountPercent
+        ) {
+          const discountPercent = new Prisma.Decimal(club.householdDiscountPercent);
+          const discount = roundMoney(baseFee.mul(discountPercent).div(100));
+          discountAmount = discount;
+          discountReason = `Haushaltsrabatt ${club.householdDiscountPercent}%`;
+          baseFee = roundMoney(baseFee.minus(discount));
+        } else if (
+          club?.householdFeeMode === 'FLAT' &&
+          member.householdId &&
+          member.householdRole === 'HEAD' &&
+          club.householdFlatAmount
+        ) {
+          const flatAmount = new Prisma.Decimal(club.householdFlatAmount.toString());
+          discountAmount = roundMoney(baseFee.minus(flatAmount));
+          discountReason = 'Haushaltspauschale';
+          baseFee = flatAmount;
+        }
+
+        baseFee = roundMoney(baseFee);
+
+        const typeName = membershipType.name;
+        const description = this.generateChargeDescription(typeName, periodStart, periodEnd, dto.billingInterval);
+
+        charges.push({
+          clubId,
+          memberId: member.id,
+          feeCategoryId: null,
+          membershipTypeId: membershipType.id,
+          description,
+          periodStart,
+          periodEnd,
+          amount: baseFee,
+          discountAmount,
+          discountReason,
+        });
+
+        // Track breakdown
+        const existing = breakdownMap.get(typeName);
+        if (existing) {
+          existing.count++;
+          existing.subtotal = existing.subtotal.plus(baseFee);
+        } else {
+          breakdownMap.set(typeName, {
+            membershipType: typeName,
+            count: 1,
+            subtotal: baseFee,
+          });
+        }
+      }
+
+      // Calculate additional category fees
+      for (const category of feeCategories) {
+        const categoryOverride = member.memberFeeOverrides.find(
+          (o: MemberWithRelations) => o.feeCategoryId === category.id
+        );
+        if (categoryOverride?.overrideType === 'EXEMPT') continue;
+
+        let categoryFee = new Prisma.Decimal(category.amount.toString());
+        let catDiscountAmount: Prisma.Decimal | null = null;
+        let catDiscountReason: string | null = null;
+
+        if (categoryOverride?.overrideType === 'CUSTOM_AMOUNT' && categoryOverride.customAmount) {
+          const originalFee = categoryFee;
+          categoryFee = new Prisma.Decimal(categoryOverride.customAmount.toString());
+          catDiscountAmount = roundMoney(originalFee.minus(categoryFee));
+          catDiscountReason = `Individueller Betrag: ${categoryOverride.reason ?? ''}`.trim();
+        }
+
+        categoryFee = roundMoney(categoryFee);
+
+        const description = this.generateChargeDescription(
+          category.name,
+          periodStart,
+          periodEnd,
+          dto.billingInterval
+        );
+
+        charges.push({
+          clubId,
+          memberId: member.id,
+          feeCategoryId: category.id,
+          membershipTypeId: null,
+          description,
+          periodStart,
+          periodEnd,
+          amount: categoryFee,
+          discountAmount: catDiscountAmount,
+          discountReason: catDiscountReason,
+        });
+      }
+    }
+
+    return {
+      charges,
+      exemptions,
+      breakdown: Array.from(breakdownMap.values()),
+    };
+  }
+
+  // ─── Private: Pro-Rata Calculation ──────────────────────────────────
+
+  /**
+   * Calculate pro-rata fee based on member join date vs billing period.
+   * For MONTHLY_PRO_RATA mode with ANNUALLY billing:
+   *   amount = feeAmount * (totalMonths - monthsElapsed) / totalMonths
+   */
+  private calculateProRata(
+    feeAmount: Prisma.Decimal,
+    joinDate: Date,
+    periodStart: Date,
+    periodEnd: Date,
+    billingInterval: string
+  ): Prisma.Decimal {
+    const join = new Date(joinDate);
+
+    // If member joined before the period start, they owe the full amount
+    if (join <= periodStart) {
+      return feeAmount;
+    }
+
+    // If member joined after the period end, they owe nothing
+    if (join > periodEnd) {
+      return ZERO;
+    }
+
+    // Calculate total months in the period (inclusive: Jan-Dec = 12 months)
+    const totalMonths = this.monthDiff(periodStart, periodEnd) + 1;
+
+    // Calculate months elapsed from period start to join date
+    const monthsElapsed = this.monthDiff(periodStart, join);
+
+    // Remaining months
+    const remainingMonths = totalMonths - monthsElapsed;
+
+    if (remainingMonths <= 0) return ZERO;
+
+    // Pro-rata: feeAmount * remainingMonths / totalMonths
+    return roundMoney(
+      feeAmount
+        .mul(new Prisma.Decimal(remainingMonths))
+        .div(new Prisma.Decimal(totalMonths))
+    );
+  }
+
+  /**
+   * Calculate the number of months between two dates (1-indexed from period start).
+   */
+  private monthDiff(start: Date, end: Date): number {
+    return (end.getFullYear() - start.getFullYear()) * 12 + (end.getMonth() - start.getMonth());
+  }
+
+  // ─── Private: Description Generator ─────────────────────────────────
+
+  /**
+   * Generate a human-readable description for a fee charge.
+   */
+  private generateChargeDescription(
+    name: string,
+    periodStart: Date,
+    periodEnd: Date,
+    billingInterval: string
+  ): string {
+    const year = periodStart.getFullYear();
+
+    switch (billingInterval) {
+      case 'ANNUALLY':
+        return `${name} ${year}`;
+      case 'QUARTERLY': {
+        const quarter = Math.floor(periodStart.getMonth() / 3) + 1;
+        return `${name} Q${quarter}/${year}`;
+      }
+      case 'MONTHLY': {
+        const month = periodStart.toLocaleString('de-DE', { month: 'long' });
+        return `${name} ${month} ${year}`;
+      }
+      default:
+        return `${name} ${year}`;
+    }
+  }
+}

--- a/apps/api/src/fees/fee-charges.service.ts
+++ b/apps/api/src/fees/fee-charges.service.ts
@@ -131,16 +131,15 @@ export class FeeChargesService {
    * Find all fee charges with computed payment status using SQL-level aggregation.
    * Returns paginated results with OPEN/PARTIAL/PAID status and overdue flag.
    *
-   * Note: OVERDUE is a computed status (dueDate < today && not fully paid), so
-   * filtering by OVERDUE happens post-query. This means `total` reflects the
-   * unfiltered count and pages may appear partially empty when the OVERDUE filter
-   * is active. A proper fix requires SQL-level status computation.
+   * When a status filter is active, uses a two-pass approach:
+   * 1. Fetch all matching charge IDs + amounts (lightweight), compute statuses
+   * 2. Filter by status, paginate, then fetch full data for the page
+   * This ensures correct `total` and pagination for computed status filters.
    */
   async findAllWithStatus(clubId: string, query: FeeChargeQueryDto) {
     const db = this.prisma.forClub(clubId);
     const page = query.page ?? 1;
     const limit = query.limit ?? 20;
-    const skip = (page - 1) * limit;
 
     // Build filter conditions
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -151,36 +150,134 @@ export class FeeChargesService {
       ...(query.periodEnd && { periodEnd: { lte: new Date(query.periodEnd) } }),
     };
 
-    const [charges, total] = await Promise.all([
-      db.feeCharge.findMany({
-        where,
-        include: {
-          member: {
-            select: { id: true, firstName: true, lastName: true, memberNumber: true },
-          },
-        },
-        orderBy: { dueDate: 'desc' },
-        skip,
-        take: limit,
-      }),
-      db.feeCharge.count({ where }),
-    ]);
-
-    // Batch-fetch payment aggregates for all charge IDs (SQL-level aggregation)
-    const chargeIds = charges.map((c: { id: string }) => c.id);
-    const paymentAggregates =
-      chargeIds.length > 0
-        ? await this.prisma.payment.groupBy({
-            by: ['feeChargeId'],
-            where: {
-              feeChargeId: { in: chargeIds },
-              deletedAt: null,
+    // No status filter: fast single-query path (existing behavior)
+    if (!query.status) {
+      const skip = (page - 1) * limit;
+      const [charges, total] = await Promise.all([
+        db.feeCharge.findMany({
+          where,
+          include: {
+            member: {
+              select: { id: true, firstName: true, lastName: true, memberNumber: true },
             },
-            _sum: { amount: true },
-          })
-        : [];
+          },
+          orderBy: { dueDate: 'desc' },
+          skip,
+          take: limit,
+        }),
+        db.feeCharge.count({ where }),
+      ]);
 
-    const paymentSumMap = new Map(
+      const enrichedCharges = await this.enrichChargesWithStatus(charges);
+      return { data: enrichedCharges, total, page, limit };
+    }
+
+    // Status filter active: two-pass approach for correct pagination
+    // Pass 1: Fetch all charge IDs + amounts (lightweight)
+    const allCharges = await db.feeCharge.findMany({
+      where,
+      select: { id: true, amount: true, dueDate: true },
+      orderBy: { dueDate: 'desc' },
+    });
+
+    const allChargeIds = allCharges.map((c: { id: string }) => c.id);
+    const paymentSumMap = await this.fetchPaymentSums(allChargeIds);
+
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    // Compute status for each charge and filter
+    const filteredIds = allCharges
+      .filter((charge: { id: string; amount: Prisma.Decimal | number; dueDate: Date }) => {
+        const amount =
+          charge.amount instanceof Prisma.Decimal
+            ? charge.amount
+            : new Prisma.Decimal(String(charge.amount));
+        const paidAmount = paymentSumMap.get(charge.id) ?? ZERO;
+        const { status, isOverdue } = this.computeChargeStatus(
+          amount,
+          paidAmount,
+          charge.dueDate,
+          today
+        );
+
+        if (query.status === 'OVERDUE') return isOverdue;
+        return status === query.status;
+      })
+      .map((c: { id: string }) => c.id);
+
+    const filteredTotal = filteredIds.length;
+
+    // Paginate the filtered IDs
+    const skip = (page - 1) * limit;
+    const pageIds = filteredIds.slice(skip, skip + limit);
+
+    if (pageIds.length === 0) {
+      return { data: [], total: filteredTotal, page, limit };
+    }
+
+    // Pass 2: Fetch full data for this page only
+    const charges = await db.feeCharge.findMany({
+      where: { id: { in: pageIds } },
+      include: {
+        member: {
+          select: { id: true, firstName: true, lastName: true, memberNumber: true },
+        },
+      },
+      orderBy: { dueDate: 'desc' },
+    });
+
+    const enrichedCharges = await this.enrichChargesWithStatus(charges);
+    return { data: enrichedCharges, total: filteredTotal, page, limit };
+  }
+
+  // ─── findByMember ───────────────────────────────────────────────────
+
+  /**
+   * Find charges for a specific member with computed status.
+   * Used for member detail section.
+   */
+  async findByMember(clubId: string, memberId: string, options?: { limit?: number }) {
+    return this.findAllWithStatus(clubId, {
+      memberId,
+      limit: options?.limit ?? 20,
+    });
+  }
+
+  // ─── Private: Status Computation Helpers ────────────────────────────
+
+  /**
+   * Compute payment status for a single charge.
+   */
+  private computeChargeStatus(
+    amount: Prisma.Decimal,
+    paidAmount: Prisma.Decimal,
+    dueDate: Date,
+    today: Date
+  ): { status: string; isOverdue: boolean } {
+    const status = paidAmount.gte(amount) ? 'PAID' : paidAmount.gt(ZERO) ? 'PARTIAL' : 'OPEN';
+    const due = new Date(dueDate);
+    due.setHours(0, 0, 0, 0);
+    const isOverdue = status !== 'PAID' && due < today;
+    return { status, isOverdue };
+  }
+
+  /**
+   * Batch-fetch payment sums for a list of charge IDs.
+   */
+  private async fetchPaymentSums(chargeIds: string[]): Promise<Map<string, Prisma.Decimal>> {
+    if (chargeIds.length === 0) return new Map();
+
+    const paymentAggregates = await this.prisma.payment.groupBy({
+      by: ['feeChargeId'],
+      where: {
+        feeChargeId: { in: chargeIds },
+        deletedAt: null,
+      },
+      _sum: { amount: true },
+    });
+
+    return new Map(
       paymentAggregates.map(
         (pa: { feeChargeId: string; _sum: { amount: Prisma.Decimal | null } }) => [
           pa.feeChargeId,
@@ -188,21 +285,31 @@ export class FeeChargesService {
         ]
       )
     );
+  }
+
+  /**
+   * Enrich charge records with computed payment status fields.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private async enrichChargesWithStatus(charges: any[]) {
+    const chargeIds = charges.map((c: { id: string }) => c.id);
+    const paymentSumMap = await this.fetchPaymentSums(chargeIds);
 
     const today = new Date();
     today.setHours(0, 0, 0, 0);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let enrichedCharges = charges.map((charge: any) => {
+    return charges.map((charge) => {
       const paidAmount = paymentSumMap.get(charge.id) ?? ZERO;
       const amount =
         charge.amount instanceof Prisma.Decimal
           ? charge.amount
           : new Prisma.Decimal(String(charge.amount));
-      const status = paidAmount.gte(amount) ? 'PAID' : paidAmount.gt(ZERO) ? 'PARTIAL' : 'OPEN';
-      const dueDate = new Date(charge.dueDate);
-      dueDate.setHours(0, 0, 0, 0);
-      const isOverdue = status !== 'PAID' && dueDate < today;
+      const { status, isOverdue } = this.computeChargeStatus(
+        amount,
+        paidAmount,
+        charge.dueDate,
+        today
+      );
       const remaining = amount.minus(paidAmount);
       const remainingAmount = remaining.lt(ZERO) ? ZERO : remaining;
 
@@ -236,40 +343,6 @@ export class FeeChargesService {
         updatedAt:
           charge.updatedAt instanceof Date ? charge.updatedAt.toISOString() : charge.updatedAt,
       };
-    });
-
-    // Post-query status filter (OVERDUE is a special computed status)
-    if (query.status) {
-      if (query.status === 'OVERDUE') {
-        enrichedCharges = enrichedCharges.filter(
-          (c: { isOverdue: boolean; status: string }) =>
-            c.isOverdue && (c.status === 'OPEN' || c.status === 'PARTIAL')
-        );
-      } else {
-        enrichedCharges = enrichedCharges.filter(
-          (c: { status: string }) => c.status === query.status
-        );
-      }
-    }
-
-    return {
-      data: enrichedCharges,
-      total,
-      page,
-      limit,
-    };
-  }
-
-  // ─── findByMember ───────────────────────────────────────────────────
-
-  /**
-   * Find charges for a specific member with computed status.
-   * Used for member detail section.
-   */
-  async findByMember(clubId: string, memberId: string, options?: { limit?: number }) {
-    return this.findAllWithStatus(clubId, {
-      memberId,
-      limit: options?.limit ?? 20,
     });
   }
 

--- a/apps/api/src/fees/fee-charges.service.ts
+++ b/apps/api/src/fees/fee-charges.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, BadRequestException } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service.js';
 import { Prisma } from '../../../../prisma/generated/client/index.js';
 import type { BillingRunPreviewDto } from './dto/billing-run-preview.dto.js';
@@ -52,6 +52,10 @@ export class FeeChargesService {
    * Calculates what each active member owes for the specified period.
    */
   async previewBillingRun(clubId: string, dto: BillingRunPreviewDto) {
+    if (new Date(dto.periodStart) >= new Date(dto.periodEnd)) {
+      throw new BadRequestException('Periodenbeginn muss vor dem Periodenende liegen');
+    }
+
     const { charges, exemptions, breakdown } = await this.calculateBillingCharges(clubId, dto);
 
     // Check for existing charges for duplicate detection
@@ -86,6 +90,10 @@ export class FeeChargesService {
    * Uses createMany with skipDuplicates for idempotency.
    */
   async executeBillingRun(clubId: string, dto: BillingRunConfirmDto, _userId: string) {
+    if (new Date(dto.periodStart) >= new Date(dto.periodEnd)) {
+      throw new BadRequestException('Periodenbeginn muss vor dem Periodenende liegen');
+    }
+
     const { charges } = await this.calculateBillingCharges(clubId, dto);
 
     const chargeDataArray: ChargeData[] = charges.map((c) => ({

--- a/apps/api/src/fees/fees.controller.ts
+++ b/apps/api/src/fees/fees.controller.ts
@@ -1,0 +1,110 @@
+import { Controller, Get, Post, Patch, Delete, Param, Body, HttpCode } from '@nestjs/common';
+import { ApiTags, ApiBearerAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { RequireClubContext, GetClubContext } from '../common/decorators/club-context.decorator.js';
+import { RequirePermissions } from '../common/decorators/permissions.decorator.js';
+import { Permission } from '../common/permissions/permissions.enum.js';
+import { CurrentUser } from '../auth/decorators/current-user.decorator.js';
+import { FeesService } from './fees.service.js';
+import { CreateFeeCategoryDto } from './dto/create-fee-category.dto.js';
+import { UpdateFeeCategoryDto } from './dto/update-fee-category.dto.js';
+import { CreateMemberFeeOverrideDto } from './dto/create-member-fee-override.dto.js';
+import type { ClubContext } from '../common/decorators/club-context.decorator.js';
+
+@ApiTags('Fee Categories')
+@ApiBearerAuth()
+@Controller('clubs/:slug/fees')
+@RequireClubContext()
+export class FeesController {
+  constructor(private feesService: FeesService) {}
+
+  // ─── Fee Category Endpoints ─────────────────────────────────────────
+
+  @Get('categories')
+  @RequirePermissions([Permission.FINANCE_READ])
+  @ApiOperation({ summary: 'List all fee categories for club' })
+  @ApiResponse({ status: 200, description: 'List of fee categories' })
+  async findAllCategories(@GetClubContext() ctx: ClubContext) {
+    return this.feesService.findAll(ctx.clubId);
+  }
+
+  @Get('categories/:id')
+  @RequirePermissions([Permission.FINANCE_READ])
+  @ApiOperation({ summary: 'Get a single fee category' })
+  @ApiResponse({ status: 200, description: 'Fee category details' })
+  @ApiResponse({ status: 404, description: 'Fee category not found' })
+  async findOneCategory(@GetClubContext() ctx: ClubContext, @Param('id') id: string) {
+    return this.feesService.findOne(ctx.clubId, id);
+  }
+
+  @Post('categories')
+  @RequirePermissions([Permission.FINANCE_CREATE])
+  @ApiOperation({ summary: 'Create a new fee category' })
+  @ApiResponse({ status: 201, description: 'Fee category created' })
+  async createCategory(@GetClubContext() ctx: ClubContext, @Body() dto: CreateFeeCategoryDto) {
+    return this.feesService.create(ctx.clubId, dto);
+  }
+
+  @Patch('categories/:id')
+  @RequirePermissions([Permission.FINANCE_UPDATE])
+  @ApiOperation({ summary: 'Update a fee category' })
+  @ApiResponse({ status: 200, description: 'Fee category updated' })
+  @ApiResponse({ status: 404, description: 'Fee category not found' })
+  async updateCategory(
+    @GetClubContext() ctx: ClubContext,
+    @Param('id') id: string,
+    @Body() dto: UpdateFeeCategoryDto
+  ) {
+    return this.feesService.update(ctx.clubId, id, dto);
+  }
+
+  @Delete('categories/:id')
+  @HttpCode(204)
+  @RequirePermissions([Permission.FINANCE_DELETE])
+  @ApiOperation({ summary: 'Soft-delete a fee category' })
+  @ApiResponse({ status: 204, description: 'Fee category deleted' })
+  @ApiResponse({ status: 404, description: 'Fee category not found' })
+  async deleteCategory(
+    @GetClubContext() ctx: ClubContext,
+    @Param('id') id: string,
+    @CurrentUser('id') userId: string
+  ): Promise<void> {
+    await this.feesService.softDelete(ctx.clubId, id, userId);
+  }
+
+  // ─── Member Fee Override Endpoints ──────────────────────────────────
+
+  @Post('overrides')
+  @RequirePermissions([Permission.FINANCE_CREATE])
+  @ApiOperation({ summary: 'Create a member fee override' })
+  @ApiResponse({ status: 201, description: 'Override created' })
+  @ApiResponse({ status: 403, description: 'Member does not belong to this club' })
+  async createOverride(
+    @GetClubContext() ctx: ClubContext,
+    @Body() dto: CreateMemberFeeOverrideDto
+  ) {
+    return this.feesService.createOverride(ctx.clubId, dto);
+  }
+
+  @Get('overrides/member/:memberId')
+  @RequirePermissions([Permission.FINANCE_READ])
+  @ApiOperation({ summary: 'Get all fee overrides for a member' })
+  @ApiResponse({ status: 200, description: 'List of member fee overrides' })
+  @ApiResponse({ status: 403, description: 'Member does not belong to this club' })
+  async findOverridesForMember(
+    @GetClubContext() ctx: ClubContext,
+    @Param('memberId') memberId: string
+  ) {
+    return this.feesService.findOverridesForMember(ctx.clubId, memberId);
+  }
+
+  @Delete('overrides/:id')
+  @HttpCode(204)
+  @RequirePermissions([Permission.FINANCE_DELETE])
+  @ApiOperation({ summary: 'Delete a member fee override' })
+  @ApiResponse({ status: 204, description: 'Override deleted' })
+  @ApiResponse({ status: 403, description: 'Override belongs to member in different club' })
+  @ApiResponse({ status: 404, description: 'Override not found' })
+  async deleteOverride(@GetClubContext() ctx: ClubContext, @Param('id') id: string): Promise<void> {
+    await this.feesService.deleteOverride(ctx.clubId, id);
+  }
+}

--- a/apps/api/src/fees/fees.module.ts
+++ b/apps/api/src/fees/fees.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { FeesController } from './fees.controller.js';
+import { FeesService } from './fees.service.js';
+
+@Module({
+  controllers: [FeesController],
+  providers: [FeesService],
+  exports: [FeesService],
+})
+export class FeesModule {}

--- a/apps/api/src/fees/fees.module.ts
+++ b/apps/api/src/fees/fees.module.ts
@@ -1,10 +1,14 @@
 import { Module } from '@nestjs/common';
 import { FeesController } from './fees.controller.js';
 import { FeesService } from './fees.service.js';
+import { FeeChargesController } from './fee-charges.controller.js';
+import { FeeChargesService } from './fee-charges.service.js';
+import { PaymentsController } from './payments.controller.js';
+import { PaymentsService } from './payments.service.js';
 
 @Module({
-  controllers: [FeesController],
-  providers: [FeesService],
-  exports: [FeesService],
+  controllers: [FeesController, FeeChargesController, PaymentsController],
+  providers: [FeesService, FeeChargesService, PaymentsService],
+  exports: [FeesService, FeeChargesService, PaymentsService],
 })
 export class FeesModule {}

--- a/apps/api/src/fees/fees.service.spec.ts
+++ b/apps/api/src/fees/fees.service.spec.ts
@@ -1,0 +1,344 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { FeesService } from './fees.service.js';
+import type { PrismaService } from '../prisma/prisma.service.js';
+import { NotFoundException, ForbiddenException } from '@nestjs/common';
+import { Prisma } from '../../../../prisma/generated/client/index.js';
+
+const { Decimal } = Prisma;
+
+// Mock forClub() scoped DB — FeeCategory is tenant-scoped
+const mockDb = {
+  feeCategory: {
+    findMany: vi.fn(),
+    findFirst: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+  },
+};
+
+const mockPrisma = {
+  forClub: vi.fn(() => mockDb),
+  member: {
+    findFirst: vi.fn(),
+  },
+  memberFeeOverride: {
+    create: vi.fn(),
+    findMany: vi.fn(),
+    findFirst: vi.fn(),
+    delete: vi.fn(),
+  },
+} as unknown as PrismaService;
+
+const CLUB_ID = 'club-1';
+const OTHER_CLUB_ID = 'club-2';
+
+function makeCategory(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'fc-1',
+    clubId: CLUB_ID,
+    name: 'Aufnahmegebuehr',
+    description: null,
+    amount: new Decimal('50.00'),
+    billingInterval: 'ANNUALLY',
+    isActive: true,
+    isOneTime: true,
+    sortOrder: 0,
+    deletedAt: null,
+    deletedBy: null,
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+    ...overrides,
+  };
+}
+
+describe('FeesService', () => {
+  let service: FeesService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (mockPrisma.forClub as ReturnType<typeof vi.fn>).mockReturnValue(mockDb);
+    service = new FeesService(mockPrisma);
+  });
+
+  describe('findAll()', () => {
+    it('should return only active, non-deleted categories with Decimal as string', async () => {
+      const categories = [
+        makeCategory({ id: 'fc-1', name: 'Aufnahmegebuehr' }),
+        makeCategory({ id: 'fc-2', name: 'Tennisabteilung', amount: new Decimal('120.00') }),
+      ];
+      (mockDb.feeCategory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(categories);
+
+      const result = await service.findAll(CLUB_ID);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].amount).toBe('50.00');
+      expect(result[1].amount).toBe('120.00');
+      expect(mockPrisma.forClub).toHaveBeenCalledWith(CLUB_ID);
+      expect(mockDb.feeCategory.findMany).toHaveBeenCalledWith({
+        where: { deletedAt: null },
+        orderBy: [{ sortOrder: 'asc' }, { name: 'asc' }],
+      });
+    });
+  });
+
+  describe('findOne()', () => {
+    it('should return a single category with Decimal as string', async () => {
+      (mockDb.feeCategory.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeCategory());
+
+      const result = await service.findOne(CLUB_ID, 'fc-1');
+
+      expect(result.amount).toBe('50.00');
+      expect(result.id).toBe('fc-1');
+    });
+
+    it('should throw NotFoundException for non-existent or deleted category', async () => {
+      (mockDb.feeCategory.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+      await expect(service.findOne(CLUB_ID, 'nonexistent')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('create()', () => {
+    it('should create a fee category and return with Decimal as string', async () => {
+      const created = makeCategory({ id: 'fc-new' });
+      (mockDb.feeCategory.create as ReturnType<typeof vi.fn>).mockResolvedValue(created);
+
+      const result = await service.create(CLUB_ID, {
+        name: 'Aufnahmegebuehr',
+        amount: '50.00',
+        billingInterval: 'ANNUALLY',
+        isOneTime: true,
+      });
+
+      expect(result.id).toBe('fc-new');
+      expect(result.amount).toBe('50.00');
+      expect(mockDb.feeCategory.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          name: 'Aufnahmegebuehr',
+          amount: expect.any(Decimal),
+          billingInterval: 'ANNUALLY',
+          isOneTime: true,
+        }),
+      });
+    });
+  });
+
+  describe('update()', () => {
+    it('should update fee category amount and return with Decimal as string', async () => {
+      (mockDb.feeCategory.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeCategory());
+      (mockDb.feeCategory.update as ReturnType<typeof vi.fn>).mockResolvedValue(
+        makeCategory({ amount: new Decimal('75.00') })
+      );
+
+      const result = await service.update(CLUB_ID, 'fc-1', { amount: '75.00' });
+
+      expect(result.amount).toBe('75.00');
+    });
+
+    it('should throw NotFoundException if category not found or deleted', async () => {
+      (mockDb.feeCategory.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+      await expect(service.update(CLUB_ID, 'nonexistent', { name: 'X' })).rejects.toThrow(
+        NotFoundException
+      );
+    });
+  });
+
+  describe('softDelete()', () => {
+    it('should set deletedAt and deletedBy', async () => {
+      (mockDb.feeCategory.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeCategory());
+      const now = new Date();
+      (mockDb.feeCategory.update as ReturnType<typeof vi.fn>).mockResolvedValue(
+        makeCategory({ deletedAt: now, deletedBy: 'user-1' })
+      );
+
+      await service.softDelete(CLUB_ID, 'fc-1', 'user-1');
+
+      expect(mockDb.feeCategory.update).toHaveBeenCalledWith({
+        where: { id: 'fc-1' },
+        data: {
+          deletedAt: expect.any(Date),
+          deletedBy: 'user-1',
+        },
+      });
+    });
+
+    it('should throw NotFoundException if category not found', async () => {
+      (mockDb.feeCategory.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+      await expect(service.softDelete(CLUB_ID, 'nonexistent', 'user-1')).rejects.toThrow(
+        NotFoundException
+      );
+    });
+
+    it('should exclude soft-deleted categories from findAll', async () => {
+      (mockDb.feeCategory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+      const result = await service.findAll(CLUB_ID);
+
+      expect(result).toHaveLength(0);
+      expect(mockDb.feeCategory.findMany).toHaveBeenCalledWith({
+        where: { deletedAt: null },
+        orderBy: [{ sortOrder: 'asc' }, { name: 'asc' }],
+      });
+    });
+  });
+
+  describe('createOverride()', () => {
+    it('should create a member fee override with EXEMPT type', async () => {
+      // Member belongs to this club
+      (mockPrisma.member.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'member-1',
+        clubId: CLUB_ID,
+      });
+      (mockPrisma.memberFeeOverride.create as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'override-1',
+        memberId: 'member-1',
+        overrideType: 'EXEMPT',
+        customAmount: null,
+        reason: 'Ehrenmitglied',
+        isBaseFee: true,
+        feeCategoryId: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const result = await service.createOverride(CLUB_ID, {
+        memberId: 'member-1',
+        overrideType: 'EXEMPT',
+        reason: 'Ehrenmitglied',
+        isBaseFee: true,
+      });
+
+      expect(result.id).toBe('override-1');
+      expect(result.overrideType).toBe('EXEMPT');
+    });
+
+    it('should create a member fee override with CUSTOM_AMOUNT and store amount as string', async () => {
+      (mockPrisma.member.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'member-1',
+        clubId: CLUB_ID,
+      });
+      (mockPrisma.memberFeeOverride.create as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'override-2',
+        memberId: 'member-1',
+        overrideType: 'CUSTOM_AMOUNT',
+        customAmount: new Decimal('25.00'),
+        reason: 'Sozialtarif',
+        isBaseFee: false,
+        feeCategoryId: 'fc-1',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const result = await service.createOverride(CLUB_ID, {
+        memberId: 'member-1',
+        overrideType: 'CUSTOM_AMOUNT',
+        customAmount: '25.00',
+        feeCategoryId: 'fc-1',
+        reason: 'Sozialtarif',
+      });
+
+      expect(result.id).toBe('override-2');
+      expect(result.customAmount).toBe('25.00');
+    });
+
+    it('should reject memberId belonging to a different club (tenant isolation)', async () => {
+      // Member belongs to a DIFFERENT club
+      (mockPrisma.member.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+      await expect(
+        service.createOverride(CLUB_ID, {
+          memberId: 'member-other-club',
+          overrideType: 'EXEMPT',
+        })
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  describe('findOverridesForMember()', () => {
+    it('should return all overrides for a specific member with Decimal serialized', async () => {
+      (mockPrisma.member.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'member-1',
+        clubId: CLUB_ID,
+      });
+      (mockPrisma.memberFeeOverride.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
+        {
+          id: 'override-1',
+          memberId: 'member-1',
+          overrideType: 'EXEMPT',
+          customAmount: null,
+          reason: 'Ehrenmitglied',
+          isBaseFee: true,
+          feeCategoryId: null,
+          feeCategory: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          id: 'override-2',
+          memberId: 'member-1',
+          overrideType: 'CUSTOM_AMOUNT',
+          customAmount: new Decimal('25.00'),
+          reason: 'Sozialtarif',
+          isBaseFee: false,
+          feeCategoryId: 'fc-1',
+          feeCategory: { id: 'fc-1', name: 'Tennisabteilung' },
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ]);
+
+      const result = await service.findOverridesForMember(CLUB_ID, 'member-1');
+
+      expect(result).toHaveLength(2);
+      expect(result[0].customAmount).toBeNull();
+      expect(result[1].customAmount).toBe('25.00');
+    });
+
+    it('should reject if member belongs to different club', async () => {
+      (mockPrisma.member.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+      await expect(service.findOverridesForMember(CLUB_ID, 'member-other')).rejects.toThrow(
+        ForbiddenException
+      );
+    });
+  });
+
+  describe('deleteOverride()', () => {
+    it('should hard-delete an override', async () => {
+      (mockPrisma.memberFeeOverride.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'override-1',
+        memberId: 'member-1',
+        member: { id: 'member-1', clubId: CLUB_ID },
+      });
+      (mockPrisma.memberFeeOverride.delete as ReturnType<typeof vi.fn>).mockResolvedValue({});
+
+      await service.deleteOverride(CLUB_ID, 'override-1');
+
+      expect(mockPrisma.memberFeeOverride.delete).toHaveBeenCalledWith({
+        where: { id: 'override-1' },
+      });
+    });
+
+    it('should reject overrideId belonging to a member in a different club (tenant isolation)', async () => {
+      (mockPrisma.memberFeeOverride.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'override-1',
+        memberId: 'member-other',
+        member: { id: 'member-other', clubId: OTHER_CLUB_ID },
+      });
+
+      await expect(service.deleteOverride(CLUB_ID, 'override-1')).rejects.toThrow(
+        ForbiddenException
+      );
+    });
+
+    it('should throw NotFoundException if override does not exist', async () => {
+      (mockPrisma.memberFeeOverride.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+      await expect(service.deleteOverride(CLUB_ID, 'nonexistent')).rejects.toThrow(
+        NotFoundException
+      );
+    });
+  });
+});

--- a/apps/api/src/fees/fees.service.spec.ts
+++ b/apps/api/src/fees/fees.service.spec.ts
@@ -71,8 +71,8 @@ describe('FeesService', () => {
       const result = await service.findAll(CLUB_ID);
 
       expect(result).toHaveLength(2);
-      expect(result[0].amount).toBe('50.00');
-      expect(result[1].amount).toBe('120.00');
+      expect(result[0]!.amount).toBe('50.00');
+      expect(result[1]!.amount).toBe('120.00');
       expect(mockPrisma.forClub).toHaveBeenCalledWith(CLUB_ID);
       expect(mockDb.feeCategory.findMany).toHaveBeenCalledWith({
         where: { deletedAt: null },
@@ -292,8 +292,8 @@ describe('FeesService', () => {
       const result = await service.findOverridesForMember(CLUB_ID, 'member-1');
 
       expect(result).toHaveLength(2);
-      expect(result[0].customAmount).toBeNull();
-      expect(result[1].customAmount).toBe('25.00');
+      expect(result[0]!.customAmount).toBeNull();
+      expect(result[1]!.customAmount).toBe('25.00');
     });
 
     it('should reject if member belongs to different club', async () => {

--- a/apps/api/src/fees/fees.service.ts
+++ b/apps/api/src/fees/fees.service.ts
@@ -1,0 +1,223 @@
+import { Injectable, NotFoundException, ForbiddenException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { CreateFeeCategoryDto } from './dto/create-fee-category.dto.js';
+import { UpdateFeeCategoryDto } from './dto/update-fee-category.dto.js';
+import { CreateMemberFeeOverrideDto } from './dto/create-member-fee-override.dto.js';
+import { Prisma } from '../../../../prisma/generated/client/index.js';
+
+const { Decimal } = Prisma;
+
+@Injectable()
+export class FeesService {
+  constructor(private prisma: PrismaService) {}
+
+  // ─── Fee Category CRUD ──────────────────────────────────────────────
+
+  /**
+   * List all active, non-deleted fee categories for a club.
+   * Ordered by sortOrder then name.
+   */
+  async findAll(clubId: string) {
+    const db = this.prisma.forClub(clubId);
+    const categories = await db.feeCategory.findMany({
+      where: { deletedAt: null },
+      orderBy: [{ sortOrder: 'asc' }, { name: 'asc' }],
+    });
+
+    return categories.map((c) => this.serializeCategory(c));
+  }
+
+  /**
+   * Get a single fee category by ID within club scope.
+   */
+  async findOne(clubId: string, id: string) {
+    const db = this.prisma.forClub(clubId);
+    const category = await db.feeCategory.findFirst({
+      where: { id, deletedAt: null },
+    });
+
+    if (!category) {
+      throw new NotFoundException('Beitragskategorie nicht gefunden');
+    }
+
+    return this.serializeCategory(category);
+  }
+
+  /**
+   * Create a new fee category.
+   * Converts amount string to Decimal for storage.
+   */
+  async create(clubId: string, dto: CreateFeeCategoryDto) {
+    const db = this.prisma.forClub(clubId);
+    const category = await db.feeCategory.create({
+      data: {
+        name: dto.name,
+        description: dto.description,
+        amount: new Decimal(dto.amount),
+        billingInterval: dto.billingInterval ?? 'ANNUALLY',
+        isOneTime: dto.isOneTime ?? false,
+        sortOrder: dto.sortOrder ?? 0,
+      },
+    });
+
+    return this.serializeCategory(category);
+  }
+
+  /**
+   * Update an existing fee category.
+   * Throws NotFoundException if not found or deleted.
+   */
+  async update(clubId: string, id: string, dto: UpdateFeeCategoryDto) {
+    const db = this.prisma.forClub(clubId);
+    const existing = await db.feeCategory.findFirst({
+      where: { id, deletedAt: null },
+    });
+
+    if (!existing) {
+      throw new NotFoundException('Beitragskategorie nicht gefunden');
+    }
+
+    const category = await db.feeCategory.update({
+      where: { id },
+      data: {
+        ...(dto.name !== undefined && { name: dto.name }),
+        ...(dto.description !== undefined && { description: dto.description }),
+        ...(dto.amount !== undefined && { amount: new Decimal(dto.amount) }),
+        ...(dto.billingInterval !== undefined && { billingInterval: dto.billingInterval }),
+        ...(dto.isOneTime !== undefined && { isOneTime: dto.isOneTime }),
+        ...(dto.isActive !== undefined && { isActive: dto.isActive }),
+        ...(dto.sortOrder !== undefined && { sortOrder: dto.sortOrder }),
+      },
+    });
+
+    return this.serializeCategory(category);
+  }
+
+  /**
+   * Soft-delete a fee category (CONV-006).
+   * Sets deletedAt/deletedBy. Category excluded from future findAll.
+   */
+  async softDelete(clubId: string, id: string, userId: string) {
+    const db = this.prisma.forClub(clubId);
+    const existing = await db.feeCategory.findFirst({
+      where: { id, deletedAt: null },
+    });
+
+    if (!existing) {
+      throw new NotFoundException('Beitragskategorie nicht gefunden');
+    }
+
+    await db.feeCategory.update({
+      where: { id },
+      data: {
+        deletedAt: new Date(),
+        deletedBy: userId,
+      },
+    });
+  }
+
+  // ─── Member Fee Overrides ───────────────────────────────────────────
+
+  /**
+   * Create a per-member fee override.
+   * Validates tenant isolation: member must belong to the specified club.
+   */
+  async createOverride(clubId: string, dto: CreateMemberFeeOverrideDto) {
+    await this.validateMemberBelongsToClub(clubId, dto.memberId);
+
+    const override = await this.prisma.memberFeeOverride.create({
+      data: {
+        memberId: dto.memberId,
+        feeCategoryId: dto.feeCategoryId,
+        overrideType: dto.overrideType,
+        customAmount: dto.customAmount ? new Decimal(dto.customAmount) : undefined,
+        reason: dto.reason,
+        isBaseFee: dto.isBaseFee ?? false,
+      },
+    });
+
+    return this.serializeOverride(override);
+  }
+
+  /**
+   * Find all overrides for a specific member.
+   * Validates tenant isolation: member must belong to the specified club.
+   */
+  async findOverridesForMember(clubId: string, memberId: string) {
+    await this.validateMemberBelongsToClub(clubId, memberId);
+
+    const overrides = await this.prisma.memberFeeOverride.findMany({
+      where: { memberId },
+      include: { feeCategory: true },
+    });
+
+    return overrides.map((o) => this.serializeOverride(o));
+  }
+
+  /**
+   * Delete a member fee override (hard delete).
+   * Validates tenant isolation: override's member must belong to the specified club.
+   */
+  async deleteOverride(clubId: string, overrideId: string) {
+    const override = await this.prisma.memberFeeOverride.findFirst({
+      where: { id: overrideId },
+      include: { member: true },
+    });
+
+    if (!override) {
+      throw new NotFoundException('Override nicht gefunden');
+    }
+
+    if (override.member.clubId !== clubId) {
+      throw new ForbiddenException('Zugriff verweigert: Mitglied gehoert nicht zu diesem Verein');
+    }
+
+    await this.prisma.memberFeeOverride.delete({
+      where: { id: overrideId },
+    });
+  }
+
+  // ─── Private Helpers ────────────────────────────────────────────────
+
+  /**
+   * Validate that a member belongs to the specified club.
+   * Throws ForbiddenException if the member is not found in this club.
+   */
+  private async validateMemberBelongsToClub(clubId: string, memberId: string) {
+    const member = await this.prisma.member.findFirst({
+      where: { id: memberId, clubId },
+    });
+
+    if (!member) {
+      throw new ForbiddenException('Zugriff verweigert: Mitglied gehoert nicht zu diesem Verein');
+    }
+  }
+
+  /**
+   * Serialize a fee category record, converting Decimal fields to strings.
+   * (Pitfall 1 from RESEARCH.md)
+   */
+  private serializeCategory(category: Record<string, unknown>) {
+    return {
+      ...category,
+      amount:
+        category.amount instanceof Decimal ? category.amount.toFixed(2) : String(category.amount),
+    };
+  }
+
+  /**
+   * Serialize a member fee override record, converting Decimal fields to strings.
+   */
+  private serializeOverride(override: Record<string, unknown>) {
+    const customAmount = override.customAmount;
+    return {
+      ...override,
+      customAmount:
+        customAmount === null || customAmount === undefined
+          ? customAmount
+          : customAmount instanceof Decimal
+            ? customAmount.toFixed(2)
+            : String(customAmount),
+    };
+  }
+}

--- a/apps/api/src/fees/fees.service.ts
+++ b/apps/api/src/fees/fees.service.ts
@@ -49,6 +49,7 @@ export class FeesService {
    */
   async create(clubId: string, dto: CreateFeeCategoryDto) {
     const db = this.prisma.forClub(clubId);
+    // clubId is injected by forClub() tenant extension at runtime
     const category = await db.feeCategory.create({
       data: {
         name: dto.name,
@@ -57,7 +58,7 @@ export class FeesService {
         billingInterval: dto.billingInterval ?? 'ANNUALLY',
         isOneTime: dto.isOneTime ?? false,
         sortOrder: dto.sortOrder ?? 0,
-      },
+      } as Prisma.FeeCategoryUncheckedCreateInput,
     });
 
     return this.serializeCategory(category);
@@ -197,7 +198,8 @@ export class FeesService {
    * Serialize a fee category record, converting Decimal fields to strings.
    * (Pitfall 1 from RESEARCH.md)
    */
-  private serializeCategory(category: Record<string, unknown>) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private serializeCategory(category: any) {
     return {
       ...category,
       amount:
@@ -208,7 +210,8 @@ export class FeesService {
   /**
    * Serialize a member fee override record, converting Decimal fields to strings.
    */
-  private serializeOverride(override: Record<string, unknown>) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private serializeOverride(override: any) {
     const customAmount = override.customAmount;
     return {
       ...override,

--- a/apps/api/src/fees/payments.controller.ts
+++ b/apps/api/src/fees/payments.controller.ts
@@ -1,0 +1,52 @@
+import { Controller, Get, Post, Delete, Param, Body, HttpCode } from '@nestjs/common';
+import { ApiTags, ApiBearerAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { RequireClubContext, GetClubContext } from '../common/decorators/club-context.decorator.js';
+import { RequirePermissions } from '../common/decorators/permissions.decorator.js';
+import { Permission } from '../common/permissions/permissions.enum.js';
+import { CurrentUser } from '../auth/decorators/current-user.decorator.js';
+import { PaymentsService } from './payments.service.js';
+import { RecordPaymentDto } from './dto/record-payment.dto.js';
+import type { ClubContext } from '../common/decorators/club-context.decorator.js';
+
+@ApiTags('Payments')
+@ApiBearerAuth()
+@Controller('clubs/:slug/fees/payments')
+@RequireClubContext()
+export class PaymentsController {
+  constructor(private paymentsService: PaymentsService) {}
+
+  @Post()
+  @RequirePermissions([Permission.FINANCE_CREATE])
+  @ApiOperation({ summary: 'Record a manual payment against a fee charge' })
+  @ApiResponse({ status: 201, description: 'Payment recorded, updated charge status returned' })
+  @ApiResponse({ status: 404, description: 'Fee charge not found' })
+  async recordPayment(
+    @GetClubContext() ctx: ClubContext,
+    @Body() dto: RecordPaymentDto,
+    @CurrentUser('id') userId: string
+  ) {
+    return this.paymentsService.recordPayment(ctx.clubId, dto, userId);
+  }
+
+  @Get('charge/:chargeId')
+  @RequirePermissions([Permission.FINANCE_READ])
+  @ApiOperation({ summary: 'List all payments for a fee charge' })
+  @ApiResponse({ status: 200, description: 'List of payments' })
+  async findPaymentsForCharge(@Param('chargeId') chargeId: string) {
+    return this.paymentsService.findPaymentsForCharge(chargeId);
+  }
+
+  @Delete(':id')
+  @HttpCode(200)
+  @RequirePermissions([Permission.FINANCE_DELETE])
+  @ApiOperation({ summary: 'Soft-delete a payment and recalculate charge status' })
+  @ApiResponse({ status: 200, description: 'Payment deleted, updated charge status returned' })
+  @ApiResponse({ status: 404, description: 'Payment not found' })
+  async softDeletePayment(
+    @GetClubContext() ctx: ClubContext,
+    @Param('id') id: string,
+    @CurrentUser('id') userId: string
+  ) {
+    return this.paymentsService.softDeletePayment(ctx.clubId, id, userId);
+  }
+}

--- a/apps/api/src/fees/payments.controller.ts
+++ b/apps/api/src/fees/payments.controller.ts
@@ -32,8 +32,11 @@ export class PaymentsController {
   @RequirePermissions([Permission.FINANCE_READ])
   @ApiOperation({ summary: 'List all payments for a fee charge' })
   @ApiResponse({ status: 200, description: 'List of payments' })
-  async findPaymentsForCharge(@Param('chargeId') chargeId: string) {
-    return this.paymentsService.findPaymentsForCharge(chargeId);
+  async findPaymentsForCharge(
+    @GetClubContext() ctx: ClubContext,
+    @Param('chargeId') chargeId: string
+  ) {
+    return this.paymentsService.findPaymentsForCharge(ctx.clubId, chargeId);
   }
 
   @Delete(':id')

--- a/apps/api/src/fees/payments.service.spec.ts
+++ b/apps/api/src/fees/payments.service.spec.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PaymentsService } from './payments.service.js';
+import type { PrismaService } from '../prisma/prisma.service.js';
+import { NotFoundException } from '@nestjs/common';
+import { Prisma } from '../../../../prisma/generated/client/index.js';
+
+const { Decimal } = Prisma;
+
+// ─── Mock Data ──────────────────────────────────────────────────────────────
+
+const CLUB_ID = 'club-1';
+const USER_ID = 'user-1';
+const CHARGE_ID = 'fc-1';
+
+function makeFeeCharge(overrides: Record<string, unknown> = {}) {
+  return {
+    id: CHARGE_ID,
+    clubId: CLUB_ID,
+    memberId: 'member-1',
+    amount: new Decimal('120.00'),
+    dueDate: new Date('2026-02-15'),
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+function makePayment(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'pay-1',
+    feeChargeId: CHARGE_ID,
+    amount: new Decimal('50.00'),
+    paidAt: new Date('2026-01-20'),
+    source: 'MANUAL',
+    reference: null,
+    notes: null,
+    recordedBy: USER_ID,
+    deletedAt: null,
+    deletedBy: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+// ─── Mock Prisma ────────────────────────────────────────────────────────────
+
+const mockPrisma = {
+  feeCharge: {
+    findFirst: vi.fn(),
+  },
+  payment: {
+    create: vi.fn(),
+    findMany: vi.fn(),
+    findFirst: vi.fn(),
+    update: vi.fn(),
+    aggregate: vi.fn(),
+  },
+} as unknown as PrismaService;
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('PaymentsService', () => {
+  let service: PaymentsService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new PaymentsService(mockPrisma);
+  });
+
+  // ─── recordPayment ──────────────────────────────────────────────────
+
+  describe('recordPayment()', () => {
+    it('should create Payment record with amount, date, source=MANUAL, recordedBy', async () => {
+      const charge = makeFeeCharge();
+      const payment = makePayment();
+
+      (mockPrisma.feeCharge.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(charge);
+      (mockPrisma.payment.create as ReturnType<typeof vi.fn>).mockResolvedValue(payment);
+      (mockPrisma.payment.aggregate as ReturnType<typeof vi.fn>).mockResolvedValue({
+        _sum: { amount: new Decimal('50.00') },
+      });
+
+      const result = await service.recordPayment(CLUB_ID, {
+        feeChargeId: CHARGE_ID,
+        amount: '50.00',
+        paidAt: '2026-01-20',
+      }, USER_ID);
+
+      expect(mockPrisma.payment.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          feeChargeId: CHARGE_ID,
+          amount: expect.any(Decimal),
+          source: 'MANUAL',
+          recordedBy: USER_ID,
+        }),
+      });
+      expect(result.payment).toBeDefined();
+    });
+
+    it('should return PARTIAL status after partial payment (OPEN -> PARTIAL)', async () => {
+      const charge = makeFeeCharge();
+      const payment = makePayment({ amount: new Decimal('50.00') });
+
+      (mockPrisma.feeCharge.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(charge);
+      (mockPrisma.payment.create as ReturnType<typeof vi.fn>).mockResolvedValue(payment);
+      (mockPrisma.payment.aggregate as ReturnType<typeof vi.fn>).mockResolvedValue({
+        _sum: { amount: new Decimal('50.00') },
+      });
+
+      const result = await service.recordPayment(CLUB_ID, {
+        feeChargeId: CHARGE_ID,
+        amount: '50.00',
+        paidAt: '2026-01-20',
+      }, USER_ID);
+
+      expect(result.chargeStatus.status).toBe('PARTIAL');
+      expect(result.chargeStatus.paidAmount).toBe('50.00');
+      expect(result.chargeStatus.remainingAmount).toBe('70.00');
+    });
+
+    it('should return PAID status after full payment', async () => {
+      const charge = makeFeeCharge();
+      const payment = makePayment({ amount: new Decimal('120.00') });
+
+      (mockPrisma.feeCharge.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(charge);
+      (mockPrisma.payment.create as ReturnType<typeof vi.fn>).mockResolvedValue(payment);
+      (mockPrisma.payment.aggregate as ReturnType<typeof vi.fn>).mockResolvedValue({
+        _sum: { amount: new Decimal('120.00') },
+      });
+
+      const result = await service.recordPayment(CLUB_ID, {
+        feeChargeId: CHARGE_ID,
+        amount: '120.00',
+        paidAt: '2026-01-20',
+      }, USER_ID);
+
+      expect(result.chargeStatus.status).toBe('PAID');
+      expect(result.chargeStatus.paidAmount).toBe('120.00');
+      expect(result.chargeStatus.remainingAmount).toBe('0.00');
+    });
+
+    it('should return PAID status with overpayment (sum >= amount)', async () => {
+      const charge = makeFeeCharge();
+      const payment = makePayment({ amount: new Decimal('150.00') });
+
+      (mockPrisma.feeCharge.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(charge);
+      (mockPrisma.payment.create as ReturnType<typeof vi.fn>).mockResolvedValue(payment);
+      (mockPrisma.payment.aggregate as ReturnType<typeof vi.fn>).mockResolvedValue({
+        _sum: { amount: new Decimal('150.00') },
+      });
+
+      const result = await service.recordPayment(CLUB_ID, {
+        feeChargeId: CHARGE_ID,
+        amount: '150.00',
+        paidAt: '2026-01-20',
+      }, USER_ID);
+
+      expect(result.chargeStatus.status).toBe('PAID');
+      expect(result.chargeStatus.remainingAmount).toBe('0.00');
+    });
+
+    it('should validate feeCharge belongs to the correct club', async () => {
+      // Charge not found (wrong club)
+      (mockPrisma.feeCharge.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+      await expect(
+        service.recordPayment(CLUB_ID, {
+          feeChargeId: 'nonexistent',
+          amount: '50.00',
+          paidAt: '2026-01-20',
+        }, USER_ID)
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ─── findPaymentsForCharge ──────────────────────────────────────────
+
+  describe('findPaymentsForCharge()', () => {
+    it('should return all non-deleted payments for a fee charge', async () => {
+      const payments = [
+        makePayment({ id: 'pay-1', amount: new Decimal('50.00') }),
+        makePayment({ id: 'pay-2', amount: new Decimal('30.00'), paidAt: new Date('2026-02-10') }),
+      ];
+      (mockPrisma.payment.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(payments);
+
+      const result = await service.findPaymentsForCharge(CHARGE_ID);
+
+      expect(result).toHaveLength(2);
+      expect(mockPrisma.payment.findMany).toHaveBeenCalledWith({
+        where: { feeChargeId: CHARGE_ID, deletedAt: null },
+        orderBy: { paidAt: 'desc' },
+      });
+    });
+  });
+
+  // ─── softDeletePayment ──────────────────────────────────────────────
+
+  describe('softDeletePayment()', () => {
+    it('should set deletedAt and recalculate charge status', async () => {
+      const payment = makePayment({
+        feeCharge: makeFeeCharge(),
+      });
+
+      (mockPrisma.payment.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(payment);
+      (mockPrisma.payment.update as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ...payment,
+        deletedAt: new Date(),
+        deletedBy: USER_ID,
+      });
+      // After soft-delete, no remaining payments -> status OPEN
+      (mockPrisma.payment.aggregate as ReturnType<typeof vi.fn>).mockResolvedValue({
+        _sum: { amount: null },
+      });
+
+      const result = await service.softDeletePayment(CLUB_ID, 'pay-1', USER_ID);
+
+      expect(mockPrisma.payment.update).toHaveBeenCalledWith({
+        where: { id: 'pay-1' },
+        data: {
+          deletedAt: expect.any(Date),
+          deletedBy: USER_ID,
+        },
+      });
+      expect(result.status).toBe('OPEN');
+    });
+  });
+});

--- a/apps/api/src/fees/payments.service.spec.ts
+++ b/apps/api/src/fees/payments.service.spec.ts
@@ -197,19 +197,32 @@ describe('PaymentsService', () => {
 
   describe('findPaymentsForCharge()', () => {
     it('should return all non-deleted payments for a fee charge', async () => {
+      const charge = makeFeeCharge();
       const payments = [
         makePayment({ id: 'pay-1', amount: new Decimal('50.00') }),
         makePayment({ id: 'pay-2', amount: new Decimal('30.00'), paidAt: new Date('2026-02-10') }),
       ];
+      (mockPrisma.feeCharge.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(charge);
       (mockPrisma.payment.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(payments);
 
-      const result = await service.findPaymentsForCharge(CHARGE_ID);
+      const result = await service.findPaymentsForCharge(CLUB_ID, CHARGE_ID);
 
       expect(result).toHaveLength(2);
+      expect(mockPrisma.feeCharge.findFirst).toHaveBeenCalledWith({
+        where: { id: CHARGE_ID, clubId: CLUB_ID, deletedAt: null },
+      });
       expect(mockPrisma.payment.findMany).toHaveBeenCalledWith({
         where: { feeChargeId: CHARGE_ID, deletedAt: null },
         orderBy: { paidAt: 'desc' },
       });
+    });
+
+    it('should reject cross-tenant access (charge from another club)', async () => {
+      (mockPrisma.feeCharge.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+      await expect(service.findPaymentsForCharge('other-club', CHARGE_ID)).rejects.toThrow(
+        NotFoundException
+      );
     });
   });
 

--- a/apps/api/src/fees/payments.service.spec.ts
+++ b/apps/api/src/fees/payments.service.spec.ts
@@ -80,11 +80,15 @@ describe('PaymentsService', () => {
         _sum: { amount: new Decimal('50.00') },
       });
 
-      const result = await service.recordPayment(CLUB_ID, {
-        feeChargeId: CHARGE_ID,
-        amount: '50.00',
-        paidAt: '2026-01-20',
-      }, USER_ID);
+      const result = await service.recordPayment(
+        CLUB_ID,
+        {
+          feeChargeId: CHARGE_ID,
+          amount: '50.00',
+          paidAt: '2026-01-20',
+        },
+        USER_ID
+      );
 
       expect(mockPrisma.payment.create).toHaveBeenCalledWith({
         data: expect.objectContaining({
@@ -107,11 +111,15 @@ describe('PaymentsService', () => {
         _sum: { amount: new Decimal('50.00') },
       });
 
-      const result = await service.recordPayment(CLUB_ID, {
-        feeChargeId: CHARGE_ID,
-        amount: '50.00',
-        paidAt: '2026-01-20',
-      }, USER_ID);
+      const result = await service.recordPayment(
+        CLUB_ID,
+        {
+          feeChargeId: CHARGE_ID,
+          amount: '50.00',
+          paidAt: '2026-01-20',
+        },
+        USER_ID
+      );
 
       expect(result.chargeStatus.status).toBe('PARTIAL');
       expect(result.chargeStatus.paidAmount).toBe('50.00');
@@ -128,11 +136,15 @@ describe('PaymentsService', () => {
         _sum: { amount: new Decimal('120.00') },
       });
 
-      const result = await service.recordPayment(CLUB_ID, {
-        feeChargeId: CHARGE_ID,
-        amount: '120.00',
-        paidAt: '2026-01-20',
-      }, USER_ID);
+      const result = await service.recordPayment(
+        CLUB_ID,
+        {
+          feeChargeId: CHARGE_ID,
+          amount: '120.00',
+          paidAt: '2026-01-20',
+        },
+        USER_ID
+      );
 
       expect(result.chargeStatus.status).toBe('PAID');
       expect(result.chargeStatus.paidAmount).toBe('120.00');
@@ -149,11 +161,15 @@ describe('PaymentsService', () => {
         _sum: { amount: new Decimal('150.00') },
       });
 
-      const result = await service.recordPayment(CLUB_ID, {
-        feeChargeId: CHARGE_ID,
-        amount: '150.00',
-        paidAt: '2026-01-20',
-      }, USER_ID);
+      const result = await service.recordPayment(
+        CLUB_ID,
+        {
+          feeChargeId: CHARGE_ID,
+          amount: '150.00',
+          paidAt: '2026-01-20',
+        },
+        USER_ID
+      );
 
       expect(result.chargeStatus.status).toBe('PAID');
       expect(result.chargeStatus.remainingAmount).toBe('0.00');
@@ -164,11 +180,15 @@ describe('PaymentsService', () => {
       (mockPrisma.feeCharge.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
 
       await expect(
-        service.recordPayment(CLUB_ID, {
-          feeChargeId: 'nonexistent',
-          amount: '50.00',
-          paidAt: '2026-01-20',
-        }, USER_ID)
+        service.recordPayment(
+          CLUB_ID,
+          {
+            feeChargeId: 'nonexistent',
+            amount: '50.00',
+            paidAt: '2026-01-20',
+          },
+          USER_ID
+        )
       ).rejects.toThrow(NotFoundException);
     });
   });

--- a/apps/api/src/fees/payments.service.ts
+++ b/apps/api/src/fees/payments.service.ts
@@ -1,0 +1,157 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { Prisma } from '../../../../prisma/generated/client/index.js';
+import type { RecordPaymentDto } from './dto/record-payment.dto.js';
+
+const ZERO = new Prisma.Decimal(0);
+const DECIMAL_PLACES = 2;
+
+/**
+ * Compute charge status from paid vs. charged amounts.
+ * Pure function using Prisma.Decimal comparison methods.
+ */
+export function computeChargeStatus(
+  chargeAmount: Prisma.Decimal,
+  paidAmount: Prisma.Decimal
+): { status: 'OPEN' | 'PARTIAL' | 'PAID'; paidAmount: string; remainingAmount: string } {
+  const status = paidAmount.gte(chargeAmount)
+    ? ('PAID' as const)
+    : paidAmount.gt(ZERO)
+      ? ('PARTIAL' as const)
+      : ('OPEN' as const);
+
+  const remaining = chargeAmount.minus(paidAmount);
+  const remainingAmount = remaining.lt(ZERO) ? ZERO : remaining;
+
+  return {
+    status,
+    paidAmount: paidAmount.toFixed(DECIMAL_PLACES),
+    remainingAmount: remainingAmount.toFixed(DECIMAL_PLACES),
+  };
+}
+
+@Injectable()
+export class PaymentsService {
+  constructor(private prisma: PrismaService) {}
+
+  // ─── Record Payment ─────────────────────────────────────────────────
+
+  /**
+   * Record a manual payment against a fee charge.
+   * Validates club ownership, creates Payment, and returns updated status.
+   */
+  async recordPayment(clubId: string, dto: RecordPaymentDto, userId: string) {
+    // 1. Validate feeCharge exists and belongs to this club
+    const charge = await this.prisma.feeCharge.findFirst({
+      where: { id: dto.feeChargeId, clubId, deletedAt: null },
+    });
+
+    if (!charge) {
+      throw new NotFoundException('Forderung nicht gefunden');
+    }
+
+    // 2. Create payment
+    const payment = await this.prisma.payment.create({
+      data: {
+        feeChargeId: dto.feeChargeId,
+        amount: new Prisma.Decimal(dto.amount),
+        paidAt: new Date(dto.paidAt),
+        source: 'MANUAL',
+        notes: dto.notes ?? null,
+        recordedBy: userId,
+      },
+    });
+
+    // 3. Recompute charge status using SQL aggregate
+    const aggregate = await this.prisma.payment.aggregate({
+      where: { feeChargeId: dto.feeChargeId, deletedAt: null },
+      _sum: { amount: true },
+    });
+    const paidAmount = aggregate._sum.amount ?? ZERO;
+
+    const chargeStatus = computeChargeStatus(charge.amount as Prisma.Decimal, paidAmount);
+
+    return {
+      payment: this.serializePayment(payment),
+      chargeStatus,
+    };
+  }
+
+  // ─── Find Payments for Charge ───────────────────────────────────────
+
+  /**
+   * Return all non-deleted payments for a charge, ordered by paidAt desc.
+   */
+  async findPaymentsForCharge(feeChargeId: string) {
+    const payments = await this.prisma.payment.findMany({
+      where: { feeChargeId, deletedAt: null },
+      orderBy: { paidAt: 'desc' },
+    });
+
+    return payments.map((p) => this.serializePayment(p));
+  }
+
+  // ─── Soft Delete Payment ────────────────────────────────────────────
+
+  /**
+   * Soft-delete a payment and recalculate charge status.
+   * Validates club ownership via the fee charge relation.
+   */
+  async softDeletePayment(clubId: string, paymentId: string, userId: string) {
+    // 1. Find payment with feeCharge for club validation
+    const payment = await this.prisma.payment.findFirst({
+      where: { id: paymentId, deletedAt: null },
+      include: { feeCharge: true },
+    });
+
+    if (!payment || payment.feeCharge.clubId !== clubId) {
+      throw new NotFoundException('Zahlung nicht gefunden');
+    }
+
+    // 2. Soft-delete
+    await this.prisma.payment.update({
+      where: { id: paymentId },
+      data: {
+        deletedAt: new Date(),
+        deletedBy: userId,
+      },
+    });
+
+    // 3. Recalculate status after deletion
+    const aggregate = await this.prisma.payment.aggregate({
+      where: { feeChargeId: payment.feeChargeId, deletedAt: null },
+      _sum: { amount: true },
+    });
+    const paidAmount = aggregate._sum.amount ?? ZERO;
+
+    return computeChargeStatus(payment.feeCharge.amount as Prisma.Decimal, paidAmount);
+  }
+
+  // ─── Private Helpers ────────────────────────────────────────────────
+
+  /**
+   * Serialize payment, converting Decimal fields to strings.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private serializePayment(payment: any) {
+    return {
+      ...payment,
+      amount:
+        payment.amount instanceof Prisma.Decimal
+          ? payment.amount.toFixed(DECIMAL_PLACES)
+          : String(payment.amount),
+      paidAt:
+        payment.paidAt instanceof Date
+          ? payment.paidAt.toISOString().split('T')[0]
+          : payment.paidAt,
+      createdAt:
+        payment.createdAt instanceof Date
+          ? payment.createdAt.toISOString()
+          : payment.createdAt,
+      updatedAt:
+        payment.updatedAt instanceof Date
+          ? payment.updatedAt.toISOString()
+          : payment.updatedAt,
+    };
+  }
+}

--- a/apps/api/src/fees/payments.service.ts
+++ b/apps/api/src/fees/payments.service.ts
@@ -82,7 +82,16 @@ export class PaymentsService {
   /**
    * Return all non-deleted payments for a charge, ordered by paidAt desc.
    */
-  async findPaymentsForCharge(feeChargeId: string) {
+  async findPaymentsForCharge(clubId: string, feeChargeId: string) {
+    // Verify charge belongs to this club before returning payments
+    const charge = await this.prisma.feeCharge.findFirst({
+      where: { id: feeChargeId, clubId, deletedAt: null },
+    });
+
+    if (!charge) {
+      throw new NotFoundException('Forderung nicht gefunden');
+    }
+
     const payments = await this.prisma.payment.findMany({
       where: { feeChargeId, deletedAt: null },
       orderBy: { paidAt: 'desc' },

--- a/apps/api/src/fees/payments.service.ts
+++ b/apps/api/src/fees/payments.service.ts
@@ -145,13 +145,9 @@ export class PaymentsService {
           ? payment.paidAt.toISOString().split('T')[0]
           : payment.paidAt,
       createdAt:
-        payment.createdAt instanceof Date
-          ? payment.createdAt.toISOString()
-          : payment.createdAt,
+        payment.createdAt instanceof Date ? payment.createdAt.toISOString() : payment.createdAt,
       updatedAt:
-        payment.updatedAt instanceof Date
-          ? payment.updatedAt.toISOString()
-          : payment.updatedAt,
+        payment.updatedAt instanceof Date ? payment.updatedAt.toISOString() : payment.updatedAt,
     };
   }
 }

--- a/apps/api/src/membership-types/dto/create-membership-type.dto.ts
+++ b/apps/api/src/membership-types/dto/create-membership-type.dto.ts
@@ -5,12 +5,14 @@ import {
   IsBoolean,
   IsInt,
   IsIn,
+  IsEnum,
   Min,
   MinLength,
   MaxLength,
   Matches,
 } from 'class-validator';
 import { MEMBER_TYPE_COLORS } from '@ktb/shared';
+import { BillingInterval } from '../../../../../prisma/generated/client/index.js';
 
 export class CreateMembershipTypeDto {
   @ApiProperty({
@@ -100,4 +102,23 @@ export class CreateMembershipTypeDto {
   @IsOptional()
   @IsIn([...MEMBER_TYPE_COLORS], { message: 'Ungueltige Farbe' })
   color?: string;
+
+  @ApiPropertyOptional({
+    description: 'Base fee amount as decimal string (e.g., "120.00")',
+    example: '120.00',
+  })
+  @IsString()
+  @IsOptional()
+  @Matches(/^\d+(\.\d{1,2})?$/, {
+    message: 'Betrag muss ein gueltiges Dezimalformat haben (z.B. "120.00")',
+  })
+  feeAmount?: string;
+
+  @ApiPropertyOptional({
+    description: 'Billing frequency for base fee',
+    enum: BillingInterval,
+  })
+  @IsEnum(BillingInterval, { message: 'Ungueltiger Abrechnungszeitraum' })
+  @IsOptional()
+  billingInterval?: BillingInterval;
 }

--- a/apps/api/src/membership-types/dto/update-membership-type.dto.ts
+++ b/apps/api/src/membership-types/dto/update-membership-type.dto.ts
@@ -5,12 +5,14 @@ import {
   IsBoolean,
   IsInt,
   IsIn,
+  IsEnum,
   Min,
   MinLength,
   MaxLength,
   Matches,
 } from 'class-validator';
 import { MEMBER_TYPE_COLORS } from '@ktb/shared';
+import { BillingInterval } from '../../../../../prisma/generated/client/index.js';
 
 export class UpdateMembershipTypeDto {
   @ApiPropertyOptional({
@@ -95,4 +97,23 @@ export class UpdateMembershipTypeDto {
   @IsOptional()
   @IsIn([...MEMBER_TYPE_COLORS], { message: 'Ungueltige Farbe' })
   color?: string;
+
+  @ApiPropertyOptional({
+    description: 'Base fee amount as decimal string (e.g., "120.00")',
+    example: '120.00',
+  })
+  @IsString()
+  @IsOptional()
+  @Matches(/^\d+(\.\d{1,2})?$/, {
+    message: 'Betrag muss ein gueltiges Dezimalformat haben (z.B. "120.00")',
+  })
+  feeAmount?: string;
+
+  @ApiPropertyOptional({
+    description: 'Billing frequency for base fee',
+    enum: BillingInterval,
+  })
+  @IsEnum(BillingInterval, { message: 'Ungueltiger Abrechnungszeitraum' })
+  @IsOptional()
+  billingInterval?: BillingInterval;
 }

--- a/apps/api/src/prisma/extensions/tenant.extension.ts
+++ b/apps/api/src/prisma/extensions/tenant.extension.ts
@@ -9,8 +9,10 @@ const TENANT_SCOPED_MODELS = [
   'Household',
   'NumberRange',
   'LedgerAccount',
-  // Future models: Transaction, TransactionLine, FeeCategory, etc.
+  'FeeCategory',
+  'FeeCharge',
   // Note: MembershipPeriod is scoped via Member relation (no clubId column)
+  // Note: Payment is scoped via FeeCharge relation (no clubId column)
 ] as const;
 
 type TenantScopedModel = (typeof TENANT_SCOPED_MODELS)[number];

--- a/apps/web/app/clubs/[slug]/(club)/fees/_client.tsx
+++ b/apps/web/app/clubs/[slug]/(club)/fees/_client.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { useQueryStates, parseAsStringLiteral } from 'nuqs';
+import { PageHeader } from '@/components/layout/page-header';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Card, CardContent } from '@/components/ui/card';
+import { FeeCategoryList } from '@/components/fees/fee-category-list';
+
+const TAB_VALUES = ['kategorien', 'erhebung', 'forderungen'] as const;
+
+/**
+ * Client component orchestrating the fees management page.
+ * Tab state is persisted in the URL via nuqs (?tab=kategorien|erhebung|forderungen).
+ */
+export function FeesClient() {
+  const [{ tab }, setParams] = useQueryStates(
+    {
+      tab: parseAsStringLiteral(TAB_VALUES).withDefault('kategorien'),
+    },
+    { shallow: true }
+  );
+
+  return (
+    <div>
+      <PageHeader
+        title="Beitraege"
+        description="Beitragskategorien, Erhebungslaeufe und Forderungen verwalten"
+      />
+
+      <div className="container mx-auto px-4 pb-6">
+        <Tabs value={tab} onValueChange={(value) => setParams({ tab: value as (typeof TAB_VALUES)[number] })}>
+          <TabsList>
+            <TabsTrigger value="kategorien">Kategorien</TabsTrigger>
+            <TabsTrigger value="erhebung">Erhebung</TabsTrigger>
+            <TabsTrigger value="forderungen">Forderungen</TabsTrigger>
+          </TabsList>
+
+          <div className="pt-8">
+            <TabsContent value="kategorien" className="mt-0">
+              <FeeCategoryList />
+            </TabsContent>
+
+            <TabsContent value="erhebung" className="mt-0">
+              <Card>
+                <CardContent className="flex items-center justify-center py-12">
+                  <p className="text-muted-foreground">Wird in Kuerze verfuegbar</p>
+                </CardContent>
+              </Card>
+            </TabsContent>
+
+            <TabsContent value="forderungen" className="mt-0">
+              <Card>
+                <CardContent className="flex items-center justify-center py-12">
+                  <p className="text-muted-foreground">Wird in Kuerze verfuegbar</p>
+                </CardContent>
+              </Card>
+            </TabsContent>
+          </div>
+        </Tabs>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/clubs/[slug]/(club)/fees/_client.tsx
+++ b/apps/web/app/clubs/[slug]/(club)/fees/_client.tsx
@@ -30,8 +30,8 @@ export function FeesClient() {
   return (
     <div>
       <PageHeader
-        title="Beitraege"
-        description="Beitragskategorien, Erhebungslaeufe und Forderungen verwalten"
+        title="Beiträge"
+        description="Beitragskategorien, Erhebungsläufe und Forderungen verwalten"
       />
 
       <div className="container mx-auto px-4 pb-6">

--- a/apps/web/app/clubs/[slug]/(club)/fees/_client.tsx
+++ b/apps/web/app/clubs/[slug]/(club)/fees/_client.tsx
@@ -1,21 +1,28 @@
 'use client';
 
-import { useQueryStates, parseAsStringLiteral } from 'nuqs';
+import { useParams } from 'next/navigation';
+import { useQueryStates, parseAsStringLiteral, parseAsString } from 'nuqs';
 import { PageHeader } from '@/components/layout/page-header';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Card, CardContent } from '@/components/ui/card';
 import { FeeCategoryList } from '@/components/fees/fee-category-list';
+import { BillingRunPanel } from '@/components/fees/billing-run-panel';
+import { FeeChargeList } from '@/components/fees/fee-charge-list';
 
 const TAB_VALUES = ['kategorien', 'erhebung', 'forderungen'] as const;
 
 /**
  * Client component orchestrating the fees management page.
  * Tab state is persisted in the URL via nuqs (?tab=kategorien|erhebung|forderungen).
+ * Supports memberId URL parameter for pre-filtering the Forderungen tab.
  */
 export function FeesClient() {
-  const [{ tab }, setParams] = useQueryStates(
+  const params = useParams<{ slug: string }>();
+  const slug = params.slug;
+
+  const [{ tab, memberId }, setParams] = useQueryStates(
     {
       tab: parseAsStringLiteral(TAB_VALUES).withDefault('kategorien'),
+      memberId: parseAsString.withDefault(''),
     },
     { shallow: true }
   );
@@ -44,19 +51,15 @@ export function FeesClient() {
             </TabsContent>
 
             <TabsContent value="erhebung" className="mt-0">
-              <Card>
-                <CardContent className="flex items-center justify-center py-12">
-                  <p className="text-muted-foreground">Wird in Kuerze verfuegbar</p>
-                </CardContent>
-              </Card>
+              <BillingRunPanel slug={slug} onComplete={() => setParams({ tab: 'forderungen' })} />
             </TabsContent>
 
             <TabsContent value="forderungen" className="mt-0">
-              <Card>
-                <CardContent className="flex items-center justify-center py-12">
-                  <p className="text-muted-foreground">Wird in Kuerze verfuegbar</p>
-                </CardContent>
-              </Card>
+              <FeeChargeList
+                slug={slug}
+                memberId={memberId || undefined}
+                onSwitchToErhebung={() => setParams({ tab: 'erhebung' })}
+              />
             </TabsContent>
           </div>
         </Tabs>

--- a/apps/web/app/clubs/[slug]/(club)/fees/_client.tsx
+++ b/apps/web/app/clubs/[slug]/(club)/fees/_client.tsx
@@ -28,7 +28,10 @@ export function FeesClient() {
       />
 
       <div className="container mx-auto px-4 pb-6">
-        <Tabs value={tab} onValueChange={(value) => setParams({ tab: value as (typeof TAB_VALUES)[number] })}>
+        <Tabs
+          value={tab}
+          onValueChange={(value) => setParams({ tab: value as (typeof TAB_VALUES)[number] })}
+        >
           <TabsList>
             <TabsTrigger value="kategorien">Kategorien</TabsTrigger>
             <TabsTrigger value="erhebung">Erhebung</TabsTrigger>

--- a/apps/web/app/clubs/[slug]/(club)/fees/error.tsx
+++ b/apps/web/app/clubs/[slug]/(club)/fees/error.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="container mx-auto py-12 text-center">
+      <h2 className="text-xl font-semibold">Fehler aufgetreten</h2>
+      <p className="text-muted-foreground mt-2">
+        {error.message || 'Ein unbekannter Fehler ist aufgetreten'}
+      </p>
+      <button onClick={reset} className="mt-4 text-primary hover:underline">
+        Erneut versuchen
+      </button>
+    </div>
+  );
+}

--- a/apps/web/app/clubs/[slug]/(club)/fees/page.tsx
+++ b/apps/web/app/clubs/[slug]/(club)/fees/page.tsx
@@ -1,0 +1,19 @@
+import { checkClubAccess } from '@/lib/check-club-access';
+import { FeesClient } from './_client';
+
+interface FeesPageProps {
+  params: Promise<{ slug: string }>;
+}
+
+/**
+ * Fee management page with server-side access check.
+ * Returns proper 404 status if user doesn't have access.
+ */
+export default async function FeesPage({ params }: FeesPageProps) {
+  const { slug } = await params;
+
+  // Server-side access check - throws notFound() with proper 404 status
+  await checkClubAccess(slug);
+
+  return <FeesClient />;
+}

--- a/apps/web/app/clubs/[slug]/(settings)/settings/membership-types/_client.tsx
+++ b/apps/web/app/clubs/[slug]/(settings)/settings/membership-types/_client.tsx
@@ -45,6 +45,14 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Separator } from '@/components/ui/separator';
 import { Plus, Pencil, Trash2, Loader2, IdCard, Check, Minus } from 'lucide-react';
 
 interface MembershipTypeFormState {
@@ -57,6 +65,8 @@ interface MembershipTypeFormState {
   vote: boolean;
   assemblyAttendance: boolean;
   eligibleForOffice: boolean;
+  feeAmount: string;
+  billingInterval: 'MONTHLY' | 'QUARTERLY' | 'ANNUALLY';
 }
 
 const DEFAULT_FORM_STATE: MembershipTypeFormState = {
@@ -69,6 +79,8 @@ const DEFAULT_FORM_STATE: MembershipTypeFormState = {
   vote: true,
   assemblyAttendance: true,
   eligibleForOffice: true,
+  feeAmount: '',
+  billingInterval: 'ANNUALLY',
 };
 
 /** Render a boolean value as check or minus icon */
@@ -119,6 +131,9 @@ export function MembershipTypesSettingsClient() {
       vote: type.vote,
       assemblyAttendance: type.assemblyAttendance,
       eligibleForOffice: type.eligibleForOffice,
+      feeAmount: type.feeAmount ?? '',
+      billingInterval:
+        (type.billingInterval as MembershipTypeFormState['billingInterval']) ?? 'ANNUALLY',
     });
     setDialogOpen(true);
   }
@@ -135,6 +150,8 @@ export function MembershipTypesSettingsClient() {
       vote: formState.vote,
       assemblyAttendance: formState.assemblyAttendance,
       eligibleForOffice: formState.eligibleForOffice,
+      feeAmount: formState.feeAmount || null,
+      billingInterval: formState.feeAmount ? formState.billingInterval : undefined,
     };
 
     if (editingType) {
@@ -514,6 +531,48 @@ export function MembershipTypesSettingsClient() {
                   setFormState((prev) => ({ ...prev, eligibleForOffice: checked }))
                 }
               />
+            </div>
+
+            {/* Beitragseinstellungen */}
+            <Separator />
+            <h4 className="text-sm font-semibold">Beitragseinstellungen</h4>
+
+            {/* Grundbeitrag (EUR) */}
+            <div className="space-y-2">
+              <Label htmlFor="feeAmount">Grundbeitrag (EUR)</Label>
+              <Input
+                id="feeAmount"
+                placeholder="z.B. 120.00"
+                inputMode="decimal"
+                value={formState.feeAmount}
+                onChange={(e) => setFormState((prev) => ({ ...prev, feeAmount: e.target.value }))}
+              />
+              <p className="text-xs text-muted-foreground">
+                Optional — nicht jede Mitgliedsart muss einen Beitrag haben.
+              </p>
+            </div>
+
+            {/* Abrechnungszeitraum */}
+            <div className="space-y-2">
+              <Label htmlFor="billingInterval">Abrechnungszeitraum</Label>
+              <Select
+                value={formState.billingInterval}
+                onValueChange={(val) =>
+                  setFormState((prev) => ({
+                    ...prev,
+                    billingInterval: val as MembershipTypeFormState['billingInterval'],
+                  }))
+                }
+              >
+                <SelectTrigger id="billingInterval" className="w-full">
+                  <SelectValue placeholder="Zeitraum waehlen" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="MONTHLY">Monatlich</SelectItem>
+                  <SelectItem value="QUARTERLY">Quartalsweise</SelectItem>
+                  <SelectItem value="ANNUALLY">Jaehrlich</SelectItem>
+                </SelectContent>
+              </Select>
             </div>
           </div>
 

--- a/apps/web/app/clubs/[slug]/(settings)/settings/membership-types/_client.tsx
+++ b/apps/web/app/clubs/[slug]/(settings)/settings/membership-types/_client.tsx
@@ -565,12 +565,12 @@ export function MembershipTypesSettingsClient() {
                 }
               >
                 <SelectTrigger id="billingInterval" className="w-full">
-                  <SelectValue placeholder="Zeitraum waehlen" />
+                  <SelectValue placeholder="Zeitraum wählen" />
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="MONTHLY">Monatlich</SelectItem>
-                  <SelectItem value="QUARTERLY">Quartalsweise</SelectItem>
-                  <SelectItem value="ANNUALLY">Jaehrlich</SelectItem>
+                  <SelectItem value="QUARTERLY">Vierteljährlich</SelectItem>
+                  <SelectItem value="ANNUALLY">Jährlich</SelectItem>
                 </SelectContent>
               </Select>
             </div>

--- a/apps/web/components/fees/billing-run-panel.tsx
+++ b/apps/web/components/fees/billing-run-panel.tsx
@@ -1,0 +1,263 @@
+'use client';
+
+import { useState } from 'react';
+import { Loader2, AlertTriangle } from 'lucide-react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Skeleton } from '@/components/ui/skeleton';
+import { BillingRunPreview } from '@/components/fees/billing-run-preview';
+import { useBillingRunPreview, useBillingRunConfirm } from '@/hooks/use-billing-run';
+import type { BillingRunPreviewResponse, BillingInterval } from '@ktb/shared';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface BillingRunPanelProps {
+  slug: string;
+  /** Callback when billing run completes (e.g., switch to Forderungen tab) */
+  onComplete?: () => void;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const moneyFormatter = new Intl.NumberFormat('de-DE', {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+function formatMoney(value: string): string {
+  return `${moneyFormatter.format(parseFloat(value))} EUR`;
+}
+
+const INTERVAL_OPTIONS: { value: BillingInterval; label: string }[] = [
+  { value: 'MONTHLY', label: 'Monatlich' },
+  { value: 'QUARTERLY', label: 'Quartalsweise' },
+  { value: 'ANNUALLY', label: 'Jaehrlich' },
+];
+
+// ============================================================================
+// Component
+// ============================================================================
+
+/**
+ * Billing run orchestration panel.
+ *
+ * Two-step flow:
+ * 1. Configuration: Select period, interval, load preview
+ * 2. Preview: Review summary, set due date, confirm
+ */
+export function BillingRunPanel({ slug, onComplete }: BillingRunPanelProps) {
+  // Form state
+  const [periodStart, setPeriodStart] = useState('');
+  const [periodEnd, setPeriodEnd] = useState('');
+  const [billingInterval, setBillingInterval] = useState<BillingInterval>('ANNUALLY');
+  const [dueDate, setDueDate] = useState('');
+  const [showConfirmDialog, setShowConfirmDialog] = useState(false);
+
+  // Preview state
+  const [previewData, setPreviewData] = useState<BillingRunPreviewResponse | null>(null);
+
+  // Mutations
+  const previewMutation = useBillingRunPreview(slug);
+  const confirmMutation = useBillingRunConfirm(slug);
+
+  // Handlers
+  function handleLoadPreview() {
+    if (!periodStart || !periodEnd) return;
+
+    previewMutation.mutate(
+      { periodStart, periodEnd, billingInterval },
+      {
+        onSuccess: (data) => {
+          setPreviewData(data);
+        },
+      }
+    );
+  }
+
+  function handleConfirm() {
+    if (!periodStart || !periodEnd || !dueDate) return;
+
+    confirmMutation.mutate(
+      { periodStart, periodEnd, billingInterval, dueDate },
+      {
+        onSuccess: () => {
+          setShowConfirmDialog(false);
+          setPreviewData(null);
+          setPeriodStart('');
+          setPeriodEnd('');
+          setDueDate('');
+          onComplete?.();
+        },
+      }
+    );
+  }
+
+  function handleBack() {
+    setPreviewData(null);
+    setDueDate('');
+  }
+
+  const canLoadPreview = periodStart && periodEnd && !previewMutation.isPending;
+  const canConfirm = previewData && dueDate && !confirmMutation.isPending;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Beitragserhebung</CardTitle>
+        <CardDescription>Forderungen fuer einen Abrechnungszeitraum erstellen</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {/* Step 1: Configuration */}
+        {!previewData && (
+          <div className="space-y-4">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+              <div className="space-y-2">
+                <Label htmlFor="periodStart">Von</Label>
+                <Input
+                  id="periodStart"
+                  type="date"
+                  value={periodStart}
+                  onChange={(e) => setPeriodStart(e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="periodEnd">Bis</Label>
+                <Input
+                  id="periodEnd"
+                  type="date"
+                  value={periodEnd}
+                  onChange={(e) => setPeriodEnd(e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="billingInterval">Rhythmus</Label>
+                <Select
+                  value={billingInterval}
+                  onValueChange={(value) => setBillingInterval(value as BillingInterval)}
+                >
+                  <SelectTrigger id="billingInterval" className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {INTERVAL_OPTIONS.map((opt) => (
+                      <SelectItem key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            <Button onClick={handleLoadPreview} disabled={!canLoadPreview}>
+              {previewMutation.isPending && <Loader2 className="h-4 w-4 animate-spin" />}
+              Vorschau laden
+            </Button>
+          </div>
+        )}
+
+        {/* Loading skeleton for preview */}
+        {previewMutation.isPending && !previewData && (
+          <div className="space-y-4">
+            <Skeleton className="h-6 w-40" />
+            <div className="flex gap-6">
+              <Skeleton className="h-5 w-32" />
+              <Skeleton className="h-5 w-40" />
+              <Skeleton className="h-5 w-24" />
+            </div>
+            <Skeleton className="h-6 w-56" />
+            <div className="space-y-2">
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+          </div>
+        )}
+
+        {/* Step 2: Preview + Confirm */}
+        {previewData && (
+          <div className="space-y-6">
+            <BillingRunPreview data={previewData} />
+
+            {/* Duplicate period warning */}
+            {previewData.existingCharges > 0 && (
+              <div className="flex items-start gap-3 rounded-md border bg-warning/15 border-warning/25 p-4">
+                <AlertTriangle className="h-5 w-5 shrink-0 text-warning-foreground" />
+                <p className="text-sm text-warning-foreground">
+                  Fuer diesen Zeitraum existieren bereits {previewData.existingCharges} Forderungen.
+                  Doppelte werden uebersprungen.
+                </p>
+              </div>
+            )}
+
+            {/* Due date field */}
+            <div className="space-y-2">
+              <Label htmlFor="dueDate">Faelligkeitsdatum</Label>
+              <Input
+                id="dueDate"
+                type="date"
+                value={dueDate}
+                onChange={(e) => setDueDate(e.target.value)}
+                className="max-w-xs"
+              />
+            </div>
+
+            {/* Action buttons */}
+            <div className="flex gap-4">
+              <Button variant="outline" onClick={handleBack}>
+                Zurueck
+              </Button>
+              <Button onClick={() => setShowConfirmDialog(true)} disabled={!canConfirm}>
+                Erhebung durchfuehren
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* Confirmation AlertDialog */}
+        <AlertDialog open={showConfirmDialog} onOpenChange={setShowConfirmDialog}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Beitragserhebung durchfuehren</AlertDialogTitle>
+              <AlertDialogDescription>
+                Es werden {previewData?.memberCount ?? 0} Forderungen ueber insgesamt{' '}
+                {previewData ? formatMoney(previewData.totalAmount) : '0,00 EUR'} erstellt. Dieser
+                Vorgang kann nicht rueckgaengig gemacht werden.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Abbrechen</AlertDialogCancel>
+              <AlertDialogAction onClick={handleConfirm} disabled={confirmMutation.isPending}>
+                {confirmMutation.isPending && <Loader2 className="h-4 w-4 animate-spin" />}
+                Erhebung starten
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/components/fees/billing-run-panel.tsx
+++ b/apps/web/components/fees/billing-run-panel.tsx
@@ -42,14 +42,7 @@ interface BillingRunPanelProps {
 // Helpers
 // ============================================================================
 
-const moneyFormatter = new Intl.NumberFormat('de-DE', {
-  minimumFractionDigits: 2,
-  maximumFractionDigits: 2,
-});
-
-function formatMoney(value: string): string {
-  return `${moneyFormatter.format(parseFloat(value))} EUR`;
-}
+import { formatMoney } from '@/lib/format-money';
 
 const INTERVAL_OPTIONS: { value: BillingInterval; label: string }[] = [
   { value: 'MONTHLY', label: 'Monatlich' },

--- a/apps/web/components/fees/billing-run-panel.tsx
+++ b/apps/web/components/fees/billing-run-panel.tsx
@@ -46,8 +46,8 @@ import { formatMoney } from '@/lib/format-money';
 
 const INTERVAL_OPTIONS: { value: BillingInterval; label: string }[] = [
   { value: 'MONTHLY', label: 'Monatlich' },
-  { value: 'QUARTERLY', label: 'Quartalsweise' },
-  { value: 'ANNUALLY', label: 'Jaehrlich' },
+  { value: 'QUARTERLY', label: 'Vierteljährlich' },
+  { value: 'ANNUALLY', label: 'Jährlich' },
 ];
 
 // ============================================================================
@@ -120,7 +120,7 @@ export function BillingRunPanel({ slug, onComplete }: BillingRunPanelProps) {
     <Card>
       <CardHeader>
         <CardTitle>Beitragserhebung</CardTitle>
-        <CardDescription>Forderungen fuer einen Abrechnungszeitraum erstellen</CardDescription>
+        <CardDescription>Forderungen für einen Abrechnungszeitraum erstellen</CardDescription>
       </CardHeader>
       <CardContent className="space-y-6">
         {/* Step 1: Configuration */}
@@ -200,15 +200,15 @@ export function BillingRunPanel({ slug, onComplete }: BillingRunPanelProps) {
               <div className="flex items-start gap-3 rounded-md border bg-warning/15 border-warning/25 p-4">
                 <AlertTriangle className="h-5 w-5 shrink-0 text-warning-foreground" />
                 <p className="text-sm text-warning-foreground">
-                  Fuer diesen Zeitraum existieren bereits {previewData.existingCharges} Forderungen.
-                  Doppelte werden uebersprungen.
+                  Für diesen Zeitraum existieren bereits {previewData.existingCharges} Forderungen.
+                  Doppelte werden übersprungen.
                 </p>
               </div>
             )}
 
             {/* Due date field */}
             <div className="space-y-2">
-              <Label htmlFor="dueDate">Faelligkeitsdatum</Label>
+              <Label htmlFor="dueDate">Fälligkeitsdatum</Label>
               <Input
                 id="dueDate"
                 type="date"
@@ -221,10 +221,10 @@ export function BillingRunPanel({ slug, onComplete }: BillingRunPanelProps) {
             {/* Action buttons */}
             <div className="flex gap-4">
               <Button variant="outline" onClick={handleBack}>
-                Zurueck
+                Zurück
               </Button>
               <Button onClick={() => setShowConfirmDialog(true)} disabled={!canConfirm}>
-                Erhebung durchfuehren
+                Erhebung durchführen
               </Button>
             </div>
           </div>
@@ -234,11 +234,11 @@ export function BillingRunPanel({ slug, onComplete }: BillingRunPanelProps) {
         <AlertDialog open={showConfirmDialog} onOpenChange={setShowConfirmDialog}>
           <AlertDialogContent>
             <AlertDialogHeader>
-              <AlertDialogTitle>Beitragserhebung durchfuehren</AlertDialogTitle>
+              <AlertDialogTitle>Beitragserhebung durchführen</AlertDialogTitle>
               <AlertDialogDescription>
-                Es werden {previewData?.memberCount ?? 0} Forderungen ueber insgesamt{' '}
+                Es werden {previewData?.memberCount ?? 0} Forderungen über insgesamt{' '}
                 {previewData ? formatMoney(previewData.totalAmount) : '0,00 EUR'} erstellt. Dieser
-                Vorgang kann nicht rueckgaengig gemacht werden.
+                Vorgang kann nicht rückgängig gemacht werden.
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>

--- a/apps/web/components/fees/billing-run-preview.tsx
+++ b/apps/web/components/fees/billing-run-preview.tsx
@@ -23,14 +23,7 @@ interface BillingRunPreviewProps {
 // Helpers
 // ============================================================================
 
-const moneyFormatter = new Intl.NumberFormat('de-DE', {
-  minimumFractionDigits: 2,
-  maximumFractionDigits: 2,
-});
-
-function formatMoney(value: string): string {
-  return `${moneyFormatter.format(parseFloat(value))} EUR`;
-}
+import { formatMoney } from '@/lib/format-money';
 
 // ============================================================================
 // Component

--- a/apps/web/components/fees/billing-run-preview.tsx
+++ b/apps/web/components/fees/billing-run-preview.tsx
@@ -63,7 +63,7 @@ export function BillingRunPreview({ data }: BillingRunPreviewProps) {
         {/* Breakdown */}
         {data.breakdown.length > 0 && (
           <div>
-            <h3 className="text-sm font-medium mb-3">Aufschluesselung nach Mitgliedsart:</h3>
+            <h3 className="text-sm font-medium mb-3">Aufschlüsselung nach Mitgliedsart:</h3>
             <Table>
               <TableHeader>
                 <TableRow>

--- a/apps/web/components/fees/billing-run-preview.tsx
+++ b/apps/web/components/fees/billing-run-preview.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { Card, CardContent } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import type { BillingRunPreviewResponse } from '@ktb/shared';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface BillingRunPreviewProps {
+  data: BillingRunPreviewResponse;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const moneyFormatter = new Intl.NumberFormat('de-DE', {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+function formatMoney(value: string): string {
+  return `${moneyFormatter.format(parseFloat(value))} EUR`;
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+/**
+ * Displays billing run preview data: summary stats and breakdown by membership type.
+ */
+export function BillingRunPreview({ data }: BillingRunPreviewProps) {
+  return (
+    <Card>
+      <CardContent className="space-y-6">
+        {/* Summary */}
+        <div>
+          <h3 className="text-sm font-medium mb-3">Zusammenfassung</h3>
+          <div className="flex flex-wrap gap-6">
+            <div>
+              <span className="text-sm text-muted-foreground">Mitglieder: </span>
+              <span className="text-sm font-medium tabular-nums">{data.memberCount}</span>
+            </div>
+            <div>
+              <span className="text-sm text-muted-foreground">Gesamtbetrag: </span>
+              <span
+                className="text-sm font-medium tabular-nums"
+                aria-label={`Gesamtbetrag: ${formatMoney(data.totalAmount)}`}
+              >
+                {formatMoney(data.totalAmount)}
+              </span>
+            </div>
+            <div>
+              <span className="text-sm text-muted-foreground">Befreit: </span>
+              <span className="text-sm font-medium tabular-nums">{data.exemptions}</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Breakdown */}
+        {data.breakdown.length > 0 && (
+          <div>
+            <h3 className="text-sm font-medium mb-3">Aufschluesselung nach Mitgliedsart:</h3>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Mitgliedsart</TableHead>
+                  <TableHead className="text-right tabular-nums">Anzahl</TableHead>
+                  <TableHead className="text-right tabular-nums">Zwischensumme</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {data.breakdown.map((item) => (
+                  <TableRow key={item.membershipType}>
+                    <TableCell>{item.membershipType}</TableCell>
+                    <TableCell className="text-right tabular-nums">{item.count}</TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {formatMoney(item.subtotal)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/components/fees/fee-category-form.tsx
+++ b/apps/web/components/fees/fee-category-form.tsx
@@ -128,7 +128,7 @@ export function FeeCategoryForm({ open, onOpenChange, editingCategory }: FeeCate
           </DialogTitle>
           <DialogDescription>
             {isEditing
-              ? 'Aendere die Konfiguration der Beitragskategorie.'
+              ? 'Ändere die Konfiguration der Beitragskategorie.'
               : 'Erstelle eine neue Beitragskategorie mit Betrag und Abrechnungszeitraum.'}
           </DialogDescription>
         </DialogHeader>
@@ -202,11 +202,11 @@ export function FeeCategoryForm({ open, onOpenChange, editingCategory }: FeeCate
               )}
             </div>
 
-            {/* Einmalige Gebuehr */}
+            {/* Einmalige Gebühr */}
             <div className="flex items-center justify-between rounded-lg border p-4">
               <div className="space-y-0.5">
                 <Label htmlFor="fc-isOneTime" className="text-sm font-medium">
-                  Einmalige Gebuehr (z.B. Aufnahmegebuehr)
+                  Einmalige Gebühr (z.B. Aufnahmegebühr)
                 </Label>
               </div>
               <Switch

--- a/apps/web/components/fees/fee-category-form.tsx
+++ b/apps/web/components/fees/fee-category-form.tsx
@@ -1,0 +1,252 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useParams } from 'next/navigation';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Loader2 } from 'lucide-react';
+import {
+  CreateFeeCategorySchema,
+  type CreateFeeCategory,
+  type FeeCategoryResponse,
+} from '@ktb/shared';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Switch } from '@/components/ui/switch';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useCreateFeeCategory, useUpdateFeeCategory } from '@/hooks/use-fee-categories';
+
+/**
+ * Form values type uses the schema _input for zodResolver compatibility.
+ */
+type FeeCategoryFormValues = (typeof CreateFeeCategorySchema)['_input'];
+
+const DEFAULT_VALUES: FeeCategoryFormValues = {
+  name: '',
+  description: '',
+  amount: '',
+  billingInterval: 'ANNUALLY',
+  isOneTime: false,
+  sortOrder: 0,
+};
+
+interface FeeCategoryFormProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  editingCategory: FeeCategoryResponse | null;
+}
+
+/**
+ * Dialog for creating or editing a fee category.
+ * Uses react-hook-form with zodResolver for validation.
+ */
+export function FeeCategoryForm({ open, onOpenChange, editingCategory }: FeeCategoryFormProps) {
+  const params = useParams<{ slug: string }>();
+  const slug = params.slug;
+  const isEditing = !!editingCategory;
+
+  const createMutation = useCreateFeeCategory(slug);
+  const updateMutation = useUpdateFeeCategory(slug);
+  const isPending = createMutation.isPending || updateMutation.isPending;
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    setValue,
+    watch,
+    formState: { errors },
+  } = useForm<FeeCategoryFormValues>({
+    resolver: zodResolver(CreateFeeCategorySchema),
+    defaultValues: DEFAULT_VALUES,
+  });
+
+  // Reset form when dialog opens/closes or editing target changes
+  useEffect(() => {
+    if (open) {
+      if (editingCategory) {
+        reset({
+          name: editingCategory.name,
+          description: editingCategory.description ?? '',
+          amount: editingCategory.amount,
+          billingInterval: editingCategory.billingInterval,
+          isOneTime: editingCategory.isOneTime,
+          sortOrder: editingCategory.sortOrder,
+        });
+      } else {
+        reset(DEFAULT_VALUES);
+      }
+    }
+  }, [open, editingCategory, reset]);
+
+  async function onSubmit(data: FeeCategoryFormValues) {
+    const payload: CreateFeeCategory = {
+      name: data.name,
+      description: data.description || undefined,
+      amount: data.amount,
+      billingInterval: data.billingInterval ?? 'ANNUALLY',
+      isOneTime: data.isOneTime ?? false,
+      sortOrder: data.sortOrder ?? 0,
+    };
+
+    if (isEditing) {
+      await updateMutation.mutateAsync({
+        id: editingCategory.id,
+        data: payload,
+      });
+    } else {
+      await createMutation.mutateAsync(payload);
+    }
+    onOpenChange(false);
+  }
+
+  const isOneTime = watch('isOneTime');
+  const billingInterval = watch('billingInterval');
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg max-h-[85vh] flex flex-col">
+        <DialogHeader>
+          <DialogTitle>
+            {isEditing ? 'Beitragskategorie bearbeiten' : 'Beitragskategorie erstellen'}
+          </DialogTitle>
+          <DialogDescription>
+            {isEditing
+              ? 'Aendere die Konfiguration der Beitragskategorie.'
+              : 'Erstelle eine neue Beitragskategorie mit Betrag und Abrechnungszeitraum.'}
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col flex-1 min-h-0">
+          <div className="space-y-4 py-4 overflow-y-auto">
+            {/* Name */}
+            <div className="space-y-2">
+              <Label htmlFor="fc-name">Name</Label>
+              <Input
+                id="fc-name"
+                placeholder="z.B. Tennisabteilung"
+                maxLength={100}
+                autoFocus
+                {...register('name')}
+              />
+              {errors.name?.message && (
+                <p className="text-destructive text-sm">{errors.name.message}</p>
+              )}
+            </div>
+
+            {/* Beschreibung */}
+            <div className="space-y-2">
+              <Label htmlFor="fc-description">Beschreibung</Label>
+              <Textarea
+                id="fc-description"
+                placeholder="Optionale Beschreibung"
+                maxLength={500}
+                rows={2}
+                {...register('description')}
+              />
+              {errors.description?.message && (
+                <p className="text-destructive text-sm">{errors.description.message}</p>
+              )}
+            </div>
+
+            {/* Betrag (EUR) */}
+            <div className="space-y-2">
+              <Label htmlFor="fc-amount">Betrag (EUR)</Label>
+              <Input
+                id="fc-amount"
+                placeholder="z.B. 120.00"
+                inputMode="decimal"
+                {...register('amount')}
+              />
+              {errors.amount?.message && (
+                <p className="text-destructive text-sm">{errors.amount.message}</p>
+              )}
+            </div>
+
+            {/* Abrechnungszeitraum */}
+            <div className="space-y-2">
+              <Label htmlFor="fc-interval">Abrechnungszeitraum</Label>
+              <Select
+                value={billingInterval}
+                onValueChange={(val) =>
+                  setValue('billingInterval', val as FeeCategoryFormValues['billingInterval'])
+                }
+              >
+                <SelectTrigger id="fc-interval" className="w-full">
+                  <SelectValue placeholder="Zeitraum waehlen" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="MONTHLY">Monatlich</SelectItem>
+                  <SelectItem value="QUARTERLY">Quartalsweise</SelectItem>
+                  <SelectItem value="ANNUALLY">Jaehrlich</SelectItem>
+                </SelectContent>
+              </Select>
+              {errors.billingInterval?.message && (
+                <p className="text-destructive text-sm">{errors.billingInterval.message}</p>
+              )}
+            </div>
+
+            {/* Einmalige Gebuehr */}
+            <div className="flex items-center justify-between rounded-lg border p-4">
+              <div className="space-y-0.5">
+                <Label htmlFor="fc-isOneTime" className="text-sm font-medium">
+                  Einmalige Gebuehr (z.B. Aufnahmegebuehr)
+                </Label>
+              </div>
+              <Switch
+                id="fc-isOneTime"
+                checked={isOneTime}
+                onCheckedChange={(checked) => setValue('isOneTime', checked)}
+              />
+            </div>
+
+            {/* Sortierung */}
+            <div className="space-y-2">
+              <Label htmlFor="fc-sortOrder">Sortierung</Label>
+              <Input
+                id="fc-sortOrder"
+                type="number"
+                min={0}
+                {...register('sortOrder', { valueAsNumber: true })}
+              />
+              {errors.sortOrder?.message && (
+                <p className="text-destructive text-sm">{errors.sortOrder.message}</p>
+              )}
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isPending}
+            >
+              Abbrechen
+            </Button>
+            <Button type="submit" disabled={isPending}>
+              {isPending && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+              {isEditing ? 'Speichern' : 'Erstellen'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/components/fees/fee-category-form.tsx
+++ b/apps/web/components/fees/fee-category-form.tsx
@@ -189,12 +189,12 @@ export function FeeCategoryForm({ open, onOpenChange, editingCategory }: FeeCate
                 }
               >
                 <SelectTrigger id="fc-interval" className="w-full">
-                  <SelectValue placeholder="Zeitraum waehlen" />
+                  <SelectValue placeholder="Zeitraum wählen" />
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="MONTHLY">Monatlich</SelectItem>
-                  <SelectItem value="QUARTERLY">Quartalsweise</SelectItem>
-                  <SelectItem value="ANNUALLY">Jaehrlich</SelectItem>
+                  <SelectItem value="QUARTERLY">Vierteljährlich</SelectItem>
+                  <SelectItem value="ANNUALLY">Jährlich</SelectItem>
                 </SelectContent>
               </Select>
               {errors.billingInterval?.message && (

--- a/apps/web/components/fees/fee-category-list.tsx
+++ b/apps/web/components/fees/fee-category-list.tsx
@@ -1,9 +1,224 @@
 'use client';
 
+import { useState } from 'react';
+import { useParams } from 'next/navigation';
+import { Pencil, Plus, Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardDescription, CardHeader } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Skeleton } from '@/components/ui/skeleton';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+import { useFeeCategories, useDeleteFeeCategory } from '@/hooks/use-fee-categories';
+import { FeeCategoryForm } from './fee-category-form';
+import type { FeeCategoryResponse } from '@ktb/shared';
+
+const INTERVAL_LABELS: Record<string, string> = {
+  MONTHLY: 'Monatlich',
+  QUARTERLY: 'Quartalsweise',
+  ANNUALLY: 'Jaehrlich',
+};
+
+function formatAmount(amount: string): string {
+  return (
+    new Intl.NumberFormat('de-DE', {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(parseFloat(amount)) + ' EUR'
+  );
+}
+
 /**
- * Fee category list component - placeholder.
- * Full implementation in Task 2.
+ * Fee category list with CRUD actions.
+ * Displays a table of fee categories with create, edit, and delete functionality.
  */
 export function FeeCategoryList() {
-  return <div>Loading fee categories...</div>;
+  const params = useParams<{ slug: string }>();
+  const slug = params.slug;
+
+  const { data: categories, isLoading } = useFeeCategories(slug);
+  const deleteMutation = useDeleteFeeCategory(slug);
+
+  // Dialog state
+  const [formOpen, setFormOpen] = useState(false);
+  const [editingCategory, setEditingCategory] = useState<FeeCategoryResponse | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<FeeCategoryResponse | null>(null);
+
+  function openCreate() {
+    setEditingCategory(null);
+    setFormOpen(true);
+  }
+
+  function openEdit(category: FeeCategoryResponse) {
+    setEditingCategory(category);
+    setFormOpen(true);
+  }
+
+  async function handleDelete() {
+    if (!deleteTarget) return;
+    await deleteMutation.mutateAsync(deleteTarget.id);
+    setDeleteTarget(null);
+  }
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-5 w-48" />
+          <Skeleton className="h-4 w-96 mt-2" />
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-3">
+            {[...Array(3)].map((_, i) => (
+              <div key={i} className="flex items-center gap-4 py-2">
+                <Skeleton className="h-4 w-32" />
+                <Skeleton className="h-4 w-48 hidden lg:block" />
+                <Skeleton className="h-4 w-20" />
+                <Skeleton className="h-4 w-24" />
+                <Skeleton className="h-5 w-12 rounded-md" />
+                <Skeleton className="h-5 w-12 rounded-md" />
+                <Skeleton className="h-8 w-16" />
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const items = categories ?? [];
+  const isEmpty = items.length === 0;
+
+  return (
+    <>
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div>
+              <CardDescription>
+                Zusaetzliche Beitragspositionen neben dem Grundbeitrag der Mitgliedsart
+              </CardDescription>
+            </div>
+            {!isEmpty && (
+              <Button onClick={openCreate}>
+                <Plus className="h-4 w-4 mr-2" />
+                Kategorie erstellen
+              </Button>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent className="p-6">
+          {isEmpty ? (
+            <div className="flex flex-col items-center justify-center py-12 text-center">
+              <h3 className="text-lg font-semibold mb-2">Noch keine Beitragskategorien</h3>
+              <p className="text-muted-foreground max-w-md mb-6">
+                Erstelle Beitragskategorien fuer zusaetzliche Positionen neben dem Grundbeitrag der
+                Mitgliedsart.
+              </p>
+              <Button onClick={openCreate}>
+                <Plus className="h-4 w-4 mr-2" />
+                Erste Kategorie erstellen
+              </Button>
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead className="hidden lg:table-cell">Beschreibung</TableHead>
+                  <TableHead className="text-right">Betrag</TableHead>
+                  <TableHead>Rhythmus</TableHead>
+                  <TableHead>Einmalig</TableHead>
+                  <TableHead>Aktiv</TableHead>
+                  <TableHead className="w-24">Aktionen</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {items.map((category) => (
+                  <TableRow key={category.id}>
+                    <TableCell className="font-medium">{category.name}</TableCell>
+                    <TableCell className="hidden lg:table-cell text-muted-foreground">
+                      {category.description || '—'}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {formatAmount(category.amount)}
+                    </TableCell>
+                    <TableCell>
+                      {category.isOneTime
+                        ? 'Einmalig'
+                        : (INTERVAL_LABELS[category.billingInterval] ?? category.billingInterval)}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={category.isOneTime ? 'default' : 'secondary'}>
+                        {category.isOneTime ? 'Ja' : 'Nein'}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <Badge
+                        className={
+                          category.isActive
+                            ? 'bg-success/15 text-success border-success/25'
+                            : 'bg-muted text-muted-foreground'
+                        }
+                      >
+                        {category.isActive ? 'Aktiv' : 'Inaktiv'}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex items-center gap-1 justify-end">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => openEdit(category)}
+                          aria-label={`${category.name} bearbeiten`}
+                        >
+                          <Pencil className="h-4 w-4" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => setDeleteTarget(category)}
+                          aria-label={`${category.name} loeschen`}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Create/Edit Dialog */}
+      <FeeCategoryForm
+        open={formOpen}
+        onOpenChange={setFormOpen}
+        editingCategory={editingCategory}
+      />
+
+      {/* Delete Confirmation */}
+      <ConfirmDialog
+        open={!!deleteTarget}
+        onOpenChange={(open) => !open && setDeleteTarget(null)}
+        title="Beitragskategorie loeschen"
+        description={`Moechtest du die Kategorie "${deleteTarget?.name}" wirklich loeschen? Bestehende Forderungen bleiben erhalten.`}
+        confirmLabel="Loeschen"
+        cancelLabel="Abbrechen"
+        variant="destructive"
+        onConfirm={handleDelete}
+        loading={deleteMutation.isPending}
+      />
+    </>
+  );
 }

--- a/apps/web/components/fees/fee-category-list.tsx
+++ b/apps/web/components/fees/fee-category-list.tsx
@@ -26,14 +26,7 @@ const INTERVAL_LABELS: Record<string, string> = {
   ANNUALLY: 'Jährlich',
 };
 
-function formatAmount(amount: string): string {
-  return (
-    new Intl.NumberFormat('de-DE', {
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    }).format(parseFloat(amount)) + ' EUR'
-  );
-}
+import { formatMoney } from '@/lib/format-money';
 
 /**
  * Fee category list with CRUD actions.
@@ -104,7 +97,7 @@ export function FeeCategoryList() {
           <div className="flex items-center justify-between">
             <div>
               <CardDescription>
-                Zusaetzliche Beitragspositionen neben dem Grundbeitrag der Mitgliedsart
+                Zusätzliche Beitragspositionen neben dem Grundbeitrag der Mitgliedsart
               </CardDescription>
             </div>
             {!isEmpty && (
@@ -149,7 +142,7 @@ export function FeeCategoryList() {
                       {category.description || '—'}
                     </TableCell>
                     <TableCell className="text-right tabular-nums">
-                      {formatAmount(category.amount)}
+                      {formatMoney(category.amount)}
                     </TableCell>
                     <TableCell>
                       {category.isOneTime

--- a/apps/web/components/fees/fee-category-list.tsx
+++ b/apps/web/components/fees/fee-category-list.tsx
@@ -22,8 +22,8 @@ import type { FeeCategoryResponse } from '@ktb/shared';
 
 const INTERVAL_LABELS: Record<string, string> = {
   MONTHLY: 'Monatlich',
-  QUARTERLY: 'Quartalsweise',
-  ANNUALLY: 'Jaehrlich',
+  QUARTERLY: 'Vierteljährlich',
+  ANNUALLY: 'Jährlich',
 };
 
 function formatAmount(amount: string): string {
@@ -120,7 +120,7 @@ export function FeeCategoryList() {
             <div className="flex flex-col items-center justify-center py-12 text-center">
               <h3 className="text-lg font-semibold mb-2">Noch keine Beitragskategorien</h3>
               <p className="text-muted-foreground max-w-md mb-6">
-                Erstelle Beitragskategorien fuer zusaetzliche Positionen neben dem Grundbeitrag der
+                Erstelle Beitragskategorien für zusätzliche Positionen neben dem Grundbeitrag der
                 Mitgliedsart.
               </p>
               <Button onClick={openCreate}>
@@ -186,7 +186,7 @@ export function FeeCategoryList() {
                           variant="ghost"
                           size="icon"
                           onClick={() => setDeleteTarget(category)}
-                          aria-label={`${category.name} loeschen`}
+                          aria-label={`${category.name} löschen`}
                         >
                           <Trash2 className="h-4 w-4" />
                         </Button>
@@ -211,9 +211,9 @@ export function FeeCategoryList() {
       <ConfirmDialog
         open={!!deleteTarget}
         onOpenChange={(open) => !open && setDeleteTarget(null)}
-        title="Beitragskategorie loeschen"
-        description={`Moechtest du die Kategorie "${deleteTarget?.name}" wirklich loeschen? Bestehende Forderungen bleiben erhalten.`}
-        confirmLabel="Loeschen"
+        title="Beitragskategorie löschen"
+        description={`Möchtest du die Kategorie „${deleteTarget?.name}" wirklich löschen? Bestehende Forderungen bleiben erhalten.`}
+        confirmLabel="Löschen"
         cancelLabel="Abbrechen"
         variant="destructive"
         onConfirm={handleDelete}

--- a/apps/web/components/fees/fee-category-list.tsx
+++ b/apps/web/components/fees/fee-category-list.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+/**
+ * Fee category list component - placeholder.
+ * Full implementation in Task 2.
+ */
+export function FeeCategoryList() {
+  return <div>Loading fee categories...</div>;
+}

--- a/apps/web/components/fees/fee-charge-list.tsx
+++ b/apps/web/components/fees/fee-charge-list.tsx
@@ -1,0 +1,432 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import { CreditCard, X, ChevronLeft, ChevronRight } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Skeleton } from '@/components/ui/skeleton';
+import { FeeChargeStatusBadge } from '@/components/fees/fee-charge-status-badge';
+import { PaymentRecordDialog } from '@/components/fees/payment-record-dialog';
+import { useFeeCharges, type FeeChargeFilters } from '@/hooks/use-fee-charges';
+import { useDebounce } from '@/hooks/use-debounce';
+import { cn } from '@/lib/utils';
+import type { FeeChargeResponse } from '@ktb/shared';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface FeeChargeListProps {
+  slug: string;
+  /** Pre-filter by member ID (from member detail navigation) */
+  memberId?: string;
+  /** Member name for the pre-filter banner */
+  memberName?: string;
+  /** Callback to switch to the Erhebung tab */
+  onSwitchToErhebung?: () => void;
+}
+
+type StatusFilter = 'ALL' | 'OPEN' | 'PARTIAL' | 'PAID' | 'OVERDUE';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const moneyFormatter = new Intl.NumberFormat('de-DE', {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+function formatMoney(value: string): string {
+  return `${moneyFormatter.format(parseFloat(value))} EUR`;
+}
+
+function formatPeriod(start: string, end: string): string {
+  const startDate = new Date(start);
+  const endDate = new Date(end);
+  const formatDay = (d: Date) =>
+    `${String(d.getDate()).padStart(2, '0')}.${String(d.getMonth() + 1).padStart(2, '0')}.`;
+  return `${formatDay(startDate)}-${formatDay(endDate)}`;
+}
+
+const PAGE_SIZE = 20;
+
+// ============================================================================
+// Component
+// ============================================================================
+
+/**
+ * Filterable table of fee charges with status badges and payment recording.
+ */
+export function FeeChargeList({
+  slug,
+  memberId: initialMemberId,
+  memberName,
+  onSwitchToErhebung,
+}: FeeChargeListProps) {
+  // Filter state
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('ALL');
+  const [memberSearch, setMemberSearch] = useState('');
+  const [periodFilter, setPeriodFilter] = useState('');
+  const [memberId, setMemberId] = useState(initialMemberId);
+  const [page, setPage] = useState(1);
+
+  // Payment dialog state
+  const [selectedCharge, setSelectedCharge] = useState<FeeChargeResponse | null>(null);
+
+  const debouncedMemberSearch = useDebounce(memberSearch, 300);
+
+  // Build filter object
+  const filters = useMemo<FeeChargeFilters>(() => {
+    const f: FeeChargeFilters = {
+      page,
+      limit: PAGE_SIZE,
+    };
+    if (statusFilter !== 'ALL' && statusFilter !== 'OVERDUE') {
+      f.status = statusFilter;
+    }
+    if (memberId) {
+      f.memberId = memberId;
+    }
+    if (periodFilter) {
+      f.periodStart = `${periodFilter}-01-01`;
+      f.periodEnd = `${periodFilter}-12-31`;
+    }
+    return f;
+  }, [statusFilter, memberId, periodFilter, page]);
+
+  const { data, isLoading } = useFeeCharges(slug, filters);
+
+  // Compute filtered data for OVERDUE client-side filter
+  const charges = useMemo(() => {
+    if (!data?.data) return [];
+    if (statusFilter === 'OVERDUE') {
+      return data.data.filter((c) => c.isOverdue);
+    }
+    // Client-side member name search (API filters by memberId; this filters by name text)
+    if (debouncedMemberSearch && !memberId) {
+      const search = debouncedMemberSearch.toLowerCase();
+      return data.data.filter(
+        (c) =>
+          c.member.firstName.toLowerCase().includes(search) ||
+          c.member.lastName.toLowerCase().includes(search) ||
+          c.member.memberNumber.toLowerCase().includes(search)
+      );
+    }
+    return data.data;
+  }, [data?.data, statusFilter, debouncedMemberSearch, memberId]);
+
+  // Summary calculations
+  const summary = useMemo(() => {
+    if (!data?.data) return { total: 0, openAmount: '0', paidAmount: '0' };
+    const total = data.total ?? data.data.length;
+    let openSum = 0;
+    let paidSum = 0;
+    for (const charge of data.data) {
+      if (charge.status !== 'PAID') {
+        openSum += parseFloat(charge.remainingAmount);
+      }
+      paidSum += parseFloat(charge.paidAmount);
+    }
+    return {
+      total,
+      openAmount: moneyFormatter.format(openSum),
+      paidAmount: moneyFormatter.format(paidSum),
+    };
+  }, [data]);
+
+  const hasActiveFilters = statusFilter !== 'ALL' || memberSearch || periodFilter || memberId;
+
+  function resetFilters() {
+    setStatusFilter('ALL');
+    setMemberSearch('');
+    setPeriodFilter('');
+    setMemberId(undefined);
+    setPage(1);
+  }
+
+  function clearMemberFilter() {
+    setMemberId(undefined);
+  }
+
+  // ---- Render ----
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <div className="flex gap-4">
+          <Skeleton className="h-9 w-32" />
+          <Skeleton className="h-9 w-48" />
+          <Skeleton className="h-9 w-28" />
+        </div>
+        <Skeleton className="h-5 w-96" />
+        <div className="space-y-2">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Skeleton key={i} className="h-12 w-full" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  // Empty state: No charges at all
+  if (!isLoading && !hasActiveFilters && charges.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 text-center">
+        <CreditCard className="h-12 w-12 text-muted-foreground mb-4" />
+        <h3 className="text-lg font-semibold">Noch keine Forderungen</h3>
+        <p className="text-sm text-muted-foreground mt-2 max-w-md">
+          Fuehre eine Beitragserhebung durch, um Forderungen fuer deine Mitglieder zu erstellen.
+        </p>
+        {onSwitchToErhebung && (
+          <Button className="mt-4" onClick={onSwitchToErhebung}>
+            Zur Erhebung
+          </Button>
+        )}
+      </div>
+    );
+  }
+
+  // Empty state: No filter results
+  if (!isLoading && hasActiveFilters && charges.length === 0) {
+    return (
+      <div className="space-y-4">
+        <FilterBar
+          statusFilter={statusFilter}
+          onStatusChange={setStatusFilter}
+          memberSearch={memberSearch}
+          onMemberSearchChange={setMemberSearch}
+          periodFilter={periodFilter}
+          onPeriodChange={setPeriodFilter}
+        />
+        {memberId && memberName && (
+          <MemberFilterBanner name={memberName} onClear={clearMemberFilter} />
+        )}
+        <div className="flex flex-col items-center justify-center py-12 text-center">
+          <h3 className="text-lg font-semibold">Keine Forderungen gefunden</h3>
+          <p className="text-sm text-muted-foreground mt-2">Deine Filter ergaben keine Treffer.</p>
+          <Button variant="outline" className="mt-4" onClick={resetFilters}>
+            Filter zuruecksetzen
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Filter bar */}
+      <FilterBar
+        statusFilter={statusFilter}
+        onStatusChange={setStatusFilter}
+        memberSearch={memberSearch}
+        onMemberSearchChange={setMemberSearch}
+        periodFilter={periodFilter}
+        onPeriodChange={setPeriodFilter}
+      />
+
+      {/* Member pre-filter banner */}
+      {memberId && memberName && (
+        <MemberFilterBanner name={memberName} onClear={clearMemberFilter} />
+      )}
+
+      {/* Summary row */}
+      <p className="text-sm text-muted-foreground">
+        Gesamt: {summary.total} Forderungen | Offen: {summary.openAmount} EUR | Bezahlt:{' '}
+        {summary.paidAmount} EUR
+      </p>
+
+      {/* Charges table */}
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Mitglied</TableHead>
+            <TableHead>Beschreibung</TableHead>
+            <TableHead className="hidden lg:table-cell">Zeitraum</TableHead>
+            <TableHead className="text-right tabular-nums">Betrag</TableHead>
+            <TableHead className="text-right tabular-nums">Bezahlt</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead className="w-10">Aktionen</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {charges.map((charge) => (
+            <TableRow
+              key={charge.id}
+              className={cn(charge.isOverdue && 'border-l-4 border-destructive')}
+            >
+              <TableCell>
+                <div>
+                  <span className="font-medium">
+                    {charge.member.lastName}, {charge.member.firstName}
+                  </span>
+                  <span className="ml-2 text-xs text-muted-foreground">
+                    {charge.member.memberNumber}
+                  </span>
+                </div>
+              </TableCell>
+              <TableCell>{charge.description}</TableCell>
+              <TableCell className="hidden lg:table-cell">
+                {formatPeriod(charge.periodStart, charge.periodEnd)}
+              </TableCell>
+              <TableCell className="text-right tabular-nums">
+                {formatMoney(charge.amount)}
+              </TableCell>
+              <TableCell className="text-right tabular-nums">
+                {formatMoney(charge.paidAmount)}
+              </TableCell>
+              <TableCell>
+                <FeeChargeStatusBadge status={charge.status} isOverdue={charge.isOverdue} />
+              </TableCell>
+              <TableCell>
+                <Button
+                  variant="ghost"
+                  size="icon-xs"
+                  onClick={() => setSelectedCharge(charge)}
+                  aria-label="Zahlung erfassen"
+                >
+                  <CreditCard className="h-4 w-4" />
+                </Button>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+
+      {/* Pagination */}
+      {data && data.total > PAGE_SIZE && (
+        <div className="flex items-center justify-end gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            disabled={page <= 1}
+          >
+            <ChevronLeft className="h-4 w-4" />
+            Zurueck
+          </Button>
+          <span className="text-sm text-muted-foreground tabular-nums">Seite {page}</span>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setPage((p) => p + 1)}
+            disabled={page * PAGE_SIZE >= data.total}
+          >
+            Weiter
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+        </div>
+      )}
+
+      {/* Payment recording dialog */}
+      {selectedCharge && (
+        <PaymentRecordDialog
+          charge={selectedCharge}
+          open={!!selectedCharge}
+          onOpenChange={(open) => {
+            if (!open) setSelectedCharge(null);
+          }}
+          slug={slug}
+        />
+      )}
+    </div>
+  );
+}
+
+// ============================================================================
+// Sub-components
+// ============================================================================
+
+interface FilterBarProps {
+  statusFilter: StatusFilter;
+  onStatusChange: (value: StatusFilter) => void;
+  memberSearch: string;
+  onMemberSearchChange: (value: string) => void;
+  periodFilter: string;
+  onPeriodChange: (value: string) => void;
+}
+
+function FilterBar({
+  statusFilter,
+  onStatusChange,
+  memberSearch,
+  onMemberSearchChange,
+  periodFilter,
+  onPeriodChange,
+}: FilterBarProps) {
+  return (
+    <div className="flex flex-wrap items-end gap-4">
+      <div className="space-y-2">
+        <Label htmlFor="statusFilter">Status</Label>
+        <Select value={statusFilter} onValueChange={(v) => onStatusChange(v as StatusFilter)}>
+          <SelectTrigger id="statusFilter" className="w-44">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="ALL">Alle</SelectItem>
+            <SelectItem value="OPEN">Offen</SelectItem>
+            <SelectItem value="PARTIAL">Teilweise bezahlt</SelectItem>
+            <SelectItem value="PAID">Bezahlt</SelectItem>
+            <SelectItem value="OVERDUE">Ueberfaellig</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="memberSearch">Mitglied</Label>
+        <Input
+          id="memberSearch"
+          placeholder="Suchen..."
+          value={memberSearch}
+          onChange={(e) => onMemberSearchChange(e.target.value)}
+          className="w-48"
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="periodFilter">Periode</Label>
+        <Input
+          id="periodFilter"
+          type="number"
+          placeholder="z.B. 2026"
+          value={periodFilter}
+          onChange={(e) => onPeriodChange(e.target.value)}
+          className="w-28"
+          min={2000}
+          max={2100}
+        />
+      </div>
+    </div>
+  );
+}
+
+interface MemberFilterBannerProps {
+  name: string;
+  onClear: () => void;
+}
+
+function MemberFilterBanner({ name, onClear }: MemberFilterBannerProps) {
+  return (
+    <div className="flex items-center gap-2 rounded-md border bg-muted px-3 py-2 text-sm">
+      <span>Gefiltert nach: {name}</span>
+      <Button variant="ghost" size="icon-xs" onClick={onClear} aria-label="Filter entfernen">
+        <X className="h-3 w-3" />
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/components/fees/fee-charge-list.tsx
+++ b/apps/web/components/fees/fee-charge-list.tsx
@@ -91,7 +91,7 @@ export function FeeChargeList({
       page,
       limit: PAGE_SIZE,
     };
-    if (statusFilter !== 'ALL' && statusFilter !== 'OVERDUE') {
+    if (statusFilter !== 'ALL') {
       f.status = statusFilter;
     }
     if (memberId) {
@@ -109,9 +109,6 @@ export function FeeChargeList({
   // Compute filtered data for OVERDUE client-side filter
   const charges = useMemo(() => {
     if (!data?.data) return [];
-    if (statusFilter === 'OVERDUE') {
-      return data.data.filter((c) => c.isOverdue);
-    }
     // Client-side member name search (API filters by memberId; this filters by name text)
     if (debouncedMemberSearch && !memberId) {
       const search = debouncedMemberSearch.toLowerCase();
@@ -216,7 +213,7 @@ export function FeeChargeList({
           <h3 className="text-lg font-semibold">Keine Forderungen gefunden</h3>
           <p className="text-sm text-muted-foreground mt-2">Deine Filter ergaben keine Treffer.</p>
           <Button variant="outline" className="mt-4" onClick={resetFilters}>
-            Filter zuruecksetzen
+            Filter zurücksetzen
           </Button>
         </div>
       </div>
@@ -313,7 +310,7 @@ export function FeeChargeList({
             disabled={page <= 1}
           >
             <ChevronLeft className="h-4 w-4" />
-            Zurueck
+            Zurück
           </Button>
           <span className="text-sm text-muted-foreground tabular-nums">Seite {page}</span>
           <Button

--- a/apps/web/components/fees/fee-charge-list.tsx
+++ b/apps/web/components/fees/fee-charge-list.tsx
@@ -186,7 +186,7 @@ export function FeeChargeList({
         <CreditCard className="h-12 w-12 text-muted-foreground mb-4" />
         <h3 className="text-lg font-semibold">Noch keine Forderungen</h3>
         <p className="text-sm text-muted-foreground mt-2 max-w-md">
-          Fuehre eine Beitragserhebung durch, um Forderungen fuer deine Mitglieder zu erstellen.
+          Führe eine Beitragserhebung durch, um Forderungen für deine Mitglieder zu erstellen.
         </p>
         {onSwitchToErhebung && (
           <Button className="mt-4" onClick={onSwitchToErhebung}>
@@ -377,7 +377,7 @@ function FilterBar({
             <SelectItem value="OPEN">Offen</SelectItem>
             <SelectItem value="PARTIAL">Teilweise bezahlt</SelectItem>
             <SelectItem value="PAID">Bezahlt</SelectItem>
-            <SelectItem value="OVERDUE">Ueberfaellig</SelectItem>
+            <SelectItem value="OVERDUE">Überfällig</SelectItem>
           </SelectContent>
         </Select>
       </div>

--- a/apps/web/components/fees/fee-charge-list.tsx
+++ b/apps/web/components/fees/fee-charge-list.tsx
@@ -48,14 +48,7 @@ type StatusFilter = 'ALL' | 'OPEN' | 'PARTIAL' | 'PAID' | 'OVERDUE';
 // Helpers
 // ============================================================================
 
-const moneyFormatter = new Intl.NumberFormat('de-DE', {
-  minimumFractionDigits: 2,
-  maximumFractionDigits: 2,
-});
-
-function formatMoney(value: string): string {
-  return `${moneyFormatter.format(parseFloat(value))} EUR`;
-}
+import { moneyFormatter, formatMoney } from '@/lib/format-money';
 
 function formatPeriod(start: string, end: string): string {
   const startDate = new Date(start);

--- a/apps/web/components/fees/fee-charge-status-badge.tsx
+++ b/apps/web/components/fees/fee-charge-status-badge.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+import type { FeeChargeStatus } from '@ktb/shared';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface FeeChargeStatusBadgeProps {
+  /** Charge payment status */
+  status: FeeChargeStatus;
+  /** Whether the charge is past due date and not fully paid */
+  isOverdue: boolean;
+  className?: string;
+}
+
+// ============================================================================
+// Status Configuration
+// ============================================================================
+
+const STATUS_CONFIG: Record<string, { label: string; className: string }> = {
+  OVERDUE: {
+    label: 'Ueberfaellig',
+    className: 'bg-destructive/15 text-destructive border-destructive/25',
+  },
+  OPEN: {
+    label: 'Offen',
+    className: 'bg-muted text-muted-foreground border-border',
+  },
+  PARTIAL: {
+    label: 'Teilweise bezahlt',
+    className: 'bg-warning/15 text-warning-foreground border-warning/25',
+  },
+  PAID: {
+    label: 'Bezahlt',
+    className: 'bg-success/15 text-success border-success/25',
+  },
+};
+
+// ============================================================================
+// Component
+// ============================================================================
+
+/**
+ * Badge displaying fee charge payment status with semantic colors.
+ *
+ * Status hierarchy:
+ * - OVERDUE takes precedence when isOverdue=true and status is OPEN or PARTIAL
+ * - PAID is always shown as PAID regardless of isOverdue
+ *
+ * Colors follow the UI-SPEC Fee Charge Status Colors table.
+ */
+export function FeeChargeStatusBadge({ status, isOverdue, className }: FeeChargeStatusBadgeProps) {
+  // Determine effective status: OVERDUE overrides OPEN/PARTIAL
+  const effectiveStatus = isOverdue && status !== 'PAID' ? 'OVERDUE' : status;
+
+  const config = STATUS_CONFIG[effectiveStatus] ?? STATUS_CONFIG.OPEN;
+
+  return (
+    <Badge variant="outline" className={cn(config.className, className)}>
+      {config.label}
+    </Badge>
+  );
+}

--- a/apps/web/components/fees/fee-charge-status-badge.tsx
+++ b/apps/web/components/fees/fee-charge-status-badge.tsx
@@ -22,7 +22,7 @@ interface FeeChargeStatusBadgeProps {
 
 const STATUS_CONFIG: Record<string, { label: string; className: string }> = {
   OVERDUE: {
-    label: 'Ueberfaellig',
+    label: 'Überfällig',
     className: 'bg-destructive/15 text-destructive border-destructive/25',
   },
   OPEN: {

--- a/apps/web/components/fees/fee-override-dialog.tsx
+++ b/apps/web/components/fees/fee-override-dialog.tsx
@@ -142,7 +142,7 @@ export function FeeOverrideDialog({
         <DialogContent className="max-w-lg max-h-[80vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle className="text-xl font-semibold">
-              Beitragsanpassungen fuer {memberName}
+              Beitragsanpassungen für {memberName}
             </DialogTitle>
             <DialogDescription>
               Befreiungen, individuelle Betraege und Zusatzbeitraege verwalten
@@ -302,7 +302,7 @@ export function FeeOverrideDialog({
           <AlertDialogHeader>
             <AlertDialogTitle>Anpassung entfernen</AlertDialogTitle>
             <AlertDialogDescription>
-              Moechtest du diese Beitragsanpassung wirklich entfernen?
+              Möchtest du diese Beitragsanpassung wirklich entfernen?
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/apps/web/components/fees/fee-override-dialog.tsx
+++ b/apps/web/components/fees/fee-override-dialog.tsx
@@ -145,7 +145,7 @@ export function FeeOverrideDialog({
               Beitragsanpassungen für {memberName}
             </DialogTitle>
             <DialogDescription>
-              Befreiungen, individuelle Betraege und Zusatzbeitraege verwalten
+              Befreiungen, individuelle Beträge und Zusatzbeiträge verwalten
             </DialogDescription>
           </DialogHeader>
 
@@ -262,7 +262,7 @@ export function FeeOverrideDialog({
                   <Label htmlFor="overrideReason">Grund</Label>
                   <Textarea
                     id="overrideReason"
-                    placeholder="z.B. Ehrenamtliche Taetigkeit"
+                    placeholder="z.B. Ehrenamtliche Tätigkeit"
                     value={formReason}
                     onChange={(e) => setFormReason(e.target.value)}
                     rows={2}
@@ -289,7 +289,7 @@ export function FeeOverrideDialog({
             {!showAddForm && !isLoading && (
               <Button variant="outline" size="sm" onClick={() => setShowAddForm(true)}>
                 <Plus className="h-4 w-4" />
-                Anpassung hinzufuegen
+                Anpassung hinzufügen
               </Button>
             )}
           </div>

--- a/apps/web/components/fees/fee-override-dialog.tsx
+++ b/apps/web/components/fees/fee-override-dialog.tsx
@@ -1,0 +1,337 @@
+'use client';
+
+import { useState } from 'react';
+import { Loader2, Plus, Trash2 } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  useFeeOverrides,
+  useCreateFeeOverride,
+  useDeleteFeeOverride,
+} from '@/hooks/use-fee-overrides';
+import { useFeeCategories } from '@/hooks/use-fee-categories';
+import type { FeeOverrideType, FeeOverrideResponse } from '@/hooks/use-fee-overrides';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface FeeOverrideDialogProps {
+  slug: string;
+  memberId: string;
+  memberName: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const moneyFormatter = new Intl.NumberFormat('de-DE', {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+const OVERRIDE_TYPE_OPTIONS: { value: FeeOverrideType; label: string }[] = [
+  { value: 'EXEMPT', label: 'Befreit' },
+  { value: 'CUSTOM_AMOUNT', label: 'Individueller Betrag' },
+  { value: 'ADDITIONAL', label: 'Zusatzbeitrag' },
+];
+
+const OVERRIDE_TYPE_LABELS: Record<string, string> = {
+  EXEMPT: 'Befreit',
+  CUSTOM_AMOUNT: 'Individueller Betrag',
+  ADDITIONAL: 'Zusatzbeitrag',
+};
+
+// ============================================================================
+// Component
+// ============================================================================
+
+/**
+ * Dialog for managing a member's fee overrides.
+ *
+ * Separates "modify existing fee" (EXEMPT, CUSTOM_AMOUNT on base fee or category)
+ * from "add new fee" (ADDITIONAL with category selection).
+ *
+ * Per CONV-010: Delete uses AlertDialog, not browser confirm().
+ */
+export function FeeOverrideDialog({
+  slug,
+  memberId,
+  memberName,
+  open,
+  onOpenChange,
+}: FeeOverrideDialogProps) {
+  const { data: overrides, isLoading } = useFeeOverrides(slug, memberId);
+  const { data: categories } = useFeeCategories(slug);
+  const createOverride = useCreateFeeOverride(slug);
+  const deleteOverride = useDeleteFeeOverride(slug);
+
+  // Form state for adding new override
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [formType, setFormType] = useState<FeeOverrideType>('EXEMPT');
+  const [formTarget, setFormTarget] = useState<string>('base');
+  const [formAmount, setFormAmount] = useState('');
+  const [formReason, setFormReason] = useState('');
+
+  // Delete confirmation state
+  const [deleteTarget, setDeleteTarget] = useState<FeeOverrideResponse | null>(null);
+
+  function resetForm() {
+    setShowAddForm(false);
+    setFormType('EXEMPT');
+    setFormTarget('base');
+    setFormAmount('');
+    setFormReason('');
+  }
+
+  async function handleCreate() {
+    const isBaseFee = formTarget === 'base';
+    const feeCategoryId = isBaseFee ? undefined : formTarget;
+
+    await createOverride.mutateAsync({
+      memberId,
+      overrideType: formType,
+      isBaseFee,
+      feeCategoryId,
+      customAmount: formType === 'CUSTOM_AMOUNT' || formType === 'ADDITIONAL' ? formAmount : undefined,
+      reason: formReason || undefined,
+    });
+
+    resetForm();
+  }
+
+  async function handleDelete() {
+    if (!deleteTarget) return;
+    await deleteOverride.mutateAsync(deleteTarget.id);
+    setDeleteTarget(null);
+  }
+
+  const showAmountField = formType === 'CUSTOM_AMOUNT' || formType === 'ADDITIONAL';
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="max-w-lg max-h-[80vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle className="text-xl font-semibold">
+              Beitragsanpassungen fuer {memberName}
+            </DialogTitle>
+            <DialogDescription>
+              Befreiungen, individuelle Betraege und Zusatzbeitraege verwalten
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4">
+            {/* Loading */}
+            {isLoading && (
+              <div className="flex items-center justify-center py-6">
+                <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+              </div>
+            )}
+
+            {/* Existing overrides list */}
+            {!isLoading && overrides && overrides.length === 0 && !showAddForm && (
+              <p className="text-sm text-muted-foreground">Keine Anpassungen vorhanden</p>
+            )}
+
+            {!isLoading && overrides && overrides.length > 0 && (
+              <div className="space-y-3">
+                {overrides.map((override) => (
+                  <div
+                    key={override.id}
+                    className="flex items-start justify-between gap-3 rounded-md border p-3"
+                  >
+                    <div className="space-y-1 min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <Badge variant="outline">
+                          {OVERRIDE_TYPE_LABELS[override.overrideType] ?? override.overrideType}
+                        </Badge>
+                        <span className="text-sm text-muted-foreground">
+                          {override.isBaseFee
+                            ? 'Grundbeitrag'
+                            : override.feeCategory?.name ?? 'Kategorie'}
+                        </span>
+                      </div>
+                      {override.customAmount && (
+                        <p className="text-sm tabular-nums">
+                          {moneyFormatter.format(parseFloat(override.customAmount))} EUR
+                        </p>
+                      )}
+                      {override.reason && (
+                        <p className="text-sm text-muted-foreground">{override.reason}</p>
+                      )}
+                    </div>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="shrink-0 h-8 w-8 text-destructive hover:text-destructive"
+                      onClick={() => setDeleteTarget(override)}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                      <span className="sr-only">Entfernen</span>
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {/* Add form */}
+            {showAddForm && (
+              <div className="space-y-4 rounded-md border p-4">
+                {/* Override type */}
+                <div className="space-y-2">
+                  <Label htmlFor="overrideType">Art der Anpassung</Label>
+                  <Select
+                    value={formType}
+                    onValueChange={(v) => setFormType(v as FeeOverrideType)}
+                  >
+                    <SelectTrigger id="overrideType" className="w-full">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {OVERRIDE_TYPE_OPTIONS.map((opt) => (
+                        <SelectItem key={opt.value} value={opt.value}>
+                          {opt.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                {/* Target */}
+                <div className="space-y-2">
+                  <Label htmlFor="overrideTarget">Betrifft</Label>
+                  <Select value={formTarget} onValueChange={setFormTarget}>
+                    <SelectTrigger id="overrideTarget" className="w-full">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="base">Grundbeitrag</SelectItem>
+                      {categories?.map((cat) => (
+                        <SelectItem key={cat.id} value={cat.id}>
+                          {cat.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                {/* Custom amount */}
+                {showAmountField && (
+                  <div className="space-y-2">
+                    <Label htmlFor="overrideAmount">Betrag (EUR)</Label>
+                    <Input
+                      id="overrideAmount"
+                      type="number"
+                      step="0.01"
+                      min="0"
+                      placeholder="0.00"
+                      value={formAmount}
+                      onChange={(e) => setFormAmount(e.target.value)}
+                    />
+                  </div>
+                )}
+
+                {/* Reason */}
+                <div className="space-y-2">
+                  <Label htmlFor="overrideReason">Grund</Label>
+                  <Textarea
+                    id="overrideReason"
+                    placeholder="z.B. Ehrenamtliche Taetigkeit"
+                    value={formReason}
+                    onChange={(e) => setFormReason(e.target.value)}
+                    rows={2}
+                  />
+                </div>
+
+                {/* Form actions */}
+                <div className="flex gap-2">
+                  <Button
+                    onClick={handleCreate}
+                    disabled={
+                      createOverride.isPending ||
+                      (showAmountField && !formAmount)
+                    }
+                  >
+                    {createOverride.isPending && (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    )}
+                    Speichern
+                  </Button>
+                  <Button variant="outline" onClick={resetForm}>
+                    Abbrechen
+                  </Button>
+                </div>
+              </div>
+            )}
+
+            {/* Add button */}
+            {!showAddForm && !isLoading && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setShowAddForm(true)}
+              >
+                <Plus className="h-4 w-4" />
+                Anpassung hinzufuegen
+              </Button>
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete confirmation - per CONV-010 */}
+      <AlertDialog open={!!deleteTarget} onOpenChange={(open) => !open && setDeleteTarget(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Anpassung entfernen</AlertDialogTitle>
+            <AlertDialogDescription>
+              Moechtest du diese Beitragsanpassung wirklich entfernen?
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Abbrechen</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              disabled={deleteOverride.isPending}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {deleteOverride.isPending && <Loader2 className="h-4 w-4 animate-spin" />}
+              Entfernen
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/apps/web/components/fees/fee-override-dialog.tsx
+++ b/apps/web/components/fees/fee-override-dialog.tsx
@@ -55,10 +55,7 @@ interface FeeOverrideDialogProps {
 // Helpers
 // ============================================================================
 
-const moneyFormatter = new Intl.NumberFormat('de-DE', {
-  minimumFractionDigits: 2,
-  maximumFractionDigits: 2,
-});
+import { moneyFormatter } from '@/lib/format-money';
 
 const OVERRIDE_TYPE_OPTIONS: { value: FeeOverrideType; label: string }[] = [
   { value: 'EXEMPT', label: 'Befreit' },

--- a/apps/web/components/fees/fee-override-dialog.tsx
+++ b/apps/web/components/fees/fee-override-dialog.tsx
@@ -123,7 +123,8 @@ export function FeeOverrideDialog({
       overrideType: formType,
       isBaseFee,
       feeCategoryId,
-      customAmount: formType === 'CUSTOM_AMOUNT' || formType === 'ADDITIONAL' ? formAmount : undefined,
+      customAmount:
+        formType === 'CUSTOM_AMOUNT' || formType === 'ADDITIONAL' ? formAmount : undefined,
       reason: formReason || undefined,
     });
 
@@ -179,7 +180,7 @@ export function FeeOverrideDialog({
                         <span className="text-sm text-muted-foreground">
                           {override.isBaseFee
                             ? 'Grundbeitrag'
-                            : override.feeCategory?.name ?? 'Kategorie'}
+                            : (override.feeCategory?.name ?? 'Kategorie')}
                         </span>
                       </div>
                       {override.customAmount && (
@@ -211,10 +212,7 @@ export function FeeOverrideDialog({
                 {/* Override type */}
                 <div className="space-y-2">
                   <Label htmlFor="overrideType">Art der Anpassung</Label>
-                  <Select
-                    value={formType}
-                    onValueChange={(v) => setFormType(v as FeeOverrideType)}
-                  >
+                  <Select value={formType} onValueChange={(v) => setFormType(v as FeeOverrideType)}>
                     <SelectTrigger id="overrideType" className="w-full">
                       <SelectValue />
                     </SelectTrigger>
@@ -278,14 +276,9 @@ export function FeeOverrideDialog({
                 <div className="flex gap-2">
                   <Button
                     onClick={handleCreate}
-                    disabled={
-                      createOverride.isPending ||
-                      (showAmountField && !formAmount)
-                    }
+                    disabled={createOverride.isPending || (showAmountField && !formAmount)}
                   >
-                    {createOverride.isPending && (
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                    )}
+                    {createOverride.isPending && <Loader2 className="h-4 w-4 animate-spin" />}
                     Speichern
                   </Button>
                   <Button variant="outline" onClick={resetForm}>
@@ -297,11 +290,7 @@ export function FeeOverrideDialog({
 
             {/* Add button */}
             {!showAddForm && !isLoading && (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => setShowAddForm(true)}
-              >
+              <Button variant="outline" size="sm" onClick={() => setShowAddForm(true)}>
                 <Plus className="h-4 w-4" />
                 Anpassung hinzufuegen
               </Button>

--- a/apps/web/components/fees/member-fee-badge.tsx
+++ b/apps/web/components/fees/member-fee-badge.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useMemo } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { useMemberFeeCharges } from '@/hooks/use-fee-charges';
+import { cn } from '@/lib/utils';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface MemberFeeBadgeProps {
+  slug: string;
+  memberId: string;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const moneyFormatter = new Intl.NumberFormat('de-DE', {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+// ============================================================================
+// Component
+// ============================================================================
+
+/**
+ * Compact fee status badge for the member detail header.
+ *
+ * Display logic per UI-SPEC IC-05:
+ * - No open/overdue charges: hidden (return null)
+ * - Open charges (not overdue): muted badge with count and total
+ * - Any overdue charge: destructive badge with count and total
+ *
+ * Badge hidden during loading (no skeleton for inline badge per UI-SPEC).
+ * Click scrolls to #member-fee-section and opens the collapsible.
+ */
+export function MemberFeeBadge({ slug, memberId }: MemberFeeBadgeProps) {
+  const { data: charges, isLoading } = useMemberFeeCharges(slug, memberId);
+
+  const badgeInfo = useMemo(() => {
+    if (!charges?.length) return null;
+
+    const openCharges = charges.filter((c) => c.status !== 'PAID');
+    if (openCharges.length === 0) return null;
+
+    const hasOverdue = openCharges.some((c) => c.isOverdue);
+    const totalAmount = openCharges.reduce((sum, c) => sum + parseFloat(c.remainingAmount), 0);
+
+    return {
+      count: openCharges.length,
+      amount: moneyFormatter.format(totalAmount),
+      hasOverdue,
+    };
+  }, [charges]);
+
+  if (isLoading || !badgeInfo) return null;
+
+  const handleClick = () => {
+    const section = document.getElementById('member-fee-section');
+    if (section) {
+      section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      // Dispatch a custom event to open the collapsible
+      section.dispatchEvent(new CustomEvent('expand-fee-section'));
+    }
+  };
+
+  return (
+    <Badge
+      variant="outline"
+      className={cn(
+        'cursor-pointer transition-colors',
+        badgeInfo.hasOverdue
+          ? 'bg-destructive/15 text-destructive border-destructive/25'
+          : 'bg-muted text-muted-foreground border-border'
+      )}
+      onClick={handleClick}
+    >
+      {badgeInfo.count} offen, {badgeInfo.amount} EUR
+    </Badge>
+  );
+}

--- a/apps/web/components/fees/member-fee-badge.tsx
+++ b/apps/web/components/fees/member-fee-badge.tsx
@@ -18,10 +18,7 @@ interface MemberFeeBadgeProps {
 // Helpers
 // ============================================================================
 
-const moneyFormatter = new Intl.NumberFormat('de-DE', {
-  minimumFractionDigits: 2,
-  maximumFractionDigits: 2,
-});
+import { moneyFormatter } from '@/lib/format-money';
 
 // ============================================================================
 // Component

--- a/apps/web/components/fees/member-fee-section.tsx
+++ b/apps/web/components/fees/member-fee-section.tsx
@@ -6,11 +6,7 @@ import { ChevronRight, ChevronsUpDown, Settings2 } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from '@/components/ui/collapsible';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { FeeChargeStatusBadge } from '@/components/fees/fee-charge-status-badge';
 import { FeeOverrideDialog } from '@/components/fees/fee-override-dialog';
 import { useMemberFeeCharges } from '@/hooks/use-fee-charges';
@@ -132,10 +128,7 @@ export function MemberFeeSection({ slug, memberId, memberName }: MemberFeeSectio
             {!chargesLoading && displayCharges.length > 0 && (
               <div className="space-y-2">
                 {displayCharges.map((charge) => (
-                  <div
-                    key={charge.id}
-                    className="flex items-center justify-between gap-2 text-sm"
-                  >
+                  <div key={charge.id} className="flex items-center justify-between gap-2 text-sm">
                     <span className="truncate min-w-0">{charge.description}</span>
                     <div className="flex items-center gap-2 shrink-0">
                       <span className="tabular-nums text-right">
@@ -150,9 +143,7 @@ export function MemberFeeSection({ slug, memberId, memberName }: MemberFeeSectio
                 ))}
 
                 {remainingCount > 0 && (
-                  <p className="text-sm text-muted-foreground">
-                    und {remainingCount} weitere...
-                  </p>
+                  <p className="text-sm text-muted-foreground">und {remainingCount} weitere...</p>
                 )}
               </div>
             )}
@@ -181,11 +172,7 @@ export function MemberFeeSection({ slug, memberId, memberName }: MemberFeeSectio
                 <ChevronRight className="h-3 w-3" />
               </Link>
 
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={() => setOverrideDialogOpen(true)}
-              >
+              <Button variant="secondary" size="sm" onClick={() => setOverrideDialogOpen(true)}>
                 <Settings2 className="h-3.5 w-3.5" />
                 Anpassungen verwalten
               </Button>

--- a/apps/web/components/fees/member-fee-section.tsx
+++ b/apps/web/components/fees/member-fee-section.tsx
@@ -1,0 +1,207 @@
+'use client';
+
+import { useMemo, useState, useEffect, useRef, useCallback } from 'react';
+import Link from 'next/link';
+import { ChevronRight, ChevronsUpDown, Settings2 } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
+import { FeeChargeStatusBadge } from '@/components/fees/fee-charge-status-badge';
+import { FeeOverrideDialog } from '@/components/fees/fee-override-dialog';
+import { useMemberFeeCharges } from '@/hooks/use-fee-charges';
+import { useFeeOverrides } from '@/hooks/use-fee-overrides';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface MemberFeeSectionProps {
+  slug: string;
+  memberId: string;
+  memberName: string;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const moneyFormatter = new Intl.NumberFormat('de-DE', {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+function formatDate(isoDate: string): string {
+  const [year, month, day] = isoDate.split('-');
+  if (!year || !month || !day) return isoDate;
+  return `${day}.${month}.${year}`;
+}
+
+const OVERRIDE_TYPE_LABELS: Record<string, string> = {
+  EXEMPT: 'Befreit',
+  CUSTOM_AMOUNT: 'Individuell',
+  ADDITIONAL: 'Zusatz',
+};
+
+// ============================================================================
+// Component
+// ============================================================================
+
+/**
+ * Collapsible section showing recent open charges for a member.
+ *
+ * Per UI-SPEC Member Detail Integration layout:
+ * - Shows up to 3 most recent open/overdue charges sorted by dueDate ASC
+ * - Link to pre-filtered fees page
+ * - Override management access via dialog
+ * - Loading: skeleton with 3 row placeholders
+ * - Empty: "Keine offenen Forderungen"
+ */
+export function MemberFeeSection({ slug, memberId, memberName }: MemberFeeSectionProps) {
+  const [isOpen, setIsOpen] = useState(true);
+  const [overrideDialogOpen, setOverrideDialogOpen] = useState(false);
+  const sectionRef = useRef<HTMLDivElement>(null);
+
+  const { data: charges, isLoading: chargesLoading } = useMemberFeeCharges(slug, memberId);
+  const { data: overrides } = useFeeOverrides(slug, memberId);
+
+  // Listen for expand event from the badge click
+  const handleExpand = useCallback(() => {
+    setIsOpen(true);
+  }, []);
+
+  useEffect(() => {
+    const el = sectionRef.current;
+    if (!el) return;
+    el.addEventListener('expand-fee-section', handleExpand);
+    return () => el.removeEventListener('expand-fee-section', handleExpand);
+  }, [handleExpand]);
+
+  // Filter and sort open/overdue charges: oldest overdue first
+  const openCharges = useMemo(() => {
+    if (!charges?.length) return [];
+    return charges
+      .filter((c) => c.status !== 'PAID')
+      .sort((a, b) => {
+        // Overdue first, then by dueDate ASC (oldest first)
+        if (a.isOverdue && !b.isOverdue) return -1;
+        if (!a.isOverdue && b.isOverdue) return 1;
+        return a.dueDate.localeCompare(b.dueDate);
+      });
+  }, [charges]);
+
+  const displayCharges = openCharges.slice(0, 3);
+  const remainingCount = openCharges.length - displayCharges.length;
+
+  const overrideCount = overrides?.length ?? 0;
+
+  return (
+    <div id="member-fee-section" ref={sectionRef} className="rounded-md border bg-muted/50">
+      <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+        <CollapsibleTrigger asChild>
+          <button
+            type="button"
+            className="flex w-full items-center justify-between px-4 py-3 text-left hover:bg-muted/80 transition-colors rounded-t-md"
+          >
+            <span className="text-sm font-semibold">Offene Beitraege</span>
+            <ChevronsUpDown className="h-4 w-4 text-muted-foreground" />
+          </button>
+        </CollapsibleTrigger>
+
+        <CollapsibleContent>
+          <div className="px-4 pb-4 space-y-3">
+            {/* Loading state */}
+            {chargesLoading && (
+              <div className="space-y-2">
+                <Skeleton className="h-8 w-full" />
+                <Skeleton className="h-8 w-full" />
+                <Skeleton className="h-8 w-full" />
+              </div>
+            )}
+
+            {/* Empty state */}
+            {!chargesLoading && openCharges.length === 0 && (
+              <p className="text-sm text-muted-foreground">Keine offenen Forderungen</p>
+            )}
+
+            {/* Charge rows */}
+            {!chargesLoading && displayCharges.length > 0 && (
+              <div className="space-y-2">
+                {displayCharges.map((charge) => (
+                  <div
+                    key={charge.id}
+                    className="flex items-center justify-between gap-2 text-sm"
+                  >
+                    <span className="truncate min-w-0">{charge.description}</span>
+                    <div className="flex items-center gap-2 shrink-0">
+                      <span className="tabular-nums text-right">
+                        {moneyFormatter.format(parseFloat(charge.remainingAmount))} EUR
+                      </span>
+                      <FeeChargeStatusBadge status={charge.status} isOverdue={charge.isOverdue} />
+                      <span className="text-xs text-muted-foreground tabular-nums">
+                        {formatDate(charge.dueDate)}
+                      </span>
+                    </div>
+                  </div>
+                ))}
+
+                {remainingCount > 0 && (
+                  <p className="text-sm text-muted-foreground">
+                    und {remainingCount} weitere...
+                  </p>
+                )}
+              </div>
+            )}
+
+            {/* Override summary */}
+            {overrideCount > 0 && (
+              <div className="flex items-center gap-2 flex-wrap">
+                <span className="text-sm text-muted-foreground">
+                  {overrideCount} Anpassung{overrideCount !== 1 ? 'en' : ''}
+                </span>
+                {overrides?.map((o) => (
+                  <Badge key={o.id} variant="outline" className="text-xs">
+                    {OVERRIDE_TYPE_LABELS[o.overrideType] ?? o.overrideType}
+                  </Badge>
+                ))}
+              </div>
+            )}
+
+            {/* Actions */}
+            <div className="flex items-center gap-3 pt-1">
+              <Link
+                href={`/clubs/${slug}/fees?tab=forderungen&memberId=${memberId}`}
+                className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
+              >
+                Beitragshistorie anzeigen
+                <ChevronRight className="h-3 w-3" />
+              </Link>
+
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => setOverrideDialogOpen(true)}
+              >
+                <Settings2 className="h-3.5 w-3.5" />
+                Anpassungen verwalten
+              </Button>
+            </div>
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
+
+      {/* Override dialog */}
+      <FeeOverrideDialog
+        slug={slug}
+        memberId={memberId}
+        memberName={memberName}
+        open={overrideDialogOpen}
+        onOpenChange={setOverrideDialogOpen}
+      />
+    </div>
+  );
+}

--- a/apps/web/components/fees/member-fee-section.tsx
+++ b/apps/web/components/fees/member-fee-section.tsx
@@ -26,10 +26,7 @@ interface MemberFeeSectionProps {
 // Helpers
 // ============================================================================
 
-const moneyFormatter = new Intl.NumberFormat('de-DE', {
-  minimumFractionDigits: 2,
-  maximumFractionDigits: 2,
-});
+import { moneyFormatter } from '@/lib/format-money';
 
 function formatDate(isoDate: string): string {
   const [year, month, day] = isoDate.split('-');

--- a/apps/web/components/fees/member-fee-section.tsx
+++ b/apps/web/components/fees/member-fee-section.tsx
@@ -100,7 +100,7 @@ export function MemberFeeSection({ slug, memberId, memberName }: MemberFeeSectio
             type="button"
             className="flex w-full items-center justify-between px-4 py-3 text-left hover:bg-muted/80 transition-colors rounded-t-md"
           >
-            <span className="text-sm font-semibold">Offene Beitraege</span>
+            <span className="text-sm font-semibold">Offene Beiträge</span>
             <ChevronsUpDown className="h-4 w-4 text-muted-foreground" />
           </button>
         </CollapsibleTrigger>

--- a/apps/web/components/fees/payment-record-dialog.tsx
+++ b/apps/web/components/fees/payment-record-dialog.tsx
@@ -32,14 +32,7 @@ interface PaymentRecordDialogProps {
 // Helpers
 // ============================================================================
 
-const moneyFormatter = new Intl.NumberFormat('de-DE', {
-  minimumFractionDigits: 2,
-  maximumFractionDigits: 2,
-});
-
-function formatMoney(value: string): string {
-  return `${moneyFormatter.format(parseFloat(value))} EUR`;
-}
+import { formatMoney } from '@/lib/format-money';
 
 function getTodayISO(): string {
   return new Date().toISOString().split('T')[0];

--- a/apps/web/components/fees/payment-record-dialog.tsx
+++ b/apps/web/components/fees/payment-record-dialog.tsx
@@ -128,7 +128,7 @@ export function PaymentRecordDialog({
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Zahlung erfassen</DialogTitle>
-          <DialogDescription>Manuelle Zahlung fuer eine Forderung erfassen</DialogDescription>
+          <DialogDescription>Manuelle Zahlung für eine Forderung erfassen</DialogDescription>
         </DialogHeader>
 
         {/* Charge context (read-only) */}

--- a/apps/web/components/fees/payment-record-dialog.tsx
+++ b/apps/web/components/fees/payment-record-dialog.tsx
@@ -1,0 +1,230 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Loader2 } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { useRecordPayment } from '@/hooks/use-payments';
+import type { FeeChargeResponse } from '@ktb/shared';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface PaymentRecordDialogProps {
+  charge: FeeChargeResponse;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  slug: string;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const moneyFormatter = new Intl.NumberFormat('de-DE', {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+function formatMoney(value: string): string {
+  return `${moneyFormatter.format(parseFloat(value))} EUR`;
+}
+
+function getTodayISO(): string {
+  return new Date().toISOString().split('T')[0];
+}
+
+// Validation: amount must be > 0, max 10 digits before decimal, max 2 after
+function validateAmount(value: string): string | null {
+  if (!value) return 'Betrag ist erforderlich';
+  const num = parseFloat(value);
+  if (isNaN(num) || num <= 0) return 'Betrag muss groesser als 0 sein';
+  if (!/^\d{1,10}(\.\d{1,2})?$/.test(value)) {
+    return 'Betrag darf maximal 10 Vorkomma- und 2 Nachkommastellen haben';
+  }
+  return null;
+}
+
+function validateDate(value: string): string | null {
+  if (!value) return 'Zahlungsdatum ist erforderlich';
+  const date = new Date(value);
+  const today = new Date();
+  today.setHours(23, 59, 59, 999);
+  if (date > today) return 'Zahlungsdatum darf nicht in der Zukunft liegen';
+  return null;
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+/**
+ * Dialog for recording a manual payment against a fee charge.
+ * Shows charge context (member, amounts) and a form for amount, date, notes.
+ */
+export function PaymentRecordDialog({
+  charge,
+  open,
+  onOpenChange,
+  slug,
+}: PaymentRecordDialogProps) {
+  const [amount, setAmount] = useState('');
+  const [paidAt, setPaidAt] = useState('');
+  const [notes, setNotes] = useState('');
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  const recordPayment = useRecordPayment(slug);
+
+  // Reset form when dialog opens
+  useEffect(() => {
+    if (open) {
+      setAmount(charge.remainingAmount);
+      setPaidAt(getTodayISO());
+      setNotes('');
+      setErrors({});
+    }
+  }, [open, charge.remainingAmount]);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+
+    // Validate
+    const newErrors: Record<string, string> = {};
+    const amountError = validateAmount(amount);
+    if (amountError) newErrors.amount = amountError;
+    const dateError = validateDate(paidAt);
+    if (dateError) newErrors.paidAt = dateError;
+
+    if (Object.keys(newErrors).length > 0) {
+      setErrors(newErrors);
+      return;
+    }
+
+    setErrors({});
+
+    recordPayment.mutate(
+      {
+        feeChargeId: charge.id,
+        amount,
+        paidAt,
+        notes: notes || undefined,
+      },
+      {
+        onSuccess: () => {
+          onOpenChange(false);
+        },
+      }
+    );
+  }
+
+  const isPending = recordPayment.isPending;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Zahlung erfassen</DialogTitle>
+          <DialogDescription>Manuelle Zahlung fuer eine Forderung erfassen</DialogDescription>
+        </DialogHeader>
+
+        {/* Charge context (read-only) */}
+        <div className="rounded-md border bg-muted/50 p-4 space-y-1 text-sm">
+          <div>
+            <span className="text-muted-foreground">Mitglied: </span>
+            <span className="font-medium">
+              {charge.member.lastName}, {charge.member.firstName}
+            </span>
+          </div>
+          <div>
+            <span className="text-muted-foreground">Beschreibung: </span>
+            <span>{charge.description}</span>
+          </div>
+          <div className="flex flex-wrap gap-4">
+            <div>
+              <span className="text-muted-foreground">Betrag: </span>
+              <span className="font-medium tabular-nums">{formatMoney(charge.amount)}</span>
+            </div>
+            <div>
+              <span className="text-muted-foreground">Bezahlt: </span>
+              <span className="font-medium tabular-nums">{formatMoney(charge.paidAmount)}</span>
+            </div>
+            <div>
+              <span className="text-muted-foreground">Offen: </span>
+              <span className="font-medium tabular-nums">
+                {formatMoney(charge.remainingAmount)}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        {/* Payment form */}
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="paymentAmount">Betrag (EUR)</Label>
+            <Input
+              id="paymentAmount"
+              type="number"
+              step="0.01"
+              min="0.01"
+              value={amount}
+              onChange={(e) => setAmount(e.target.value)}
+              disabled={isPending}
+              className="tabular-nums"
+            />
+            {errors.amount && <p className="text-sm text-destructive">{errors.amount}</p>}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="paymentDate">Zahlungsdatum</Label>
+            <Input
+              id="paymentDate"
+              type="date"
+              value={paidAt}
+              onChange={(e) => setPaidAt(e.target.value)}
+              disabled={isPending}
+            />
+            {errors.paidAt && <p className="text-sm text-destructive">{errors.paidAt}</p>}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="paymentNotes">Notizen</Label>
+            <Textarea
+              id="paymentNotes"
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              disabled={isPending}
+              placeholder="Optional..."
+              rows={3}
+            />
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isPending}
+            >
+              Abbrechen
+            </Button>
+            <Button type="submit" disabled={isPending}>
+              {isPending && <Loader2 className="h-4 w-4 animate-spin" />}
+              Zahlung erfassen
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/components/fees/payment-record-dialog.tsx
+++ b/apps/web/components/fees/payment-record-dialog.tsx
@@ -42,7 +42,7 @@ function getTodayISO(): string {
 function validateAmount(value: string): string | null {
   if (!value) return 'Betrag ist erforderlich';
   const num = parseFloat(value);
-  if (isNaN(num) || num <= 0) return 'Betrag muss groesser als 0 sein';
+  if (isNaN(num) || num <= 0) return 'Betrag muss größer als 0 sein';
   if (!/^\d{1,10}(\.\d{1,2})?$/.test(value)) {
     return 'Betrag darf maximal 10 Vorkomma- und 2 Nachkommastellen haben';
   }

--- a/apps/web/components/layout/sidebar-nav-items.ts
+++ b/apps/web/components/layout/sidebar-nav-items.ts
@@ -94,7 +94,7 @@ export function getClubNavGroups(slug: string): NavGroup[] {
           title: 'Beiträge',
           url: `${base}/fees`,
           icon: CreditCard,
-          visibleTo: 'club-members',
+          visibleTo: 'finance',
         },
         {
           title: 'SEPA',

--- a/apps/web/components/layout/sidebar-nav-items.ts
+++ b/apps/web/components/layout/sidebar-nav-items.ts
@@ -94,7 +94,6 @@ export function getClubNavGroups(slug: string): NavGroup[] {
           title: 'Beiträge',
           url: `${base}/fees`,
           icon: CreditCard,
-          comingSoon: true,
           visibleTo: 'club-members',
         },
         {

--- a/apps/web/components/members/member-detail-header.tsx
+++ b/apps/web/components/members/member-detail-header.tsx
@@ -27,6 +27,7 @@ import { useMemberStatusHistory } from '@/hooks/use-members';
 import { MemberAvatar } from './member-avatar';
 import { MemberStatusBadge } from './member-status-badge';
 import { HouseholdBadge } from './household-badge';
+import { MemberFeeBadge } from '@/components/fees/member-fee-badge';
 import { useCanManageUsers } from '@/lib/club-permissions';
 import { buildTransitionActions, CANCELLATION_STATUSES } from './member-status-actions';
 import type { MemberDetail } from '@/hooks/use-member-detail';
@@ -177,6 +178,7 @@ export function MemberDetailHeader({
               </Badge>
             )}
             <span className="text-sm text-muted-foreground font-mono">{member.memberNumber}</span>
+            <MemberFeeBadge slug={slug} memberId={member.id} />
             {member.household && (
               <HouseholdBadge
                 name={member.household.name}

--- a/apps/web/components/members/member-detail-panel.tsx
+++ b/apps/web/components/members/member-detail-panel.tsx
@@ -23,6 +23,7 @@ import { useToast } from '@/hooks/use-toast';
 import { formatDate } from '@/lib/format-date';
 import { MemberDetailHeader } from './member-detail-header';
 import { MemberForm } from './member-form/member-form';
+import { MemberFeeSection } from '@/components/fees/member-fee-section';
 import { MemberDeleteDialog } from './member-delete-dialog';
 import { MemberAnonymizeDialog } from './member-anonymize-dialog';
 import { MemberLinkUserDialog } from './member-link-user-dialog';
@@ -191,6 +192,19 @@ function DetailContent({
           onLinkUser={() => setLinkUserDialogOpen(true)}
           onDelete={() => setDeleteDialogOpen(true)}
           onAnonymize={() => setAnonymizeDialogOpen(true)}
+        />
+      </div>
+
+      {/* Fee section — collapsible section with open charges and override management */}
+      <div className="px-4 pt-3">
+        <MemberFeeSection
+          slug={slug}
+          memberId={member.id}
+          memberName={
+            member.personType === 'LEGAL_ENTITY' && member.organizationName
+              ? member.organizationName
+              : `${member.firstName} ${member.lastName}`
+          }
         />
       </div>
 

--- a/apps/web/components/settings/club-settings-form.tsx
+++ b/apps/web/components/settings/club-settings-form.tsx
@@ -74,6 +74,12 @@ function clubToFormValues(club: ClubSettingsResponse): SettingsFormValues {
     defaultMembershipTypeId:
       (club.defaultMembershipTypeId as SettingsFormValues['defaultMembershipTypeId']) ?? undefined,
     probationPeriodDays: club.probationPeriodDays ?? undefined,
+    // Beitragseinstellungen
+    proRataMode: (club.proRataMode as SettingsFormValues['proRataMode']) ?? undefined,
+    householdFeeMode:
+      (club.householdFeeMode as SettingsFormValues['householdFeeMode']) ?? undefined,
+    householdDiscountPercent: club.householdDiscountPercent ?? undefined,
+    householdFlatAmount: club.householdFlatAmount ?? undefined,
     // Sichtbarkeit
     visibility: club.visibility,
     // Logo & Avatar

--- a/apps/web/components/settings/sections/operational-section.tsx
+++ b/apps/web/components/settings/sections/operational-section.tsx
@@ -36,7 +36,8 @@ const MONTH_OPTIONS = [
 ] as const;
 
 /**
- * Betriebseinstellungen section: Geschäftsjahrbeginn, Standard-Mitgliedschaftstyp, Probezeitraum.
+ * Betriebseinstellungen section: Geschaeftsjahrbeginn, Standard-Mitgliedschaftstyp, Probezeitraum,
+ * and Beitragseinstellungen (proRataMode, householdFeeMode with conditional fields).
  */
 export function OperationalSection({ form, disabled }: OperationalSectionProps) {
   const params = useParams<{ slug: string }>();
@@ -45,93 +46,212 @@ export function OperationalSection({ form, disabled }: OperationalSectionProps) 
   const {
     register,
     control,
+    watch,
     formState: { errors },
   } = form;
 
+  const householdFeeMode = watch('householdFeeMode');
+
   return (
-    <Card id="section-defaults">
-      <CardHeader>
-        <CardTitle>Vereinsvorgaben</CardTitle>
-        <CardDescription>Standardwerte für Mitgliedschaften und Geschäftsjahr</CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        {/* Geschäftsjahrbeginn */}
-        <div className="space-y-1.5">
-          <Label htmlFor="settings-fiscalYearStartMonth">Geschäftsjahrbeginn</Label>
-          <Controller
-            name="fiscalYearStartMonth"
-            control={control}
-            render={({ field }) => (
-              <Select
-                value={field.value != null ? String(field.value) : undefined}
-                onValueChange={(val) => field.onChange(Number(val))}
-                disabled={disabled}
-              >
-                <SelectTrigger id="settings-fiscalYearStartMonth" className="w-full">
-                  <SelectValue placeholder="Monat wählen" />
-                </SelectTrigger>
-                <SelectContent>
-                  {MONTH_OPTIONS.map((month) => (
-                    <SelectItem key={month.value} value={month.value}>
-                      {month.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            )}
-          />
-        </div>
+    <>
+      <Card id="section-defaults">
+        <CardHeader>
+          <CardTitle>Vereinsvorgaben</CardTitle>
+          <CardDescription>Standardwerte fuer Mitgliedschaften und Geschaeftsjahr</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {/* Geschaeftsjahrbeginn */}
+          <div className="space-y-1.5">
+            <Label htmlFor="settings-fiscalYearStartMonth">Geschaeftsjahrbeginn</Label>
+            <Controller
+              name="fiscalYearStartMonth"
+              control={control}
+              render={({ field }) => (
+                <Select
+                  value={field.value != null ? String(field.value) : undefined}
+                  onValueChange={(val) => field.onChange(Number(val))}
+                  disabled={disabled}
+                >
+                  <SelectTrigger id="settings-fiscalYearStartMonth" className="w-full">
+                    <SelectValue placeholder="Monat waehlen" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {MONTH_OPTIONS.map((month) => (
+                      <SelectItem key={month.value} value={month.value}>
+                        {month.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            />
+          </div>
 
-        {/* Standard-Mitgliedschaftstyp */}
-        <div className="space-y-1.5">
-          <Label htmlFor="settings-defaultMembershipTypeId">Standard-Mitgliedschaftstyp</Label>
-          <Controller
-            name="defaultMembershipTypeId"
-            control={control}
-            render={({ field }) => (
-              <Select
-                value={field.value ?? undefined}
-                onValueChange={field.onChange}
-                disabled={disabled}
-              >
-                <SelectTrigger id="settings-defaultMembershipTypeId" className="w-full">
-                  <SelectValue placeholder="Typ wählen" />
-                </SelectTrigger>
-                <SelectContent>
-                  {(membershipTypes ?? []).map((type) => (
-                    <SelectItem key={type.id} value={type.id}>
-                      {type.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            )}
-          />
-        </div>
+          {/* Standard-Mitgliedschaftstyp */}
+          <div className="space-y-1.5">
+            <Label htmlFor="settings-defaultMembershipTypeId">Standard-Mitgliedschaftstyp</Label>
+            <Controller
+              name="defaultMembershipTypeId"
+              control={control}
+              render={({ field }) => (
+                <Select
+                  value={field.value ?? undefined}
+                  onValueChange={field.onChange}
+                  disabled={disabled}
+                >
+                  <SelectTrigger id="settings-defaultMembershipTypeId" className="w-full">
+                    <SelectValue placeholder="Typ waehlen" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {(membershipTypes ?? []).map((type) => (
+                      <SelectItem key={type.id} value={type.id}>
+                        {type.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            />
+          </div>
 
-        {/* Probezeitraum */}
-        <div className="space-y-1.5">
-          <Label htmlFor="settings-probationPeriodDays">Probezeitraum (Tage)</Label>
-          <Input
-            id="settings-probationPeriodDays"
-            type="number"
-            min={0}
-            max={365}
-            placeholder="0"
-            disabled={disabled}
-            {...register('probationPeriodDays', {
-              setValueAs: (v: string | number | undefined | null) => {
-                if (v === '' || v === undefined || v === null) return undefined;
-                const n = Number(v);
-                return Number.isNaN(n) ? undefined : n;
-              },
-            })}
-          />
-          {errors.probationPeriodDays?.message && (
-            <p className="text-xs text-destructive">{String(errors.probationPeriodDays.message)}</p>
+          {/* Probezeitraum */}
+          <div className="space-y-1.5">
+            <Label htmlFor="settings-probationPeriodDays">Probezeitraum (Tage)</Label>
+            <Input
+              id="settings-probationPeriodDays"
+              type="number"
+              min={0}
+              max={365}
+              placeholder="0"
+              disabled={disabled}
+              {...register('probationPeriodDays', {
+                setValueAs: (v: string | number | undefined | null) => {
+                  if (v === '' || v === undefined || v === null) return undefined;
+                  const n = Number(v);
+                  return Number.isNaN(n) ? undefined : n;
+                },
+              })}
+            />
+            {errors.probationPeriodDays?.message && (
+              <p className="text-xs text-destructive">
+                {String(errors.probationPeriodDays.message)}
+              </p>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card id="section-fees">
+        <CardHeader>
+          <CardTitle>Beitragseinstellungen</CardTitle>
+          <CardDescription>
+            Konfiguration fuer anteilige Berechnung und Haushaltsrabatte
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {/* Anteilige Berechnung (proRataMode) */}
+          <div className="space-y-1.5">
+            <Label htmlFor="settings-proRataMode">Anteilige Berechnung</Label>
+            <Controller
+              name="proRataMode"
+              control={control}
+              render={({ field }) => (
+                <Select
+                  value={field.value ?? undefined}
+                  onValueChange={field.onChange}
+                  disabled={disabled}
+                >
+                  <SelectTrigger id="settings-proRataMode" className="w-full">
+                    <SelectValue placeholder="Modus waehlen" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="FULL">Voller Beitrag</SelectItem>
+                    <SelectItem value="MONTHLY_PRO_RATA">Monatsanteilig</SelectItem>
+                  </SelectContent>
+                </Select>
+              )}
+            />
+            <p className="text-xs text-muted-foreground">
+              Bestimmt, ob bei unterjährigem Eintritt der volle Beitrag oder ein anteiliger Betrag
+              berechnet wird.
+            </p>
+          </div>
+
+          {/* Haushaltsbeitrag (householdFeeMode) */}
+          <div className="space-y-1.5">
+            <Label htmlFor="settings-householdFeeMode">Haushaltsbeitrag</Label>
+            <Controller
+              name="householdFeeMode"
+              control={control}
+              render={({ field }) => (
+                <Select
+                  value={field.value ?? undefined}
+                  onValueChange={field.onChange}
+                  disabled={disabled}
+                >
+                  <SelectTrigger id="settings-householdFeeMode" className="w-full">
+                    <SelectValue placeholder="Modus waehlen" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="NONE">Kein Rabatt</SelectItem>
+                    <SelectItem value="PERCENTAGE">Prozentual</SelectItem>
+                    <SelectItem value="FLAT">Pauschal</SelectItem>
+                  </SelectContent>
+                </Select>
+              )}
+            />
+            <p className="text-xs text-muted-foreground">
+              Rabatt fuer weitere Haushaltsmitglieder.
+            </p>
+          </div>
+
+          {/* Conditional: Rabatt (%) for PERCENTAGE mode */}
+          {householdFeeMode === 'PERCENTAGE' && (
+            <div className="space-y-1.5">
+              <Label htmlFor="settings-householdDiscountPercent">Rabatt (%)</Label>
+              <Input
+                id="settings-householdDiscountPercent"
+                type="number"
+                min={0}
+                max={100}
+                placeholder="z.B. 50"
+                disabled={disabled}
+                {...register('householdDiscountPercent', {
+                  setValueAs: (v: string | number | undefined | null) => {
+                    if (v === '' || v === undefined || v === null) return undefined;
+                    const n = Number(v);
+                    return Number.isNaN(n) ? undefined : n;
+                  },
+                })}
+              />
+              {errors.householdDiscountPercent?.message && (
+                <p className="text-xs text-destructive">
+                  {String(errors.householdDiscountPercent.message)}
+                </p>
+              )}
+            </div>
           )}
-        </div>
-      </CardContent>
-    </Card>
+
+          {/* Conditional: Pauschalbetrag (EUR) for FLAT mode */}
+          {householdFeeMode === 'FLAT' && (
+            <div className="space-y-1.5">
+              <Label htmlFor="settings-householdFlatAmount">Pauschalbetrag (EUR)</Label>
+              <Input
+                id="settings-householdFlatAmount"
+                placeholder="z.B. 50.00"
+                inputMode="decimal"
+                disabled={disabled}
+                {...register('householdFlatAmount')}
+              />
+              {errors.householdFlatAmount?.message && (
+                <p className="text-xs text-destructive">
+                  {String(errors.householdFlatAmount.message)}
+                </p>
+              )}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </>
   );
 }

--- a/apps/web/hooks/use-billing-run.ts
+++ b/apps/web/hooks/use-billing-run.ts
@@ -1,0 +1,100 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiFetch } from '@/lib/api';
+import { useToast } from '@/hooks/use-toast';
+import { feeChargeKeys } from '@/hooks/use-fee-charges';
+import type {
+  BillingRunPreview,
+  BillingRunPreviewResponse,
+  BillingRunConfirm,
+} from '@ktb/shared';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface BillingRunConfirmResponse {
+  chargesCreated: number;
+}
+
+// ============================================================================
+// Mutation Hooks
+// ============================================================================
+
+/**
+ * Preview a billing run (no side effects).
+ * Returns member counts, totals, exemptions, and breakdown.
+ */
+export function useBillingRunPreview(slug: string) {
+  const { toast } = useToast();
+
+  return useMutation<BillingRunPreviewResponse, Error, BillingRunPreview>({
+    mutationFn: async (data) => {
+      const res = await apiFetch(`/api/clubs/${slug}/fees/charges/billing-run/preview`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+
+      if (!res.ok) {
+        const error = await res.json().catch(() => ({}));
+        throw new Error(
+          error.message ||
+            'Die Beitragserhebung konnte nicht durchgefuehrt werden. Bitte versuche es erneut.'
+        );
+      }
+
+      return res.json();
+    },
+    onError: (error) => {
+      toast({
+        title:
+          'Die Beitragserhebung konnte nicht durchgefuehrt werden. Bitte versuche es erneut.',
+        variant: 'destructive',
+      });
+    },
+  });
+}
+
+/**
+ * Confirm a billing run (creates FeeCharge records).
+ * On success, invalidates fee charge queries and shows success toast.
+ */
+export function useBillingRunConfirm(slug: string) {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation<BillingRunConfirmResponse, Error, BillingRunConfirm>({
+    mutationFn: async (data) => {
+      const res = await apiFetch(`/api/clubs/${slug}/fees/charges/billing-run/confirm`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+
+      if (!res.ok) {
+        const error = await res.json().catch(() => ({}));
+        throw new Error(
+          error.message ||
+            'Die Beitragserhebung konnte nicht durchgefuehrt werden. Bitte versuche es erneut.'
+        );
+      }
+
+      return res.json();
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({
+        queryKey: feeChargeKeys.all(slug),
+      });
+      toast({
+        title: `Erhebung abgeschlossen -- ${data.chargesCreated} Forderungen erstellt`,
+      });
+    },
+    onError: () => {
+      toast({
+        title:
+          'Die Beitragserhebung konnte nicht durchgefuehrt werden. Bitte versuche es erneut.',
+        variant: 'destructive',
+      });
+    },
+  });
+}

--- a/apps/web/hooks/use-billing-run.ts
+++ b/apps/web/hooks/use-billing-run.ts
@@ -2,11 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiFetch } from '@/lib/api';
 import { useToast } from '@/hooks/use-toast';
 import { feeChargeKeys } from '@/hooks/use-fee-charges';
-import type {
-  BillingRunPreview,
-  BillingRunPreviewResponse,
-  BillingRunConfirm,
-} from '@ktb/shared';
+import type { BillingRunPreview, BillingRunPreviewResponse, BillingRunConfirm } from '@ktb/shared';
 
 // ============================================================================
 // Types
@@ -45,10 +41,9 @@ export function useBillingRunPreview(slug: string) {
 
       return res.json();
     },
-    onError: (error) => {
+    onError: () => {
       toast({
-        title:
-          'Die Beitragserhebung konnte nicht durchgefuehrt werden. Bitte versuche es erneut.',
+        title: 'Die Beitragserhebung konnte nicht durchgefuehrt werden. Bitte versuche es erneut.',
         variant: 'destructive',
       });
     },
@@ -91,8 +86,7 @@ export function useBillingRunConfirm(slug: string) {
     },
     onError: () => {
       toast({
-        title:
-          'Die Beitragserhebung konnte nicht durchgefuehrt werden. Bitte versuche es erneut.',
+        title: 'Die Beitragserhebung konnte nicht durchgefuehrt werden. Bitte versuche es erneut.',
         variant: 'destructive',
       });
     },

--- a/apps/web/hooks/use-club-settings.ts
+++ b/apps/web/hooks/use-club-settings.ts
@@ -44,6 +44,11 @@ export interface ClubSettingsResponse {
   fiscalYearStartMonth?: number | null;
   defaultMembershipTypeId?: string | null;
   probationPeriodDays?: number | null;
+  // Beitragseinstellungen
+  proRataMode?: string | null;
+  householdFeeMode?: string | null;
+  householdDiscountPercent?: number | null;
+  householdFlatAmount?: string | null;
   // Logo
   logoFileId?: string | null;
   // Meta

--- a/apps/web/hooks/use-fee-categories.ts
+++ b/apps/web/hooks/use-fee-categories.ts
@@ -1,0 +1,160 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiFetch } from '@/lib/api';
+import { useToast } from '@/hooks/use-toast';
+import type { FeeCategoryResponse, CreateFeeCategory, UpdateFeeCategory } from '@ktb/shared';
+
+// ============================================================================
+// Query Key Factory
+// ============================================================================
+
+export const feeCategoryKeys = {
+  all: (slug: string) => ['feeCategories', slug] as const,
+  list: (slug: string) => [...feeCategoryKeys.all(slug), 'list'] as const,
+};
+
+// ============================================================================
+// Query Hooks
+// ============================================================================
+
+/**
+ * Fetch all fee categories for a club.
+ */
+export function useFeeCategories(slug: string) {
+  return useQuery<FeeCategoryResponse[]>({
+    queryKey: feeCategoryKeys.list(slug),
+    queryFn: async () => {
+      const res = await apiFetch(`/api/clubs/${slug}/fees/categories`);
+      if (!res.ok) {
+        throw new Error('Fehler beim Laden der Beitragsdaten. Bitte versuche es erneut.');
+      }
+      return res.json();
+    },
+    staleTime: 60_000, // 1 minute
+    enabled: !!slug,
+  });
+}
+
+// ============================================================================
+// Mutation Hooks
+// ============================================================================
+
+/**
+ * Create a new fee category.
+ */
+export function useCreateFeeCategory(slug: string) {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async (data: CreateFeeCategory): Promise<FeeCategoryResponse> => {
+      const res = await apiFetch(`/api/clubs/${slug}/fees/categories`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      if (!res.ok) {
+        const error = await res.json().catch(() => ({}));
+        throw new Error(
+          error.message ||
+            'Beitragskategorie konnte nicht erstellt werden. Bitte pruefe deine Eingaben.'
+        );
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: feeCategoryKeys.list(slug),
+      });
+      toast({ title: 'Beitragskategorie erstellt' });
+    },
+    onError: (error) => {
+      toast({
+        title: 'Fehler',
+        description:
+          error instanceof Error
+            ? error.message
+            : 'Beitragskategorie konnte nicht erstellt werden. Bitte pruefe deine Eingaben.',
+        variant: 'destructive',
+      });
+    },
+  });
+}
+
+/**
+ * Update an existing fee category.
+ */
+export function useUpdateFeeCategory(slug: string) {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async ({
+      id,
+      data,
+    }: {
+      id: string;
+      data: UpdateFeeCategory;
+    }): Promise<FeeCategoryResponse> => {
+      const res = await apiFetch(`/api/clubs/${slug}/fees/categories/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      if (!res.ok) {
+        const error = await res.json().catch(() => ({}));
+        throw new Error(error.message || 'Fehler beim Aktualisieren der Beitragskategorie');
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: feeCategoryKeys.list(slug),
+      });
+      toast({ title: 'Beitragskategorie aktualisiert' });
+    },
+    onError: (error) => {
+      toast({
+        title: 'Fehler',
+        description:
+          error instanceof Error
+            ? error.message
+            : 'Fehler beim Aktualisieren der Beitragskategorie',
+        variant: 'destructive',
+      });
+    },
+  });
+}
+
+/**
+ * Delete a fee category (soft delete).
+ */
+export function useDeleteFeeCategory(slug: string) {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async (id: string): Promise<void> => {
+      const res = await apiFetch(`/api/clubs/${slug}/fees/categories/${id}`, {
+        method: 'DELETE',
+      });
+      if (!res.ok) {
+        const error = await res.json().catch(() => ({}));
+        throw new Error(error.message || 'Fehler beim Loeschen der Beitragskategorie');
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: feeCategoryKeys.list(slug),
+      });
+      toast({ title: 'Beitragskategorie geloescht' });
+    },
+    onError: (error) => {
+      toast({
+        title: 'Fehler',
+        description:
+          error instanceof Error ? error.message : 'Fehler beim Loeschen der Beitragskategorie',
+        variant: 'destructive',
+      });
+    },
+  });
+}

--- a/apps/web/hooks/use-fee-charges.ts
+++ b/apps/web/hooks/use-fee-charges.ts
@@ -90,7 +90,8 @@ export function useMemberFeeCharges(slug: string, memberId: string) {
         throw new Error('Fehler beim Laden der Beitragsdaten');
       }
 
-      return res.json();
+      const json = await res.json();
+      return json.data as FeeChargeResponse[];
     },
     staleTime: 30_000,
     enabled: !!slug && !!memberId,

--- a/apps/web/hooks/use-fee-charges.ts
+++ b/apps/web/hooks/use-fee-charges.ts
@@ -1,4 +1,4 @@
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { apiFetch } from '@/lib/api';
 import { useToast } from '@/hooks/use-toast';
 import type { FeeChargeResponse, FeeChargeQuery } from '@ktb/shared';

--- a/apps/web/hooks/use-fee-charges.ts
+++ b/apps/web/hooks/use-fee-charges.ts
@@ -1,0 +1,98 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { apiFetch } from '@/lib/api';
+import { useToast } from '@/hooks/use-toast';
+import type { FeeChargeResponse, FeeChargeQuery } from '@ktb/shared';
+
+// ============================================================================
+// Query Key Factory
+// ============================================================================
+
+export const feeChargeKeys = {
+  all: (slug: string) => ['feeCharges', slug] as const,
+  list: (slug: string, filters?: FeeChargeFilters) =>
+    [...feeChargeKeys.all(slug), 'list', filters] as const,
+  member: (slug: string, memberId: string) =>
+    [...feeChargeKeys.all(slug), 'member', memberId] as const,
+};
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type FeeChargeFilters = Omit<FeeChargeQuery, 'page' | 'limit'> & {
+  page?: number;
+  limit?: number;
+};
+
+export interface FeeChargeListResponse {
+  data: FeeChargeResponse[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+// ============================================================================
+// Query Hooks
+// ============================================================================
+
+/**
+ * Fetch fee charges for a club with optional filters.
+ */
+export function useFeeCharges(slug: string, filters?: FeeChargeFilters) {
+  const { toast } = useToast();
+
+  return useQuery<FeeChargeListResponse>({
+    queryKey: feeChargeKeys.list(slug, filters),
+    queryFn: async () => {
+      const params = new URLSearchParams();
+      if (filters?.status) params.set('status', filters.status);
+      if (filters?.memberId) params.set('memberId', filters.memberId);
+      if (filters?.periodStart) params.set('periodStart', filters.periodStart);
+      if (filters?.periodEnd) params.set('periodEnd', filters.periodEnd);
+      if (filters?.page) params.set('page', String(filters.page));
+      if (filters?.limit) params.set('limit', String(filters.limit));
+
+      const query = params.toString();
+      const url = `/api/clubs/${slug}/fees/charges${query ? `?${query}` : ''}`;
+      const res = await apiFetch(url);
+
+      if (!res.ok) {
+        toast({
+          title: 'Fehler beim Laden der Beitragsdaten. Bitte versuche es erneut.',
+          variant: 'destructive',
+        });
+        throw new Error('Fehler beim Laden der Beitragsdaten');
+      }
+
+      return res.json();
+    },
+    staleTime: 30_000,
+    enabled: !!slug,
+  });
+}
+
+/**
+ * Fetch fee charges for a specific member.
+ */
+export function useMemberFeeCharges(slug: string, memberId: string) {
+  const { toast } = useToast();
+
+  return useQuery<FeeChargeResponse[]>({
+    queryKey: feeChargeKeys.member(slug, memberId),
+    queryFn: async () => {
+      const res = await apiFetch(`/api/clubs/${slug}/fees/charges/member/${memberId}`);
+
+      if (!res.ok) {
+        toast({
+          title: 'Fehler beim Laden der Beitragsdaten. Bitte versuche es erneut.',
+          variant: 'destructive',
+        });
+        throw new Error('Fehler beim Laden der Beitragsdaten');
+      }
+
+      return res.json();
+    },
+    staleTime: 30_000,
+    enabled: !!slug && !!memberId,
+  });
+}

--- a/apps/web/hooks/use-fee-overrides.ts
+++ b/apps/web/hooks/use-fee-overrides.ts
@@ -1,0 +1,146 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiFetch } from '@/lib/api';
+import { useToast } from '@/hooks/use-toast';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type FeeOverrideType = 'EXEMPT' | 'CUSTOM_AMOUNT' | 'ADDITIONAL';
+
+export interface FeeOverrideResponse {
+  id: string;
+  memberId: string;
+  feeCategoryId: string | null;
+  overrideType: FeeOverrideType;
+  customAmount: string | null;
+  reason: string | null;
+  isBaseFee: boolean;
+  feeCategory: {
+    id: string;
+    name: string;
+    amount: string;
+  } | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateFeeOverrideInput {
+  memberId: string;
+  feeCategoryId?: string;
+  overrideType: FeeOverrideType;
+  customAmount?: string;
+  reason?: string;
+  isBaseFee?: boolean;
+}
+
+// ============================================================================
+// Query Key Factory
+// ============================================================================
+
+export const feeOverrideKeys = {
+  all: (slug: string) => ['feeOverrides', slug] as const,
+  member: (slug: string, memberId: string) =>
+    [...feeOverrideKeys.all(slug), 'member', memberId] as const,
+};
+
+// ============================================================================
+// Query Hooks
+// ============================================================================
+
+/**
+ * Fetch all fee overrides for a specific member.
+ */
+export function useFeeOverrides(slug: string, memberId: string) {
+  return useQuery<FeeOverrideResponse[]>({
+    queryKey: feeOverrideKeys.member(slug, memberId),
+    queryFn: async () => {
+      const res = await apiFetch(`/api/clubs/${slug}/fees/overrides/member/${memberId}`);
+      if (!res.ok) {
+        throw new Error('Fehler beim Laden der Beitragsanpassungen');
+      }
+      return res.json();
+    },
+    staleTime: 60_000,
+    enabled: !!slug && !!memberId,
+  });
+}
+
+// ============================================================================
+// Mutation Hooks
+// ============================================================================
+
+/**
+ * Create a new fee override for a member.
+ */
+export function useCreateFeeOverride(slug: string) {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async (data: CreateFeeOverrideInput): Promise<FeeOverrideResponse> => {
+      const res = await apiFetch(`/api/clubs/${slug}/fees/overrides`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      if (!res.ok) {
+        const error = await res.json().catch(() => ({}));
+        throw new Error(
+          error.message || 'Beitragsanpassung konnte nicht erstellt werden. Bitte pruefe deine Eingaben.'
+        );
+      }
+      return res.json();
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: feeOverrideKeys.member(slug, variables.memberId),
+      });
+      toast({ title: 'Beitragsanpassung gespeichert' });
+    },
+    onError: (error) => {
+      toast({
+        title: 'Fehler',
+        description:
+          error instanceof Error
+            ? error.message
+            : 'Beitragsanpassung konnte nicht erstellt werden. Bitte pruefe deine Eingaben.',
+        variant: 'destructive',
+      });
+    },
+  });
+}
+
+/**
+ * Delete a fee override.
+ */
+export function useDeleteFeeOverride(slug: string) {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async (id: string): Promise<void> => {
+      const res = await apiFetch(`/api/clubs/${slug}/fees/overrides/${id}`, {
+        method: 'DELETE',
+      });
+      if (!res.ok) {
+        const error = await res.json().catch(() => ({}));
+        throw new Error(error.message || 'Fehler beim Entfernen der Beitragsanpassung');
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: feeOverrideKeys.all(slug),
+      });
+      toast({ title: 'Beitragsanpassung entfernt' });
+    },
+    onError: (error) => {
+      toast({
+        title: 'Fehler',
+        description:
+          error instanceof Error ? error.message : 'Fehler beim Entfernen der Beitragsanpassung',
+        variant: 'destructive',
+      });
+    },
+  });
+}

--- a/apps/web/hooks/use-fee-overrides.ts
+++ b/apps/web/hooks/use-fee-overrides.ts
@@ -87,7 +87,8 @@ export function useCreateFeeOverride(slug: string) {
       if (!res.ok) {
         const error = await res.json().catch(() => ({}));
         throw new Error(
-          error.message || 'Beitragsanpassung konnte nicht erstellt werden. Bitte pruefe deine Eingaben.'
+          error.message ||
+            'Beitragsanpassung konnte nicht erstellt werden. Bitte pruefe deine Eingaben.'
         );
       }
       return res.json();

--- a/apps/web/hooks/use-payments.ts
+++ b/apps/web/hooks/use-payments.ts
@@ -1,0 +1,128 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiFetch } from '@/lib/api';
+import { useToast } from '@/hooks/use-toast';
+import { feeChargeKeys } from '@/hooks/use-fee-charges';
+import type { PaymentResponse, RecordPayment } from '@ktb/shared';
+
+// ============================================================================
+// Query Key Factory
+// ============================================================================
+
+export const paymentKeys = {
+  all: (slug: string) => ['payments', slug] as const,
+  forCharge: (slug: string, chargeId: string) =>
+    [...paymentKeys.all(slug), 'charge', chargeId] as const,
+};
+
+// ============================================================================
+// Query Hooks
+// ============================================================================
+
+/**
+ * Fetch payments for a specific fee charge.
+ */
+export function usePaymentsForCharge(slug: string, chargeId: string) {
+  return useQuery<PaymentResponse[]>({
+    queryKey: paymentKeys.forCharge(slug, chargeId),
+    queryFn: async () => {
+      const res = await apiFetch(`/api/clubs/${slug}/fees/payments/charge/${chargeId}`);
+
+      if (!res.ok) {
+        throw new Error('Fehler beim Laden der Zahlungsdaten');
+      }
+
+      return res.json();
+    },
+    staleTime: 30_000,
+    enabled: !!slug && !!chargeId,
+  });
+}
+
+// ============================================================================
+// Mutation Hooks
+// ============================================================================
+
+/**
+ * Record a manual payment against a fee charge.
+ * On success, invalidates both payment and fee charge queries.
+ */
+export function useRecordPayment(slug: string) {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation<PaymentResponse, Error, RecordPayment>({
+    mutationFn: async (data) => {
+      const res = await apiFetch(`/api/clubs/${slug}/fees/payments`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+
+      if (!res.ok) {
+        const error = await res.json().catch(() => ({}));
+        throw new Error(
+          error.message ||
+            'Zahlung konnte nicht erfasst werden. Bitte versuche es erneut.'
+        );
+      }
+
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: paymentKeys.all(slug),
+      });
+      queryClient.invalidateQueries({
+        queryKey: feeChargeKeys.all(slug),
+      });
+      toast({
+        title: 'Zahlung erfasst',
+      });
+    },
+    onError: () => {
+      toast({
+        title: 'Zahlung konnte nicht erfasst werden. Bitte versuche es erneut.',
+        variant: 'destructive',
+      });
+    },
+  });
+}
+
+/**
+ * Delete a payment (soft delete).
+ * On success, invalidates both payment and fee charge queries.
+ */
+export function useDeletePayment(slug: string) {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation<void, Error, string>({
+    mutationFn: async (paymentId) => {
+      const res = await apiFetch(`/api/clubs/${slug}/fees/payments/${paymentId}`, {
+        method: 'DELETE',
+      });
+
+      if (!res.ok) {
+        const error = await res.json().catch(() => ({}));
+        throw new Error(error.message || 'Zahlung konnte nicht geloescht werden');
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: paymentKeys.all(slug),
+      });
+      queryClient.invalidateQueries({
+        queryKey: feeChargeKeys.all(slug),
+      });
+      toast({
+        title: 'Zahlung geloescht',
+      });
+    },
+    onError: () => {
+      toast({
+        title: 'Zahlung konnte nicht geloescht werden. Bitte versuche es erneut.',
+        variant: 'destructive',
+      });
+    },
+  });
+}

--- a/apps/web/hooks/use-payments.ts
+++ b/apps/web/hooks/use-payments.ts
@@ -61,8 +61,7 @@ export function useRecordPayment(slug: string) {
       if (!res.ok) {
         const error = await res.json().catch(() => ({}));
         throw new Error(
-          error.message ||
-            'Zahlung konnte nicht erfasst werden. Bitte versuche es erneut.'
+          error.message || 'Zahlung konnte nicht erfasst werden. Bitte versuche es erneut.'
         );
       }
 

--- a/apps/web/lib/format-money.ts
+++ b/apps/web/lib/format-money.ts
@@ -1,0 +1,20 @@
+/**
+ * German locale money formatting utilities.
+ *
+ * moneyFormatter — Intl.NumberFormat instance for German locale (1.234,56)
+ * formatMoney    — Formats a decimal string as "1.234,56 EUR"
+ * formatMoneyValue — Formats a number as "1.234,56" (no currency suffix)
+ */
+
+export const moneyFormatter = new Intl.NumberFormat('de-DE', {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+export function formatMoney(value: string): string {
+  return `${moneyFormatter.format(parseFloat(value))} EUR`;
+}
+
+export function formatMoneyValue(value: number): string {
+  return moneyFormatter.format(value);
+}

--- a/packages/shared/src/schemas/billing-run.ts
+++ b/packages/shared/src/schemas/billing-run.ts
@@ -1,0 +1,63 @@
+import { z } from 'zod';
+
+import { BillingIntervalEnum } from './fee-category.ts';
+
+/**
+ * Schema for billing run preview request.
+ * Treasurer selects period and interval to see what would be generated.
+ */
+export const BillingRunPreviewSchema = z.object({
+  /** Start of the billing period (ISO date string) */
+  periodStart: z.string().date(),
+
+  /** End of the billing period (ISO date string) */
+  periodEnd: z.string().date(),
+
+  /** Billing interval to generate charges for */
+  billingInterval: BillingIntervalEnum,
+});
+
+export type BillingRunPreview = z.infer<typeof BillingRunPreviewSchema>;
+
+/**
+ * Response schema for billing run preview.
+ * Shows what would be generated without creating anything.
+ */
+export const BillingRunPreviewResponseSchema = z.object({
+  /** Number of members that would receive charges */
+  memberCount: z.number(),
+
+  /** Total amount of all charges (decimal string) */
+  totalAmount: z.string(),
+
+  /** Number of members exempt from this billing */
+  exemptions: z.number(),
+
+  /** Breakdown by membership type */
+  breakdown: z.array(
+    z.object({
+      /** Membership type name */
+      membershipType: z.string(),
+      /** Number of members in this type */
+      count: z.number(),
+      /** Subtotal for this type (decimal string) */
+      subtotal: z.string(),
+    })
+  ),
+
+  /** Number of existing charges for this period (duplicate warning) */
+  existingCharges: z.number(),
+});
+
+export type BillingRunPreviewResponse = z.infer<typeof BillingRunPreviewResponseSchema>;
+
+/**
+ * Schema for confirming a billing run (creates FeeCharge records).
+ * Same fields as preview plus due date.
+ */
+export const BillingRunConfirmSchema = BillingRunPreviewSchema.extend({
+  /** Due date for all generated charges (ISO date string) */
+  dueDate: z.string().date(),
+});
+
+export type BillingRunConfirm = z.infer<typeof BillingRunConfirmSchema>;

--- a/packages/shared/src/schemas/club-settings.ts
+++ b/packages/shared/src/schemas/club-settings.ts
@@ -27,6 +27,20 @@ export const ClubVisibilitySchema = z.enum(['PUBLIC', 'PRIVATE']);
 export type ClubVisibility = z.infer<typeof ClubVisibilitySchema>;
 
 /**
+ * Pro-rata mode for mid-period membership joins.
+ * Must match Prisma ProRataMode enum exactly.
+ */
+export const ProRataModeSchema = z.enum(['FULL', 'MONTHLY_PRO_RATA']);
+export type ProRataMode = z.infer<typeof ProRataModeSchema>;
+
+/**
+ * Household fee discount mode.
+ * Must match Prisma HouseholdFeeMode enum exactly.
+ */
+export const HouseholdFeeModeSchema = z.enum(['NONE', 'PERCENTAGE', 'FLAT']);
+export type HouseholdFeeMode = z.infer<typeof HouseholdFeeModeSchema>;
+
+/**
  * Schema for updating club settings (PATCH semantics).
  * All fields optional — only provided fields are updated.
  * Uses `.optional().nullable()` for clearable fields and `.optional()` for booleans/enums with defaults.
@@ -74,6 +88,12 @@ export const UpdateClubSettingsSchema = z.object({
     .union([z.nan().transform(() => null), z.number().int().min(0).max(365)])
     .optional()
     .nullable(),
+
+  // Beitragseinstellungen (Fee Settings)
+  proRataMode: ProRataModeSchema.optional(),
+  householdFeeMode: HouseholdFeeModeSchema.optional(),
+  householdDiscountPercent: z.number().int().min(0).max(100).optional().nullable(),
+  householdFlatAmount: z.string().optional().nullable(),
 
   // Sichtbarkeit
   visibility: ClubVisibilitySchema.optional(),

--- a/packages/shared/src/schemas/fee-category.ts
+++ b/packages/shared/src/schemas/fee-category.ts
@@ -1,0 +1,68 @@
+import { z } from 'zod';
+
+/**
+ * Available billing intervals for fee categories.
+ */
+export const BillingIntervalEnum = z.enum(['MONTHLY', 'QUARTERLY', 'ANNUALLY']);
+export type BillingInterval = z.infer<typeof BillingIntervalEnum>;
+
+/**
+ * Regex for validating decimal amounts (e.g., "12.50", "0.00", "1000.99").
+ */
+const DECIMAL_REGEX = /^\d+(\.\d{1,2})?$/;
+
+/**
+ * Schema for creating a new fee category (club-scoped entity).
+ * Additional fee categories beyond the base MembershipType fee.
+ */
+export const CreateFeeCategorySchema = z.object({
+  /** Category name (e.g., "Aufnahmegebuehr", "Tennisabteilung") */
+  name: z.string().min(1, 'Name ist erforderlich').max(100),
+
+  /** Optional description */
+  description: z.string().max(500).optional(),
+
+  /** Fee amount as decimal string (e.g., "120.00") */
+  amount: z.string().regex(DECIMAL_REGEX, 'Betrag muss ein gueltiges Dezimalformat haben'),
+
+  /** Billing frequency */
+  billingInterval: BillingIntervalEnum.default('ANNUALLY'),
+
+  /** Whether this is a one-time fee (e.g., enrollment fee) */
+  isOneTime: z.boolean().default(false),
+
+  /** Display order in lists */
+  sortOrder: z.number().int().min(0).default(0),
+});
+
+export type CreateFeeCategory = z.infer<typeof CreateFeeCategorySchema>;
+
+/**
+ * Schema for updating an existing fee category.
+ * All fields optional for partial updates.
+ */
+export const UpdateFeeCategorySchema = CreateFeeCategorySchema.partial().extend({
+  /** Whether this category is active */
+  isActive: z.boolean().optional(),
+});
+
+export type UpdateFeeCategory = z.infer<typeof UpdateFeeCategorySchema>;
+
+/**
+ * Full fee category response schema including server-generated fields.
+ */
+export const FeeCategoryResponseSchema = z.object({
+  id: z.string(),
+  clubId: z.string(),
+  name: z.string(),
+  description: z.string().nullable(),
+  amount: z.string(),
+  billingInterval: BillingIntervalEnum,
+  isActive: z.boolean(),
+  isOneTime: z.boolean(),
+  sortOrder: z.number(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export type FeeCategoryResponse = z.infer<typeof FeeCategoryResponseSchema>;

--- a/packages/shared/src/schemas/fee-charge.ts
+++ b/packages/shared/src/schemas/fee-charge.ts
@@ -6,6 +6,10 @@ import { z } from 'zod';
 export const FeeChargeStatusEnum = z.enum(['OPEN', 'PARTIAL', 'PAID']);
 export type FeeChargeStatus = z.infer<typeof FeeChargeStatusEnum>;
 
+/** Extended status enum for query filters — includes OVERDUE (a computed pseudo-status). */
+export const FeeChargeFilterStatusEnum = z.enum(['OPEN', 'PARTIAL', 'PAID', 'OVERDUE']);
+export type FeeChargeFilterStatus = z.infer<typeof FeeChargeFilterStatusEnum>;
+
 /**
  * Full fee charge response schema including derived payment status.
  * Amounts are serialized as strings for Decimal precision.
@@ -50,8 +54,8 @@ export type FeeChargeResponse = z.infer<typeof FeeChargeResponseSchema>;
  * Query parameters for filtering fee charges.
  */
 export const FeeChargeQuerySchema = z.object({
-  /** Filter by derived payment status */
-  status: FeeChargeStatusEnum.optional(),
+  /** Filter by derived payment status (includes OVERDUE pseudo-status) */
+  status: FeeChargeFilterStatusEnum.optional(),
   /** Filter by specific member */
   memberId: z.string().optional(),
   /** Filter by period start (inclusive) */

--- a/packages/shared/src/schemas/fee-charge.ts
+++ b/packages/shared/src/schemas/fee-charge.ts
@@ -1,0 +1,67 @@
+import { z } from 'zod';
+
+/**
+ * Derived status of a fee charge based on payment sum vs. charge amount.
+ */
+export const FeeChargeStatusEnum = z.enum(['OPEN', 'PARTIAL', 'PAID']);
+export type FeeChargeStatus = z.infer<typeof FeeChargeStatusEnum>;
+
+/**
+ * Full fee charge response schema including derived payment status.
+ * Amounts are serialized as strings for Decimal precision.
+ */
+export const FeeChargeResponseSchema = z.object({
+  id: z.string(),
+  clubId: z.string(),
+  memberId: z.string(),
+  feeCategoryId: z.string().nullable(),
+  membershipTypeId: z.string().nullable(),
+  description: z.string(),
+  periodStart: z.string(),
+  periodEnd: z.string(),
+  amount: z.string(),
+  dueDate: z.string(),
+  /** Amount of discount applied (null if no discount) */
+  discountAmount: z.string().nullable(),
+  /** Human-readable reason for the discount */
+  discountReason: z.string().nullable(),
+  /** Derived status: OPEN, PARTIAL, or PAID */
+  status: FeeChargeStatusEnum,
+  /** Sum of all payments against this charge */
+  paidAmount: z.string(),
+  /** Remaining amount to be paid */
+  remainingAmount: z.string(),
+  /** Whether the charge is past due date and not fully paid */
+  isOverdue: z.boolean(),
+  /** Member summary for list display */
+  member: z.object({
+    id: z.string(),
+    firstName: z.string(),
+    lastName: z.string(),
+    memberNumber: z.string(),
+  }),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export type FeeChargeResponse = z.infer<typeof FeeChargeResponseSchema>;
+
+/**
+ * Query parameters for filtering fee charges.
+ */
+export const FeeChargeQuerySchema = z.object({
+  /** Filter by derived payment status */
+  status: FeeChargeStatusEnum.optional(),
+  /** Filter by specific member */
+  memberId: z.string().optional(),
+  /** Filter by period start (inclusive) */
+  periodStart: z.string().date().optional(),
+  /** Filter by period end (inclusive) */
+  periodEnd: z.string().date().optional(),
+  /** Page number for pagination */
+  page: z.coerce.number().int().min(1).optional(),
+  /** Items per page */
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+});
+
+export type FeeChargeQuery = z.infer<typeof FeeChargeQuerySchema>;

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -12,3 +12,7 @@ export * from './club-settings.ts';
 export * from './file.ts';
 export * from './user-profile.ts';
 export * from './club-deletion.schema.ts';
+export * from './fee-category.ts';
+export * from './fee-charge.ts';
+export * from './payment.ts';
+export * from './billing-run.ts';

--- a/packages/shared/src/schemas/membership-type.ts
+++ b/packages/shared/src/schemas/membership-type.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { BillingIntervalEnum } from './fee-category.js';
 
 /**
  * Available badge colors for membership types.
@@ -57,6 +58,12 @@ export const CreateMembershipTypeSchema = z.object({
 
   /** Badge color for UI display */
   color: MemberTypeColorSchema.optional(),
+
+  /** Fee amount as decimal string (e.g., "120.00") — nullable, not all types have fees */
+  feeAmount: z.string().nullable().optional(),
+
+  /** Billing frequency for this membership type's base fee */
+  billingInterval: BillingIntervalEnum.optional(),
 });
 
 export type CreateMembershipType = z.infer<typeof CreateMembershipTypeSchema>;
@@ -85,6 +92,8 @@ export const MembershipTypeResponseSchema = z.object({
   assemblyAttendance: z.boolean(),
   eligibleForOffice: z.boolean(),
   color: MemberTypeColorSchema,
+  feeAmount: z.string().nullable().optional(),
+  billingInterval: BillingIntervalEnum.optional(),
   createdAt: z.string(),
   updatedAt: z.string(),
 });

--- a/packages/shared/src/schemas/membership-type.ts
+++ b/packages/shared/src/schemas/membership-type.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { BillingIntervalEnum } from './fee-category.js';
+import { BillingIntervalEnum } from './fee-category.ts';
 
 /**
  * Available badge colors for membership types.

--- a/packages/shared/src/schemas/payment.ts
+++ b/packages/shared/src/schemas/payment.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod';
+
+/**
+ * Source of a payment recording.
+ */
+export const PaymentSourceEnum = z.enum(['MANUAL', 'BANK_IMPORT', 'SEPA']);
+export type PaymentSource = z.infer<typeof PaymentSourceEnum>;
+
+/**
+ * Regex for validating decimal amounts (e.g., "12.50", "0.00", "1000.99").
+ */
+const DECIMAL_REGEX = /^\d+(\.\d{1,2})?$/;
+
+/**
+ * Schema for recording a new payment against a fee charge.
+ */
+export const RecordPaymentSchema = z.object({
+  /** The fee charge this payment is for */
+  feeChargeId: z.string(),
+
+  /** Payment amount as decimal string */
+  amount: z.string().regex(DECIMAL_REGEX, 'Betrag muss ein gueltiges Dezimalformat haben'),
+
+  /** Date the payment was made (ISO date string, e.g., "2026-01-15") */
+  paidAt: z.string().date(),
+
+  /** Optional notes about this payment */
+  notes: z.string().max(500).optional(),
+});
+
+export type RecordPayment = z.infer<typeof RecordPaymentSchema>;
+
+/**
+ * Full payment response schema including server-generated fields.
+ */
+export const PaymentResponseSchema = z.object({
+  id: z.string(),
+  feeChargeId: z.string(),
+  amount: z.string(),
+  paidAt: z.string(),
+  source: PaymentSourceEnum,
+  reference: z.string().nullable(),
+  notes: z.string().nullable(),
+  recordedBy: z.string(),
+  createdAt: z.string(),
+});
+
+export type PaymentResponse = z.infer<typeof PaymentResponseSchema>;

--- a/prisma/migrations/20260326155100_add_fee_management_models/migration.sql
+++ b/prisma/migrations/20260326155100_add_fee_management_models/migration.sql
@@ -1,0 +1,143 @@
+-- CreateEnum
+CREATE TYPE "BillingInterval" AS ENUM ('MONTHLY', 'QUARTERLY', 'ANNUALLY');
+
+-- CreateEnum
+CREATE TYPE "PaymentSource" AS ENUM ('MANUAL', 'BANK_IMPORT', 'SEPA');
+
+-- CreateEnum
+CREATE TYPE "FeeOverrideType" AS ENUM ('EXEMPT', 'CUSTOM_AMOUNT', 'ADDITIONAL');
+
+-- CreateEnum
+CREATE TYPE "ProRataMode" AS ENUM ('FULL', 'MONTHLY_PRO_RATA');
+
+-- CreateEnum
+CREATE TYPE "HouseholdFeeMode" AS ENUM ('NONE', 'PERCENTAGE', 'FLAT');
+
+-- AlterTable
+ALTER TABLE "clubs" ADD COLUMN     "householdDiscountPercent" INTEGER,
+ADD COLUMN     "householdFeeMode" "HouseholdFeeMode" NOT NULL DEFAULT 'NONE',
+ADD COLUMN     "householdFlatAmount" DECIMAL(10,2),
+ADD COLUMN     "proRataMode" "ProRataMode" NOT NULL DEFAULT 'FULL';
+
+-- AlterTable
+ALTER TABLE "membership_types" ADD COLUMN     "billingInterval" "BillingInterval" NOT NULL DEFAULT 'ANNUALLY',
+ADD COLUMN     "feeAmount" DECIMAL(10,2);
+
+-- CreateTable
+CREATE TABLE "fee_categories" (
+    "id" TEXT NOT NULL,
+    "clubId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "amount" DECIMAL(10,2) NOT NULL,
+    "billingInterval" "BillingInterval" NOT NULL DEFAULT 'ANNUALLY',
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "isOneTime" BOOLEAN NOT NULL DEFAULT false,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "deletedAt" TIMESTAMP(3),
+    "deletedBy" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "fee_categories_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "member_fee_overrides" (
+    "id" TEXT NOT NULL,
+    "memberId" TEXT NOT NULL,
+    "feeCategoryId" TEXT,
+    "overrideType" "FeeOverrideType" NOT NULL,
+    "customAmount" DECIMAL(10,2),
+    "reason" TEXT,
+    "isBaseFee" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "member_fee_overrides_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "fee_charges" (
+    "id" TEXT NOT NULL,
+    "clubId" TEXT NOT NULL,
+    "memberId" TEXT NOT NULL,
+    "feeCategoryId" TEXT,
+    "membershipTypeId" TEXT,
+    "description" TEXT NOT NULL,
+    "periodStart" DATE NOT NULL,
+    "periodEnd" DATE NOT NULL,
+    "amount" DECIMAL(10,2) NOT NULL,
+    "dueDate" DATE NOT NULL,
+    "discountAmount" DECIMAL(10,2),
+    "discountReason" TEXT,
+    "deletedAt" TIMESTAMP(3),
+    "deletedBy" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "fee_charges_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "payments" (
+    "id" TEXT NOT NULL,
+    "feeChargeId" TEXT NOT NULL,
+    "amount" DECIMAL(10,2) NOT NULL,
+    "paidAt" DATE NOT NULL,
+    "source" "PaymentSource" NOT NULL DEFAULT 'MANUAL',
+    "reference" TEXT,
+    "notes" TEXT,
+    "recordedBy" TEXT NOT NULL,
+    "deletedAt" TIMESTAMP(3),
+    "deletedBy" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "payments_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "fee_categories_clubId_idx" ON "fee_categories"("clubId");
+
+-- CreateIndex
+CREATE INDEX "member_fee_overrides_memberId_idx" ON "member_fee_overrides"("memberId");
+
+-- CreateIndex
+CREATE INDEX "fee_charges_clubId_idx" ON "fee_charges"("clubId");
+
+-- CreateIndex
+CREATE INDEX "fee_charges_memberId_idx" ON "fee_charges"("memberId");
+
+-- CreateIndex
+CREATE INDEX "fee_charges_clubId_dueDate_idx" ON "fee_charges"("clubId", "dueDate");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "fee_charges_billing_unique" ON "fee_charges"("memberId", "feeCategoryId", "membershipTypeId", "periodStart", "periodEnd");
+
+-- CreateIndex
+CREATE INDEX "payments_feeChargeId_idx" ON "payments"("feeChargeId");
+
+-- AddForeignKey
+ALTER TABLE "fee_categories" ADD CONSTRAINT "fee_categories_clubId_fkey" FOREIGN KEY ("clubId") REFERENCES "clubs"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "member_fee_overrides" ADD CONSTRAINT "member_fee_overrides_memberId_fkey" FOREIGN KEY ("memberId") REFERENCES "members"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "member_fee_overrides" ADD CONSTRAINT "member_fee_overrides_feeCategoryId_fkey" FOREIGN KEY ("feeCategoryId") REFERENCES "fee_categories"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "fee_charges" ADD CONSTRAINT "fee_charges_clubId_fkey" FOREIGN KEY ("clubId") REFERENCES "clubs"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "fee_charges" ADD CONSTRAINT "fee_charges_memberId_fkey" FOREIGN KEY ("memberId") REFERENCES "members"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "fee_charges" ADD CONSTRAINT "fee_charges_feeCategoryId_fkey" FOREIGN KEY ("feeCategoryId") REFERENCES "fee_categories"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "fee_charges" ADD CONSTRAINT "fee_charges_membershipTypeId_fkey" FOREIGN KEY ("membershipTypeId") REFERENCES "membership_types"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "payments" ADD CONSTRAINT "payments_feeChargeId_fkey" FOREIGN KEY ("feeChargeId") REFERENCES "fee_charges"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -97,6 +97,16 @@ model Club {
   /// Probezeit in Tagen / Probation period in days
   probationPeriodDays     Int?
 
+  // --- Beitragseinstellungen (Fee Settings) ---
+  /// Whether to pro-rate fees for mid-period joins
+  proRataMode          ProRataMode      @default(FULL)
+  /// Household discount mode
+  householdFeeMode     HouseholdFeeMode @default(NONE)
+  /// Percentage discount for additional household members (for PERCENTAGE mode)
+  householdDiscountPercent Int?
+  /// Flat household fee (for FLAT mode)
+  householdFlatAmount  Decimal?         @db.Decimal(10, 2)
+
   // --- Logo ---
   /// Referenz zur Logo-Datei / Reference to the logo file
   logoFileId String? @unique
@@ -135,6 +145,8 @@ model Club {
   membershipTypes    MembershipType[]
   statusTransitions  MemberStatusTransition[]
   auditLogs          AuditLog[]
+  feeCategories      FeeCategory[]
+  feeCharges         FeeCharge[]
 
   @@map("clubs")
 }
@@ -540,6 +552,12 @@ model MembershipType {
   /// Badge color for UI display (light/dark mode aware)
   color               MemberTypeColor @default(BLUE)
 
+  // --- Beitragseinstellungen (Fee Settings) ---
+  /// Base fee amount for this membership type (nullable to avoid breaking existing data)
+  feeAmount           Decimal?        @db.Decimal(10, 2)
+  /// Billing frequency for the base fee
+  billingInterval     BillingInterval @default(ANNUALLY)
+
   createdAt           DateTime        @default(now())
   updatedAt           DateTime        @updatedAt
 
@@ -547,6 +565,8 @@ model MembershipType {
   membershipPeriods   MembershipPeriod[]
   /// Clubs using this as default membership type
   clubDefaults        Club[]   @relation("ClubDefaultMembershipType")
+  /// Fee charges referencing this membership type
+  feeCharges          FeeCharge[]
 
   @@unique([clubId, code])
   @@index([clubId])
@@ -696,9 +716,13 @@ model Member {
 
   // Relations
   /// Membership periods (supports membership type changes with multiple consecutive periods)
-  membershipPeriods  MembershipPeriod[]
+  membershipPeriods    MembershipPeriod[]
   /// Status transition history
-  statusTransitions  MemberStatusTransition[]
+  statusTransitions    MemberStatusTransition[]
+  /// Per-member fee overrides (exemptions, custom amounts)
+  memberFeeOverrides   MemberFeeOverride[]
+  /// Fee charges (Forderungen) for this member
+  feeCharges           FeeCharge[]
 
   @@unique([clubId, memberNumber])
   @@index([clubId])
@@ -881,6 +905,225 @@ model LedgerAccount {
   @@unique([clubId, code])
   @@index([clubId])
   @@map("ledger_accounts")
+}
+
+// =============================================================================
+// Fee Management Models (Phase 12)
+// =============================================================================
+// Fee categories, member overrides, billing charges, and payments.
+// Supports hybrid model: MembershipType defines base fee,
+// FeeCategory handles additional charges.
+
+/// Billing frequency for fees
+enum BillingInterval {
+  /// Monthly billing (Monatlich)
+  MONTHLY
+  /// Quarterly billing (Quartalsweise)
+  QUARTERLY
+  /// Annual billing (Jaehrlich)
+  ANNUALLY
+}
+
+/// Source of a payment recording
+enum PaymentSource {
+  /// Manually recorded by treasurer
+  MANUAL
+  /// Matched from bank statement import (Phase 15)
+  BANK_IMPORT
+  /// Generated via SEPA direct debit (Phase 16)
+  SEPA
+}
+
+/// Type of per-member fee override
+enum FeeOverrideType {
+  /// Member is exempt from this fee (Befreiung)
+  EXEMPT
+  /// Custom amount replaces the standard fee (Individueller Betrag)
+  CUSTOM_AMOUNT
+  /// Additional fee on top of standard (Zusatzbeitrag)
+  ADDITIONAL
+}
+
+/// Pro-rata mode for mid-period membership joins
+enum ProRataMode {
+  /// Full fee regardless of join date
+  FULL
+  /// Monthly pro-rata calculation
+  MONTHLY_PRO_RATA
+}
+
+/// Household fee discount mode
+enum HouseholdFeeMode {
+  /// No household discount
+  NONE
+  /// Percentage discount for additional household members
+  PERCENTAGE
+  /// Flat household fee regardless of member count
+  FLAT
+}
+
+/// Additional fee category beyond base MembershipType fee.
+/// Examples: Aufnahmegebuehr, Abteilungsbeitrag, Sonderbeitrag.
+model FeeCategory {
+  /// Unique identifier (CUID format)
+  id              String          @id @default(cuid())
+  /// Reference to the parent club (tenant)
+  clubId          String
+  /// The club this fee category belongs to
+  club            Club            @relation(fields: [clubId], references: [id])
+
+  /// Category name (e.g., "Aufnahmegebuehr", "Tennisabteilung")
+  name            String
+  /// Optional description
+  description     String?
+  /// Fee amount
+  amount          Decimal         @db.Decimal(10, 2)
+  /// Billing frequency
+  billingInterval BillingInterval @default(ANNUALLY)
+  /// Whether this category is active and available for billing
+  isActive        Boolean         @default(true)
+  /// Whether this is a one-time fee (e.g., enrollment fee)
+  isOneTime       Boolean         @default(false)
+  /// Display order in lists
+  sortOrder       Int             @default(0)
+
+  /// Soft deletion timestamp (CONV-006)
+  deletedAt DateTime?
+  /// User ID who performed the soft deletion
+  deletedBy String?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  // Relations
+  memberFeeOverrides MemberFeeOverride[]
+  feeCharges         FeeCharge[]
+
+  @@index([clubId])
+  @@map("fee_categories")
+}
+
+/// Per-member fee adjustment (exemption, custom amount, additional fee).
+/// Overrides are replaced, not soft-deleted.
+model MemberFeeOverride {
+  /// Unique identifier (CUID format)
+  id            String          @id @default(cuid())
+  /// Reference to the member
+  memberId      String
+  /// The member this override applies to
+  member        Member          @relation(fields: [memberId], references: [id])
+  /// Reference to the fee category (null if overriding base fee)
+  feeCategoryId String?
+  /// The fee category being overridden (null = base membership fee)
+  feeCategory   FeeCategory?    @relation(fields: [feeCategoryId], references: [id])
+
+  /// Type of override
+  overrideType  FeeOverrideType
+  /// Custom amount (for CUSTOM_AMOUNT and ADDITIONAL types)
+  customAmount  Decimal?        @db.Decimal(10, 2)
+  /// Reason for the override
+  reason        String?
+  /// Whether this override applies to the base membership fee
+  isBaseFee     Boolean         @default(false)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([memberId])
+  @@map("member_fee_overrides")
+}
+
+/// A fee demand (Forderung) generated by a billing run.
+/// Represents what a member owes for a specific period.
+model FeeCharge {
+  /// Unique identifier (CUID format)
+  id               String       @id @default(cuid())
+  /// Reference to the parent club (tenant)
+  clubId           String
+  /// The club this charge belongs to
+  club             Club         @relation(fields: [clubId], references: [id])
+  /// Reference to the member
+  memberId         String
+  /// The member this charge is for
+  member           Member       @relation(fields: [memberId], references: [id])
+  /// Reference to the fee category (null for base membership fee)
+  feeCategoryId    String?
+  /// The fee category (null = base membership fee from MembershipType)
+  feeCategory      FeeCategory? @relation(fields: [feeCategoryId], references: [id])
+  /// Reference to the membership type (for base fee charges)
+  membershipTypeId String?
+  /// The membership type (for base fee charges)
+  membershipType   MembershipType? @relation(fields: [membershipTypeId], references: [id])
+
+  /// Human-readable description of the charge
+  description   String
+  /// Start of the billing period (date-only)
+  periodStart   DateTime    @db.Date
+  /// End of the billing period (date-only)
+  periodEnd     DateTime    @db.Date
+  /// Charged amount
+  amount        Decimal     @db.Decimal(10, 2)
+  /// Due date for payment (date-only)
+  dueDate       DateTime    @db.Date
+
+  // --- Discount traceability (review concern: override traceability) ---
+  /// Amount of discount applied (e.g., household discount, override reduction)
+  discountAmount Decimal?   @db.Decimal(10, 2)
+  /// Human-readable reason for the discount
+  discountReason String?
+
+  /// Soft deletion timestamp (CONV-006)
+  deletedAt DateTime?
+  /// User ID who performed the soft deletion
+  deletedBy String?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  // Relations
+  payments Payment[]
+
+  @@index([clubId])
+  @@index([memberId])
+  @@index([clubId, dueDate])
+  /// Prevents duplicate charges for same member + fee source + period
+  @@unique([memberId, feeCategoryId, membershipTypeId, periodStart, periodEnd], map: "fee_charges_billing_unique")
+  @@map("fee_charges")
+}
+
+/// Payment recorded against a fee charge.
+/// Status is derived: sum(payments.amount) vs FeeCharge.amount.
+model Payment {
+  /// Unique identifier (CUID format)
+  id          String        @id @default(cuid())
+  /// Reference to the fee charge
+  feeChargeId String
+  /// The fee charge this payment is for
+  feeCharge   FeeCharge     @relation(fields: [feeChargeId], references: [id])
+
+  /// Payment amount
+  amount      Decimal       @db.Decimal(10, 2)
+  /// Date the payment was made (date-only)
+  paidAt      DateTime      @db.Date
+  /// Source of the payment
+  source      PaymentSource @default(MANUAL)
+  /// Reference number (bank transaction ID, SEPA end-to-end ID)
+  reference   String?
+  /// Optional notes
+  notes       String?
+  /// User ID who recorded this payment
+  recordedBy  String
+
+  /// Soft deletion timestamp (CONV-006)
+  deletedAt DateTime?
+  /// User ID who performed the soft deletion
+  deletedBy String?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([feeChargeId])
+  @@map("payments")
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- **Data layer**: Prisma schema with 5 enums, 4 models (FeeCategory, FeeCharge, Payment, MemberFeeOverride), Zod validation schemas, and tenant isolation
- **Backend API**: Fee category CRUD, billing run engine (preview/confirm two-step flow), payment recording with automatic status derivation — 37 unit tests
- **Frontend**: Fees page with 3 tabs (categories, billing runs, charges), fee category CRUD UI, billing run panel, charge list with status badges, payment recording dialog, member fee integration (badge + section + override dialog)
- **Key features**: Pro-rata calculation, household discounts, HALF_UP rounding, overdue detection, member fee overrides (EXEMPT/CUSTOM_AMOUNT/ADDITIONAL)

Requirements: FEE-01, FEE-02, FEE-03, FEE-04, FEE-05, FEE-06

## Test plan

- [x] 580 API tests pass (37 new fee tests)
- [x] 1111 total tests pass (no regressions)
- [x] Fee categories CRUD works in UI
- [ ] Billing run preview shows correct amounts
- [ ] Billing run confirm creates fee charges
- [ ] Payment recording updates charge status
- [ ] Member detail shows fee badge and fee section
- [ ] Fee overrides (exempt/custom/additional) apply correctly
- [x] Sidebar navigation shows "Beiträge" link
- [x] Tab navigation persists in URL via nuqs