### PR TITLE
Phase 12.1: Neugestaltung Beitragsmodell (FeeType-Kreuztabelle + Haushaltsmodell)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,6 +4,7 @@ FROM mcr.microsoft.com/devcontainers/typescript-node:24
 RUN apt-get update && apt-get install -y \
     postgresql-client \
     redis-tools \
+    bubblewrap \
     && rm -rf /var/lib/apt/lists/*
 
 # Install pnpm

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -45,11 +45,10 @@
 
   "mounts": [
     "source=${localEnv:HOME}/.claude,target=/home/node/.claude,type=bind",
-    "source=${localEnv:HOME}/.claude.json,target=/home/node/.claude.json,type=bind",
     "source=clubmanager-local-${devcontainerId},target=/home/node/.local,type=volume"
   ],
 
   "forwardPorts": [33000, 33001, 35432, 36379, 35050, 35900, 35901, 38081, 39999],
 
-  "postCreateCommand": "sudo chown -R node:node /home/node/.local /home/node/.codex /home/node/.gemini 2>/dev/null || true; command -v pnpm >/dev/null || { SHELL=/bin/bash pnpm setup 2>/dev/null || true; export PNPM_HOME=\"$HOME/.local/share/pnpm\" && export PATH=\"$PNPM_HOME:$PATH\" && pnpm self-update 2>/dev/null || true; }; command -v claude >/dev/null || curl -fsSL https://claude.ai/install.sh | bash; command -v codex >/dev/null || npm install -g @openai/codex; command -v gemini >/dev/null || npm install -g @google/gemini-cli; if [ -f package.json ]; then pnpm install && (pnpm db:migrate >/dev/null 2>&1 || echo 'Note: db:migrate skipped - run manually if needed'); fi"
+  "postCreateCommand": "sudo chown -R node:node /home/node/.local /home/node/.codex /home/node/.gemini 2>/dev/null || true; [ -f /home/node/.claude/claude.json ] && ln -sf /home/node/.claude/claude.json /home/node/.claude.json; command -v pnpm >/dev/null || { SHELL=/bin/bash pnpm setup 2>/dev/null || true; export PNPM_HOME=\"$HOME/.local/share/pnpm\" && export PATH=\"$PNPM_HOME:$PATH\" && pnpm self-update 2>/dev/null || true; }; command -v claude >/dev/null || curl -fsSL https://claude.ai/install.sh | bash; command -v codex >/dev/null || npm install -g @openai/codex; command -v gemini >/dev/null || npm install -g @google/gemini-cli; if [ -f package.json ]; then pnpm install && (pnpm db:migrate >/dev/null 2>&1 || echo 'Note: db:migrate skipped - run manually if needed'); fi"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -51,5 +51,5 @@
 
   "forwardPorts": [33000, 33001, 35432, 36379, 35050, 35900, 35901, 38081, 39999],
 
-  "postCreateCommand": "sudo chown -R node:node /home/node/.local 2>/dev/null || true; command -v pnpm >/dev/null || { SHELL=/bin/bash pnpm setup 2>/dev/null || true; export PNPM_HOME=\"$HOME/.local/share/pnpm\" && export PATH=\"$PNPM_HOME:$PATH\" && pnpm self-update 2>/dev/null || true; }; command -v claude >/dev/null || curl -fsSL https://claude.ai/install.sh | bash; if [ -f package.json ]; then pnpm install && (pnpm db:migrate >/dev/null 2>&1 || echo 'Note: db:migrate skipped - run manually if needed'); fi"
+  "postCreateCommand": "sudo chown -R node:node /home/node/.local /home/node/.codex /home/node/.gemini 2>/dev/null || true; command -v pnpm >/dev/null || { SHELL=/bin/bash pnpm setup 2>/dev/null || true; export PNPM_HOME=\"$HOME/.local/share/pnpm\" && export PATH=\"$PNPM_HOME:$PATH\" && pnpm self-update 2>/dev/null || true; }; command -v claude >/dev/null || curl -fsSL https://claude.ai/install.sh | bash; command -v codex >/dev/null || npm install -g @openai/codex; command -v gemini >/dev/null || npm install -g @google/gemini-cli; if [ -f package.json ]; then pnpm install && (pnpm db:migrate >/dev/null 2>&1 || echo 'Note: db:migrate skipped - run manually if needed'); fi"
 }

--- a/.devcontainer/docker-compose.local.yml.example
+++ b/.devcontainer/docker-compose.local.yml.example
@@ -10,5 +10,9 @@ services:
       # Permissions: Issues (read/write)
       - GH_TOKEN=ghp_your_token_here
     volumes:
-      # Mount Claude config from host for persistent login
+      # Mount Claude config directory from host for persistent login.
+      # NOTE: ~/.claude.json lives INSIDE this directory (as claude.json) and is
+      # symlinked by postCreateCommand. Do NOT add a separate file bind mount for
+      # ~/.claude.json — file bind mounts break on atomic writes and cause corruption.
       - ~/.claude:/home/node/.claude:cached
+

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       - ..:/workspace:cached
       - node_modules:/workspace/node_modules
       - pnpm-store:/home/node/.local/share/pnpm
+      - gemini-config:/home/node/.gemini
+      - codex-config:/home/node/.codex
     environment:
       - NODE_ENV=development
       - DATABASE_URL=postgresql://clubmanager:clubmanager@postgres:5432/clubmanager
@@ -40,3 +42,5 @@ services:
 volumes:
   node_modules:
   pnpm-store:
+  gemini-config:
+  codex-config:

--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ temp/
 # SBOM / VEX (generated in CI)
 sbom.json
 vex.json
+
+# UAT prompts (ephemeral)
+.uat/

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -21,6 +21,7 @@ import { TierGuard } from './common/guards/tier.guard.js';
 import { PermissionGuard } from './common/guards/permission.guard.js';
 import { DeactivatedClubGuard } from './common/guards/deactivated-club.guard.js';
 import { ClubDeletionModule } from './club-deletion/club-deletion.module';
+import { FeesModule } from './fees/fees.module';
 
 @Module({
   imports: [
@@ -41,6 +42,7 @@ import { ClubDeletionModule } from './club-deletion/club-deletion.module';
     MembershipTypesModule,
     FilesModule,
     ClubDeletionModule,
+    FeesModule,
     HealthModule,
   ],
   providers: [

--- a/apps/api/src/clubs/access-requests/access-requests.service.ts
+++ b/apps/api/src/clubs/access-requests/access-requests.service.ts
@@ -225,7 +225,7 @@ export class AccessRequestsService {
 
     if (existingRequest) {
       if (existingRequest.status === 'PENDING') {
-        throw new BadRequestException('Du hast bereits eine Anfrage fuer diesen Verein gestellt');
+        throw new BadRequestException('Du hast bereits eine Anfrage für diesen Verein gestellt');
       }
 
       if (

--- a/apps/api/src/clubs/clubs.service.ts
+++ b/apps/api/src/clubs/clubs.service.ts
@@ -301,6 +301,9 @@ export class ClubsService {
         fiscalYearStartMonth: dto.fiscalYearStartMonth,
         defaultMembershipTypeId: dto.defaultMembershipTypeId,
         probationPeriodDays: dto.probationPeriodDays,
+        // Beitragseinstellungen
+        proRataMode: dto.proRataMode,
+        householdBillingModel: dto.householdBillingModel,
         // Logo
         logoFileId: dto.logoFileId,
       },
@@ -758,6 +761,9 @@ export class ClubsService {
       fiscalYearStartMonth: number | null;
       defaultMembershipTypeId: string | null;
       probationPeriodDays: number | null;
+      // Beitragseinstellungen
+      proRataMode: string | null;
+      householdBillingModel: string | null;
       // Logo
       logoFileId: string | null;
       // Deactivation
@@ -815,6 +821,9 @@ export class ClubsService {
       fiscalYearStartMonth: club.fiscalYearStartMonth ?? undefined,
       defaultMembershipTypeId: club.defaultMembershipTypeId ?? undefined,
       probationPeriodDays: club.probationPeriodDays ?? undefined,
+      // Beitragseinstellungen
+      proRataMode: club.proRataMode ?? undefined,
+      householdBillingModel: club.householdBillingModel ?? undefined,
       // Logo
       logoFileId: club.logoFileId ?? undefined,
       // Deactivation

--- a/apps/api/src/clubs/dto/create-club.dto.ts
+++ b/apps/api/src/clubs/dto/create-club.dto.ts
@@ -288,6 +288,24 @@ export class CreateClubDto {
   @Max(365)
   probationPeriodDays?: number;
 
+  // --- Beitragseinstellungen (Fee Settings) ---
+
+  @ApiPropertyOptional({
+    description: 'Pro-rata mode for mid-period membership joins',
+    enum: ['FULL', 'MONTHLY_PRO_RATA'],
+  })
+  @IsString()
+  @IsOptional()
+  proRataMode?: string;
+
+  @ApiPropertyOptional({
+    description: 'Household billing model (determines FeeType auto-suggestion)',
+    enum: ['NONE', 'REDUCED_MEMBERS', 'FAMILY_PAYER', 'ALL_REDUCED'],
+  })
+  @IsString()
+  @IsOptional()
+  householdBillingModel?: string;
+
   // --- Logo ---
 
   @ApiPropertyOptional({ description: 'Reference to uploaded logo file ID' })

--- a/apps/api/src/clubs/dto/create-club.dto.ts
+++ b/apps/api/src/clubs/dto/create-club.dto.ts
@@ -294,17 +294,22 @@ export class CreateClubDto {
     description: 'Pro-rata mode for mid-period membership joins',
     enum: ['FULL', 'MONTHLY_PRO_RATA'],
   })
-  @IsString()
+  @IsEnum({ FULL: 'FULL', MONTHLY_PRO_RATA: 'MONTHLY_PRO_RATA' })
   @IsOptional()
-  proRataMode?: string;
+  proRataMode?: 'FULL' | 'MONTHLY_PRO_RATA';
 
   @ApiPropertyOptional({
     description: 'Household billing model (determines FeeType auto-suggestion)',
     enum: ['NONE', 'REDUCED_MEMBERS', 'FAMILY_PAYER', 'ALL_REDUCED'],
   })
-  @IsString()
+  @IsEnum({
+    NONE: 'NONE',
+    REDUCED_MEMBERS: 'REDUCED_MEMBERS',
+    FAMILY_PAYER: 'FAMILY_PAYER',
+    ALL_REDUCED: 'ALL_REDUCED',
+  })
   @IsOptional()
-  householdBillingModel?: string;
+  householdBillingModel?: 'NONE' | 'REDUCED_MEMBERS' | 'FAMILY_PAYER' | 'ALL_REDUCED';
 
   // --- Logo ---
 

--- a/apps/api/src/common/filters/all-exceptions.filter.spec.ts
+++ b/apps/api/src/common/filters/all-exceptions.filter.spec.ts
@@ -51,11 +51,11 @@ describe('AllExceptionsFilter', () => {
   });
 
   it('passes through HttpException status and message', () => {
-    filter.catch(new BadRequestException('Ungueltige Daten'), mockHost as never);
+    filter.catch(new BadRequestException('Ungültige Daten'), mockHost as never);
 
     expect(mockReply).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ statusCode: 400, message: 'Ungueltige Daten' }),
+      expect.objectContaining({ statusCode: 400, message: 'Ungültige Daten' }),
       400
     );
   });
@@ -137,7 +137,7 @@ describe('AllExceptionsFilter', () => {
 
     expect(mockReply).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ statusCode: 400, message: 'Ungueltige Referenz' }),
+      expect.objectContaining({ statusCode: 400, message: 'Ungültige Referenz' }),
       400
     );
   });

--- a/apps/api/src/common/filters/all-exceptions.filter.ts
+++ b/apps/api/src/common/filters/all-exceptions.filter.ts
@@ -48,7 +48,7 @@ export class AllExceptionsFilter implements ExceptionFilter {
           break;
         case 'P2003':
           statusCode = 400;
-          message = 'Ungueltige Referenz';
+          message = 'Ungültige Referenz';
           break;
         default:
           statusCode = 400;

--- a/apps/api/src/fees/dto/billing-run-confirm.dto.ts
+++ b/apps/api/src/fees/dto/billing-run-confirm.dto.ts
@@ -7,27 +7,27 @@ export class BillingRunConfirmDto {
     description: 'Start of the billing period (ISO date string)',
     example: '2026-01-01',
   })
-  @IsDateString({}, { message: 'Periodenbeginn muss ein gueltiges Datum sein' })
+  @IsDateString({}, { message: 'Periodenbeginn muss ein gültiges Datum sein' })
   periodStart!: string;
 
   @ApiProperty({
     description: 'End of the billing period (ISO date string)',
     example: '2026-12-31',
   })
-  @IsDateString({}, { message: 'Periodenende muss ein gueltiges Datum sein' })
+  @IsDateString({}, { message: 'Periodenende muss ein gültiges Datum sein' })
   periodEnd!: string;
 
   @ApiProperty({
     description: 'Billing interval to generate charges for',
     enum: BillingInterval,
   })
-  @IsEnum(BillingInterval, { message: 'Ungueltiger Abrechnungszeitraum' })
+  @IsEnum(BillingInterval, { message: 'Ungültiger Abrechnungszeitraum' })
   billingInterval!: BillingInterval;
 
   @ApiProperty({
     description: 'Due date for all generated charges (ISO date string)',
     example: '2026-02-15',
   })
-  @IsDateString({}, { message: 'Faelligkeitsdatum muss ein gueltiges Datum sein' })
+  @IsDateString({}, { message: 'Fälligkeitsdatum muss ein gültiges Datum sein' })
   dueDate!: string;
 }

--- a/apps/api/src/fees/dto/billing-run-confirm.dto.ts
+++ b/apps/api/src/fees/dto/billing-run-confirm.dto.ts
@@ -1,0 +1,33 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsDateString, IsEnum } from 'class-validator';
+import { BillingInterval } from '../../../../../prisma/generated/client/index.js';
+
+export class BillingRunConfirmDto {
+  @ApiProperty({
+    description: 'Start of the billing period (ISO date string)',
+    example: '2026-01-01',
+  })
+  @IsDateString({}, { message: 'Periodenbeginn muss ein gueltiges Datum sein' })
+  periodStart!: string;
+
+  @ApiProperty({
+    description: 'End of the billing period (ISO date string)',
+    example: '2026-12-31',
+  })
+  @IsDateString({}, { message: 'Periodenende muss ein gueltiges Datum sein' })
+  periodEnd!: string;
+
+  @ApiProperty({
+    description: 'Billing interval to generate charges for',
+    enum: BillingInterval,
+  })
+  @IsEnum(BillingInterval, { message: 'Ungueltiger Abrechnungszeitraum' })
+  billingInterval!: BillingInterval;
+
+  @ApiProperty({
+    description: 'Due date for all generated charges (ISO date string)',
+    example: '2026-02-15',
+  })
+  @IsDateString({}, { message: 'Faelligkeitsdatum muss ein gueltiges Datum sein' })
+  dueDate!: string;
+}

--- a/apps/api/src/fees/dto/billing-run-preview.dto.ts
+++ b/apps/api/src/fees/dto/billing-run-preview.dto.ts
@@ -7,20 +7,20 @@ export class BillingRunPreviewDto {
     description: 'Start of the billing period (ISO date string)',
     example: '2026-01-01',
   })
-  @IsDateString({}, { message: 'Periodenbeginn muss ein gueltiges Datum sein' })
+  @IsDateString({}, { message: 'Periodenbeginn muss ein gültiges Datum sein' })
   periodStart!: string;
 
   @ApiProperty({
     description: 'End of the billing period (ISO date string)',
     example: '2026-12-31',
   })
-  @IsDateString({}, { message: 'Periodenende muss ein gueltiges Datum sein' })
+  @IsDateString({}, { message: 'Periodenende muss ein gültiges Datum sein' })
   periodEnd!: string;
 
   @ApiProperty({
     description: 'Billing interval to generate charges for',
     enum: BillingInterval,
   })
-  @IsEnum(BillingInterval, { message: 'Ungueltiger Abrechnungszeitraum' })
+  @IsEnum(BillingInterval, { message: 'Ungültiger Abrechnungszeitraum' })
   billingInterval!: BillingInterval;
 }

--- a/apps/api/src/fees/dto/billing-run-preview.dto.ts
+++ b/apps/api/src/fees/dto/billing-run-preview.dto.ts
@@ -1,0 +1,26 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsDateString, IsEnum } from 'class-validator';
+import { BillingInterval } from '../../../../../prisma/generated/client/index.js';
+
+export class BillingRunPreviewDto {
+  @ApiProperty({
+    description: 'Start of the billing period (ISO date string)',
+    example: '2026-01-01',
+  })
+  @IsDateString({}, { message: 'Periodenbeginn muss ein gueltiges Datum sein' })
+  periodStart!: string;
+
+  @ApiProperty({
+    description: 'End of the billing period (ISO date string)',
+    example: '2026-12-31',
+  })
+  @IsDateString({}, { message: 'Periodenende muss ein gueltiges Datum sein' })
+  periodEnd!: string;
+
+  @ApiProperty({
+    description: 'Billing interval to generate charges for',
+    enum: BillingInterval,
+  })
+  @IsEnum(BillingInterval, { message: 'Ungueltiger Abrechnungszeitraum' })
+  billingInterval!: BillingInterval;
+}

--- a/apps/api/src/fees/dto/create-fee-category.dto.ts
+++ b/apps/api/src/fees/dto/create-fee-category.dto.ts
@@ -1,0 +1,70 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsString,
+  IsOptional,
+  IsBoolean,
+  IsInt,
+  IsEnum,
+  Min,
+  MinLength,
+  MaxLength,
+  Matches,
+} from 'class-validator';
+import { BillingInterval } from '../../../../prisma/generated/client/index.js';
+
+export class CreateFeeCategoryDto {
+  @ApiProperty({
+    description: 'Category name (e.g., "Aufnahmegebuehr", "Tennisabteilung")',
+    example: 'Aufnahmegebuehr',
+  })
+  @IsString()
+  @MinLength(1, { message: 'Name darf nicht leer sein' })
+  @MaxLength(100, { message: 'Name darf maximal 100 Zeichen lang sein' })
+  name!: string;
+
+  @ApiPropertyOptional({
+    description: 'Optional description',
+    example: 'Einmalige Aufnahmegebuehr fuer neue Mitglieder',
+  })
+  @IsString()
+  @IsOptional()
+  @MaxLength(500, { message: 'Beschreibung darf maximal 500 Zeichen lang sein' })
+  description?: string;
+
+  @ApiProperty({
+    description: 'Fee amount as decimal string (e.g., "120.00")',
+    example: '120.00',
+  })
+  @IsString()
+  @Matches(/^\d+(\.\d{1,2})?$/, {
+    message: 'Betrag muss ein gueltiges Dezimalformat haben (z.B. "120.00")',
+  })
+  amount!: string;
+
+  @ApiPropertyOptional({
+    description: 'Billing frequency',
+    enum: BillingInterval,
+    default: 'ANNUALLY',
+  })
+  @IsEnum(BillingInterval, { message: 'Ungueltiger Abrechnungszeitraum' })
+  @IsOptional()
+  billingInterval?: BillingInterval;
+
+  @ApiPropertyOptional({
+    description: 'Whether this is a one-time fee (e.g., enrollment fee)',
+    default: false,
+  })
+  @IsBoolean()
+  @IsOptional()
+  isOneTime?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Display order in lists',
+    default: 0,
+    minimum: 0,
+  })
+  @IsInt()
+  @IsOptional()
+  @Min(0, { message: 'Sortierung muss mindestens 0 sein' })
+  sortOrder?: number;
+}

--- a/apps/api/src/fees/dto/create-fee-category.dto.ts
+++ b/apps/api/src/fees/dto/create-fee-category.dto.ts
@@ -36,8 +36,8 @@ export class CreateFeeCategoryDto {
     example: '120.00',
   })
   @IsString()
-  @Matches(/^\d+(\.\d{1,2})?$/, {
-    message: 'Betrag muss ein gueltiges Dezimalformat haben (z.B. "120.00")',
+  @Matches(/^\d{1,8}(\.\d{1,2})?$/, {
+    message: 'Betrag muss ein gueltiges Dezimalformat haben (z.B. "120.00", max 8 Vorkommastellen)',
   })
   amount!: string;
 

--- a/apps/api/src/fees/dto/create-fee-category.dto.ts
+++ b/apps/api/src/fees/dto/create-fee-category.dto.ts
@@ -37,7 +37,7 @@ export class CreateFeeCategoryDto {
   })
   @IsString()
   @Matches(/^\d{1,8}(\.\d{1,2})?$/, {
-    message: 'Betrag muss ein gueltiges Dezimalformat haben (z.B. "120.00", max 8 Vorkommastellen)',
+    message: 'Betrag muss ein gültiges Dezimalformat haben (z.B. „120.00", max 8 Vorkommastellen)',
   })
   amount!: string;
 
@@ -46,7 +46,7 @@ export class CreateFeeCategoryDto {
     enum: BillingInterval,
     default: 'ANNUALLY',
   })
-  @IsEnum(BillingInterval, { message: 'Ungueltiger Abrechnungszeitraum' })
+  @IsEnum(BillingInterval, { message: 'Ungültiger Abrechnungszeitraum' })
   @IsOptional()
   billingInterval?: BillingInterval;
 

--- a/apps/api/src/fees/dto/create-fee-category.dto.ts
+++ b/apps/api/src/fees/dto/create-fee-category.dto.ts
@@ -10,7 +10,7 @@ import {
   MaxLength,
   Matches,
 } from 'class-validator';
-import { BillingInterval } from '../../../../prisma/generated/client/index.js';
+import { BillingInterval } from '../../../../../prisma/generated/client/index.js';
 
 export class CreateFeeCategoryDto {
   @ApiProperty({

--- a/apps/api/src/fees/dto/create-fee-category.dto.ts
+++ b/apps/api/src/fees/dto/create-fee-category.dto.ts
@@ -5,17 +5,19 @@ import {
   IsBoolean,
   IsInt,
   IsEnum,
+  IsArray,
   Min,
   MinLength,
   MaxLength,
   Matches,
 } from 'class-validator';
-import { BillingInterval } from '../../../../../prisma/generated/client/index.js';
+import { Transform } from 'class-transformer';
+import { BillingInterval, FeeCategoryScope } from '../../../../../prisma/generated/client/index.js';
 
 export class CreateFeeCategoryDto {
   @ApiProperty({
-    description: 'Category name (e.g., "Aufnahmegebuehr", "Tennisabteilung")',
-    example: 'Aufnahmegebuehr',
+    description: 'Category name (e.g., "Aufnahmegebühr", "Tennisabteilung")',
+    example: 'Aufnahmegebühr',
   })
   @IsString()
   @MinLength(1, { message: 'Name darf nicht leer sein' })
@@ -24,7 +26,7 @@ export class CreateFeeCategoryDto {
 
   @ApiPropertyOptional({
     description: 'Optional description',
-    example: 'Einmalige Aufnahmegebuehr fuer neue Mitglieder',
+    example: 'Einmalige Aufnahmegebühr für neue Mitglieder',
   })
   @IsString()
   @IsOptional()
@@ -36,7 +38,8 @@ export class CreateFeeCategoryDto {
     example: '120.00',
   })
   @IsString()
-  @Matches(/^\d{1,8}(\.\d{1,2})?$/, {
+  @Transform(({ value }) => (typeof value === 'string' ? value.replace(',', '.') : value))
+  @Matches(/^\d{1,8}([.,]\d{1,2})?$/, {
     message: 'Betrag muss ein gültiges Dezimalformat haben (z.B. „120.00", max 8 Vorkommastellen)',
   })
   amount!: string;
@@ -67,4 +70,22 @@ export class CreateFeeCategoryDto {
   @IsOptional()
   @Min(0, { message: 'Sortierung muss mindestens 0 sein' })
   sortOrder?: number;
+
+  @ApiPropertyOptional({
+    description: 'Scope: which members this category applies to',
+    enum: FeeCategoryScope,
+    default: 'ALL_MEMBERS',
+  })
+  @IsEnum(FeeCategoryScope, { message: 'Ungültiger Geltungsbereich' })
+  @IsOptional()
+  scope?: FeeCategoryScope;
+
+  @ApiPropertyOptional({
+    description: 'Membership type IDs (for BY_MEMBERSHIP_TYPE scope)',
+    type: [String],
+  })
+  @IsArray()
+  @IsString({ each: true })
+  @IsOptional()
+  membershipTypeIds?: string[];
 }

--- a/apps/api/src/fees/dto/create-fee-type.dto.ts
+++ b/apps/api/src/fees/dto/create-fee-type.dto.ts
@@ -1,0 +1,30 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsString, IsOptional, IsBoolean, MinLength, MaxLength } from 'class-validator';
+
+export class CreateFeeTypeDto {
+  @ApiProperty({
+    description: 'Display name (e.g., "Einzelbeitrag", "Familientarif")',
+    example: 'Einzelbeitrag',
+  })
+  @IsString()
+  @MinLength(1, { message: 'Name ist erforderlich' })
+  @MaxLength(100, { message: 'Name darf maximal 100 Zeichen lang sein' })
+  name!: string;
+
+  @ApiPropertyOptional({
+    description: 'Optional description explaining when this fee type applies',
+    example: 'Standardbeitrag fuer Einzelmitglieder',
+  })
+  @IsString()
+  @IsOptional()
+  @MaxLength(500, { message: 'Beschreibung darf maximal 500 Zeichen lang sein' })
+  description?: string;
+
+  @ApiPropertyOptional({
+    description: 'Whether this fee type is currently available for selection',
+    default: true,
+  })
+  @IsBoolean()
+  @IsOptional()
+  isActive?: boolean;
+}

--- a/apps/api/src/fees/dto/create-member-fee-override.dto.ts
+++ b/apps/api/src/fees/dto/create-member-fee-override.dto.ts
@@ -1,0 +1,52 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsString, IsOptional, IsBoolean, IsEnum, Matches } from 'class-validator';
+import { FeeOverrideType } from '../../../../prisma/generated/client/index.js';
+
+export class CreateMemberFeeOverrideDto {
+  @ApiProperty({
+    description: 'Member ID to create override for',
+  })
+  @IsString()
+  memberId!: string;
+
+  @ApiPropertyOptional({
+    description: 'Fee category ID (null if overriding base membership fee)',
+  })
+  @IsString()
+  @IsOptional()
+  feeCategoryId?: string;
+
+  @ApiProperty({
+    description: 'Type of override (EXEMPT, CUSTOM_AMOUNT, ADDITIONAL)',
+    enum: FeeOverrideType,
+  })
+  @IsEnum(FeeOverrideType, { message: 'Ungueltiger Override-Typ' })
+  overrideType!: FeeOverrideType;
+
+  @ApiPropertyOptional({
+    description: 'Custom amount for CUSTOM_AMOUNT and ADDITIONAL types',
+    example: '50.00',
+  })
+  @IsString()
+  @IsOptional()
+  @Matches(/^\d+(\.\d{1,2})?$/, {
+    message: 'Betrag muss ein gueltiges Dezimalformat haben (z.B. "50.00")',
+  })
+  customAmount?: string;
+
+  @ApiPropertyOptional({
+    description: 'Reason for the override',
+    example: 'Soziale Haertefallregelung',
+  })
+  @IsString()
+  @IsOptional()
+  reason?: string;
+
+  @ApiPropertyOptional({
+    description: 'Whether this override applies to the base membership fee',
+    default: false,
+  })
+  @IsBoolean()
+  @IsOptional()
+  isBaseFee?: boolean;
+}

--- a/apps/api/src/fees/dto/create-member-fee-override.dto.ts
+++ b/apps/api/src/fees/dto/create-member-fee-override.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsString, IsOptional, IsBoolean, IsEnum, Matches } from 'class-validator';
-import { FeeOverrideType } from '../../../../prisma/generated/client/index.js';
+import { FeeOverrideType } from '../../../../../prisma/generated/client/index.js';
 
 export class CreateMemberFeeOverrideDto {
   @ApiProperty({

--- a/apps/api/src/fees/dto/create-member-fee-override.dto.ts
+++ b/apps/api/src/fees/dto/create-member-fee-override.dto.ts
@@ -29,8 +29,8 @@ export class CreateMemberFeeOverrideDto {
   })
   @IsString()
   @IsOptional()
-  @Matches(/^\d+(\.\d{1,2})?$/, {
-    message: 'Betrag muss ein gueltiges Dezimalformat haben (z.B. "50.00")',
+  @Matches(/^\d{1,8}(\.\d{1,2})?$/, {
+    message: 'Betrag muss ein gueltiges Dezimalformat haben (z.B. "50.00", max 8 Vorkommastellen)',
   })
   customAmount?: string;
 

--- a/apps/api/src/fees/dto/create-member-fee-override.dto.ts
+++ b/apps/api/src/fees/dto/create-member-fee-override.dto.ts
@@ -20,7 +20,7 @@ export class CreateMemberFeeOverrideDto {
     description: 'Type of override (EXEMPT, CUSTOM_AMOUNT, ADDITIONAL)',
     enum: FeeOverrideType,
   })
-  @IsEnum(FeeOverrideType, { message: 'Ungueltiger Override-Typ' })
+  @IsEnum(FeeOverrideType, { message: 'Ungültiger Override-Typ' })
   overrideType!: FeeOverrideType;
 
   @ApiPropertyOptional({
@@ -30,7 +30,7 @@ export class CreateMemberFeeOverrideDto {
   @IsString()
   @IsOptional()
   @Matches(/^\d{1,8}(\.\d{1,2})?$/, {
-    message: 'Betrag muss ein gueltiges Dezimalformat haben (z.B. "50.00", max 8 Vorkommastellen)',
+    message: 'Betrag muss ein gültiges Dezimalformat haben (z.B. „50.00", max 8 Vorkommastellen)',
   })
   customAmount?: string;
 

--- a/apps/api/src/fees/dto/create-member-fee-override.dto.ts
+++ b/apps/api/src/fees/dto/create-member-fee-override.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsString, IsOptional, IsBoolean, IsEnum, Matches } from 'class-validator';
+import { Transform } from 'class-transformer';
 import { FeeOverrideType } from '../../../../../prisma/generated/client/index.js';
 
 export class CreateMemberFeeOverrideDto {
@@ -29,7 +30,8 @@ export class CreateMemberFeeOverrideDto {
   })
   @IsString()
   @IsOptional()
-  @Matches(/^\d{1,8}(\.\d{1,2})?$/, {
+  @Transform(({ value }) => (typeof value === 'string' ? value.replace(',', '.') : value))
+  @Matches(/^\d{1,8}([.,]\d{1,2})?$/, {
     message: 'Betrag muss ein gültiges Dezimalformat haben (z.B. „50.00", max 8 Vorkommastellen)',
   })
   customAmount?: string;

--- a/apps/api/src/fees/dto/fee-charge-query.dto.ts
+++ b/apps/api/src/fees/dto/fee-charge-query.dto.ts
@@ -1,5 +1,5 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsDateString, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+import { IsDateString, IsIn, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
 import { Transform } from 'class-transformer';
 
 export class FeeChargeQueryDto {
@@ -8,8 +8,10 @@ export class FeeChargeQueryDto {
     enum: ['OPEN', 'PARTIAL', 'PAID', 'OVERDUE'],
   })
   @IsOptional()
-  @IsString()
-  status?: string;
+  @IsIn(['OPEN', 'PARTIAL', 'PAID', 'OVERDUE'], {
+    message: 'Status muss OPEN, PARTIAL, PAID oder OVERDUE sein',
+  })
+  status?: 'OPEN' | 'PARTIAL' | 'PAID' | 'OVERDUE';
 
   @ApiPropertyOptional({
     description: 'Filter by specific member ID',

--- a/apps/api/src/fees/dto/fee-charge-query.dto.ts
+++ b/apps/api/src/fees/dto/fee-charge-query.dto.ts
@@ -23,7 +23,7 @@ export class FeeChargeQueryDto {
     example: '2026-01-01',
   })
   @IsOptional()
-  @IsDateString({}, { message: 'Periodenbeginn muss ein gueltiges Datum sein' })
+  @IsDateString({}, { message: 'Periodenbeginn muss ein gültiges Datum sein' })
   periodStart?: string;
 
   @ApiPropertyOptional({
@@ -31,7 +31,7 @@ export class FeeChargeQueryDto {
     example: '2026-12-31',
   })
   @IsOptional()
-  @IsDateString({}, { message: 'Periodenende muss ein gueltiges Datum sein' })
+  @IsDateString({}, { message: 'Periodenende muss ein gültiges Datum sein' })
   periodEnd?: string;
 
   @ApiPropertyOptional({

--- a/apps/api/src/fees/dto/fee-charge-query.dto.ts
+++ b/apps/api/src/fees/dto/fee-charge-query.dto.ts
@@ -1,5 +1,5 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsDateString, IsEnum, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+import { IsDateString, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
 import { Transform } from 'class-transformer';
 
 export class FeeChargeQueryDto {

--- a/apps/api/src/fees/dto/fee-charge-query.dto.ts
+++ b/apps/api/src/fees/dto/fee-charge-query.dto.ts
@@ -1,0 +1,57 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsDateString, IsEnum, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+import { Transform } from 'class-transformer';
+
+export class FeeChargeQueryDto {
+  @ApiPropertyOptional({
+    description: 'Filter by derived payment status',
+    enum: ['OPEN', 'PARTIAL', 'PAID', 'OVERDUE'],
+  })
+  @IsOptional()
+  @IsString()
+  status?: string;
+
+  @ApiPropertyOptional({
+    description: 'Filter by specific member ID',
+  })
+  @IsOptional()
+  @IsString()
+  memberId?: string;
+
+  @ApiPropertyOptional({
+    description: 'Filter by period start (inclusive)',
+    example: '2026-01-01',
+  })
+  @IsOptional()
+  @IsDateString({}, { message: 'Periodenbeginn muss ein gueltiges Datum sein' })
+  periodStart?: string;
+
+  @ApiPropertyOptional({
+    description: 'Filter by period end (inclusive)',
+    example: '2026-12-31',
+  })
+  @IsOptional()
+  @IsDateString({}, { message: 'Periodenende muss ein gueltiges Datum sein' })
+  periodEnd?: string;
+
+  @ApiPropertyOptional({
+    description: 'Page number (1-based)',
+    default: 1,
+  })
+  @IsOptional()
+  @Transform(({ value }) => parseInt(value as string, 10))
+  @IsInt()
+  @Min(1)
+  page?: number;
+
+  @ApiPropertyOptional({
+    description: 'Items per page (max 100)',
+    default: 20,
+  })
+  @IsOptional()
+  @Transform(({ value }) => parseInt(value as string, 10))
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number;
+}

--- a/apps/api/src/fees/dto/index.ts
+++ b/apps/api/src/fees/dto/index.ts
@@ -1,0 +1,3 @@
+export { CreateFeeCategoryDto } from './create-fee-category.dto.js';
+export { UpdateFeeCategoryDto } from './update-fee-category.dto.js';
+export { CreateMemberFeeOverrideDto } from './create-member-fee-override.dto.js';

--- a/apps/api/src/fees/dto/index.ts
+++ b/apps/api/src/fees/dto/index.ts
@@ -1,3 +1,7 @@
 export { CreateFeeCategoryDto } from './create-fee-category.dto.js';
 export { UpdateFeeCategoryDto } from './update-fee-category.dto.js';
 export { CreateMemberFeeOverrideDto } from './create-member-fee-override.dto.js';
+export { BillingRunPreviewDto } from './billing-run-preview.dto.js';
+export { BillingRunConfirmDto } from './billing-run-confirm.dto.js';
+export { FeeChargeQueryDto } from './fee-charge-query.dto.js';
+export { RecordPaymentDto } from './record-payment.dto.js';

--- a/apps/api/src/fees/dto/record-payment.dto.ts
+++ b/apps/api/src/fees/dto/record-payment.dto.ts
@@ -14,8 +14,8 @@ export class RecordPaymentDto {
     example: '50.00',
   })
   @IsString()
-  @Matches(/^\d+(\.\d{1,2})?$/, {
-    message: 'Betrag muss ein gueltiges Dezimalformat haben (z.B. "50.00")',
+  @Matches(/^(?!0+(\.0{1,2})?$)\d{1,8}(\.\d{1,2})?$/, {
+    message: 'Betrag muss groesser als 0 sein und ein gueltiges Dezimalformat haben (z.B. "50.00")',
   })
   amount!: string;
 

--- a/apps/api/src/fees/dto/record-payment.dto.ts
+++ b/apps/api/src/fees/dto/record-payment.dto.ts
@@ -1,0 +1,37 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsDateString, IsOptional, IsString, Matches, MaxLength } from 'class-validator';
+
+export class RecordPaymentDto {
+  @ApiProperty({
+    description: 'The fee charge this payment is for',
+    example: 'clxyz123...',
+  })
+  @IsString()
+  feeChargeId!: string;
+
+  @ApiProperty({
+    description: 'Payment amount as decimal string (e.g., "50.00")',
+    example: '50.00',
+  })
+  @IsString()
+  @Matches(/^\d+(\.\d{1,2})?$/, {
+    message: 'Betrag muss ein gueltiges Dezimalformat haben (z.B. "50.00")',
+  })
+  amount!: string;
+
+  @ApiProperty({
+    description: 'Date the payment was made (ISO date string)',
+    example: '2026-01-20',
+  })
+  @IsDateString({}, { message: 'Zahlungsdatum muss ein gueltiges Datum sein' })
+  paidAt!: string;
+
+  @ApiPropertyOptional({
+    description: 'Optional notes about this payment',
+    example: 'Barbezahlung',
+  })
+  @IsString()
+  @IsOptional()
+  @MaxLength(500, { message: 'Notizen duerfen maximal 500 Zeichen lang sein' })
+  notes?: string;
+}

--- a/apps/api/src/fees/dto/record-payment.dto.ts
+++ b/apps/api/src/fees/dto/record-payment.dto.ts
@@ -15,7 +15,7 @@ export class RecordPaymentDto {
   })
   @IsString()
   @Matches(/^(?!0+(\.0{1,2})?$)\d{1,8}(\.\d{1,2})?$/, {
-    message: 'Betrag muss groesser als 0 sein und ein gueltiges Dezimalformat haben (z.B. "50.00")',
+    message: 'Betrag muss größer als 0 sein und ein gültiges Dezimalformat haben (z.B. "50.00")',
   })
   amount!: string;
 
@@ -23,7 +23,7 @@ export class RecordPaymentDto {
     description: 'Date the payment was made (ISO date string)',
     example: '2026-01-20',
   })
-  @IsDateString({}, { message: 'Zahlungsdatum muss ein gueltiges Datum sein' })
+  @IsDateString({}, { message: 'Zahlungsdatum muss ein gültiges Datum sein' })
   paidAt!: string;
 
   @ApiPropertyOptional({
@@ -32,6 +32,6 @@ export class RecordPaymentDto {
   })
   @IsString()
   @IsOptional()
-  @MaxLength(500, { message: 'Notizen duerfen maximal 500 Zeichen lang sein' })
+  @MaxLength(500, { message: 'Notizen dürfen maximal 500 Zeichen lang sein' })
   notes?: string;
 }

--- a/apps/api/src/fees/dto/record-payment.dto.ts
+++ b/apps/api/src/fees/dto/record-payment.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsDateString, IsOptional, IsString, Matches, MaxLength } from 'class-validator';
+import { Transform } from 'class-transformer';
 
 export class RecordPaymentDto {
   @ApiProperty({
@@ -14,7 +15,8 @@ export class RecordPaymentDto {
     example: '50.00',
   })
   @IsString()
-  @Matches(/^(?!0+(\.0{1,2})?$)\d{1,8}(\.\d{1,2})?$/, {
+  @Transform(({ value }) => (typeof value === 'string' ? value.replace(',', '.') : value))
+  @Matches(/^(?!0+([.,]0{1,2})?$)\d{1,8}([.,]\d{1,2})?$/, {
     message: 'Betrag muss größer als 0 sein und ein gültiges Dezimalformat haben (z.B. "50.00")',
   })
   amount!: string;

--- a/apps/api/src/fees/dto/update-fee-category.dto.ts
+++ b/apps/api/src/fees/dto/update-fee-category.dto.ts
@@ -10,7 +10,7 @@ import {
   MaxLength,
   Matches,
 } from 'class-validator';
-import { BillingInterval } from '../../../../prisma/generated/client/index.js';
+import { BillingInterval } from '../../../../../prisma/generated/client/index.js';
 
 export class UpdateFeeCategoryDto {
   @ApiPropertyOptional({

--- a/apps/api/src/fees/dto/update-fee-category.dto.ts
+++ b/apps/api/src/fees/dto/update-fee-category.dto.ts
@@ -1,0 +1,75 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsString,
+  IsOptional,
+  IsBoolean,
+  IsInt,
+  IsEnum,
+  Min,
+  MinLength,
+  MaxLength,
+  Matches,
+} from 'class-validator';
+import { BillingInterval } from '../../../../prisma/generated/client/index.js';
+
+export class UpdateFeeCategoryDto {
+  @ApiPropertyOptional({
+    description: 'Category name (e.g., "Aufnahmegebuehr", "Tennisabteilung")',
+    example: 'Aufnahmegebuehr',
+  })
+  @IsString()
+  @IsOptional()
+  @MinLength(1, { message: 'Name darf nicht leer sein' })
+  @MaxLength(100, { message: 'Name darf maximal 100 Zeichen lang sein' })
+  name?: string;
+
+  @ApiPropertyOptional({
+    description: 'Optional description',
+  })
+  @IsString()
+  @IsOptional()
+  @MaxLength(500, { message: 'Beschreibung darf maximal 500 Zeichen lang sein' })
+  description?: string;
+
+  @ApiPropertyOptional({
+    description: 'Fee amount as decimal string (e.g., "120.00")',
+    example: '120.00',
+  })
+  @IsString()
+  @IsOptional()
+  @Matches(/^\d+(\.\d{1,2})?$/, {
+    message: 'Betrag muss ein gueltiges Dezimalformat haben (z.B. "120.00")',
+  })
+  amount?: string;
+
+  @ApiPropertyOptional({
+    description: 'Billing frequency',
+    enum: BillingInterval,
+  })
+  @IsEnum(BillingInterval, { message: 'Ungueltiger Abrechnungszeitraum' })
+  @IsOptional()
+  billingInterval?: BillingInterval;
+
+  @ApiPropertyOptional({
+    description: 'Whether this is a one-time fee',
+  })
+  @IsBoolean()
+  @IsOptional()
+  isOneTime?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Whether this category is active',
+  })
+  @IsBoolean()
+  @IsOptional()
+  isActive?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Display order in lists',
+    minimum: 0,
+  })
+  @IsInt()
+  @IsOptional()
+  @Min(0, { message: 'Sortierung muss mindestens 0 sein' })
+  sortOrder?: number;
+}

--- a/apps/api/src/fees/dto/update-fee-category.dto.ts
+++ b/apps/api/src/fees/dto/update-fee-category.dto.ts
@@ -37,8 +37,8 @@ export class UpdateFeeCategoryDto {
   })
   @IsString()
   @IsOptional()
-  @Matches(/^\d+(\.\d{1,2})?$/, {
-    message: 'Betrag muss ein gültiges Dezimalformat haben (z.B. „120.00")',
+  @Matches(/^\d{1,8}(\.\d{1,2})?$/, {
+    message: 'Betrag muss ein gültiges Dezimalformat haben (z.B. „120.00", max 8 Vorkommastellen)',
   })
   amount?: string;
 

--- a/apps/api/src/fees/dto/update-fee-category.dto.ts
+++ b/apps/api/src/fees/dto/update-fee-category.dto.ts
@@ -38,7 +38,7 @@ export class UpdateFeeCategoryDto {
   @IsString()
   @IsOptional()
   @Matches(/^\d+(\.\d{1,2})?$/, {
-    message: 'Betrag muss ein gueltiges Dezimalformat haben (z.B. "120.00")',
+    message: 'Betrag muss ein gültiges Dezimalformat haben (z.B. „120.00")',
   })
   amount?: string;
 
@@ -46,7 +46,7 @@ export class UpdateFeeCategoryDto {
     description: 'Billing frequency',
     enum: BillingInterval,
   })
-  @IsEnum(BillingInterval, { message: 'Ungueltiger Abrechnungszeitraum' })
+  @IsEnum(BillingInterval, { message: 'Ungültiger Abrechnungszeitraum' })
   @IsOptional()
   billingInterval?: BillingInterval;
 

--- a/apps/api/src/fees/dto/update-fee-category.dto.ts
+++ b/apps/api/src/fees/dto/update-fee-category.dto.ts
@@ -5,17 +5,19 @@ import {
   IsBoolean,
   IsInt,
   IsEnum,
+  IsArray,
   Min,
   MinLength,
   MaxLength,
   Matches,
 } from 'class-validator';
-import { BillingInterval } from '../../../../../prisma/generated/client/index.js';
+import { Transform } from 'class-transformer';
+import { BillingInterval, FeeCategoryScope } from '../../../../../prisma/generated/client/index.js';
 
 export class UpdateFeeCategoryDto {
   @ApiPropertyOptional({
-    description: 'Category name (e.g., "Aufnahmegebuehr", "Tennisabteilung")',
-    example: 'Aufnahmegebuehr',
+    description: 'Category name (e.g., "Aufnahmegebühr", "Tennisabteilung")',
+    example: 'Aufnahmegebühr',
   })
   @IsString()
   @IsOptional()
@@ -37,7 +39,8 @@ export class UpdateFeeCategoryDto {
   })
   @IsString()
   @IsOptional()
-  @Matches(/^\d{1,8}(\.\d{1,2})?$/, {
+  @Transform(({ value }) => (typeof value === 'string' ? value.replace(',', '.') : value))
+  @Matches(/^\d{1,8}([.,]\d{1,2})?$/, {
     message: 'Betrag muss ein gültiges Dezimalformat haben (z.B. „120.00", max 8 Vorkommastellen)',
   })
   amount?: string;
@@ -72,4 +75,21 @@ export class UpdateFeeCategoryDto {
   @IsOptional()
   @Min(0, { message: 'Sortierung muss mindestens 0 sein' })
   sortOrder?: number;
+
+  @ApiPropertyOptional({
+    description: 'Scope: which members this category applies to',
+    enum: FeeCategoryScope,
+  })
+  @IsEnum(FeeCategoryScope, { message: 'Ungültiger Geltungsbereich' })
+  @IsOptional()
+  scope?: FeeCategoryScope;
+
+  @ApiPropertyOptional({
+    description: 'Membership type IDs (for BY_MEMBERSHIP_TYPE scope)',
+    type: [String],
+  })
+  @IsArray()
+  @IsString({ each: true })
+  @IsOptional()
+  membershipTypeIds?: string[];
 }

--- a/apps/api/src/fees/dto/update-fee-type.dto.ts
+++ b/apps/api/src/fees/dto/update-fee-type.dto.ts
@@ -1,0 +1,29 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsString, IsOptional, IsBoolean, MinLength, MaxLength } from 'class-validator';
+
+export class UpdateFeeTypeDto {
+  @ApiPropertyOptional({
+    description: 'Display name (e.g., "Einzelbeitrag", "Familientarif")',
+    example: 'Einzelbeitrag',
+  })
+  @IsString()
+  @IsOptional()
+  @MinLength(1, { message: 'Name darf nicht leer sein' })
+  @MaxLength(100, { message: 'Name darf maximal 100 Zeichen lang sein' })
+  name?: string;
+
+  @ApiPropertyOptional({
+    description: 'Optional description explaining when this fee type applies',
+  })
+  @IsString()
+  @IsOptional()
+  @MaxLength(500, { message: 'Beschreibung darf maximal 500 Zeichen lang sein' })
+  description?: string;
+
+  @ApiPropertyOptional({
+    description: 'Whether this fee type is currently available for selection',
+  })
+  @IsBoolean()
+  @IsOptional()
+  isActive?: boolean;
+}

--- a/apps/api/src/fees/dto/upsert-cross-table-entry.dto.ts
+++ b/apps/api/src/fees/dto/upsert-cross-table-entry.dto.ts
@@ -1,0 +1,40 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsString, IsOptional, IsEnum, Matches } from 'class-validator';
+import { Transform } from 'class-transformer';
+import { BillingInterval } from '../../../../../prisma/generated/client/index.js';
+
+export class UpsertCrossTableEntryDto {
+  @ApiProperty({
+    description: 'Reference to the membership type',
+    example: 'clxyz123abc',
+  })
+  @IsString()
+  membershipTypeId!: string;
+
+  @ApiProperty({
+    description: 'Reference to the fee type',
+    example: 'clxyz456def',
+  })
+  @IsString()
+  feeTypeId!: string;
+
+  @ApiProperty({
+    description: 'Fee amount as decimal string (e.g., "65.00" or "65,00")',
+    example: '65.00',
+  })
+  @IsString()
+  @Transform(({ value }) => (typeof value === 'string' ? value.replace(',', '.') : value))
+  @Matches(/^\d+([.,]\d{1,2})?$/, {
+    message: 'Bitte gib einen gueltigen Betrag ein (z.B. 65.00)',
+  })
+  amount!: string;
+
+  @ApiPropertyOptional({
+    description: 'Billing frequency for this combination',
+    enum: BillingInterval,
+    default: 'ANNUALLY',
+  })
+  @IsEnum(BillingInterval, { message: 'Ungueltiger Abrechnungszeitraum' })
+  @IsOptional()
+  billingInterval?: BillingInterval;
+}

--- a/apps/api/src/fees/fee-charges.controller.ts
+++ b/apps/api/src/fees/fee-charges.controller.ts
@@ -1,0 +1,55 @@
+import { Controller, Get, Post, Param, Body, Query } from '@nestjs/common';
+import { ApiTags, ApiBearerAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { RequireClubContext, GetClubContext } from '../common/decorators/club-context.decorator.js';
+import { RequirePermissions } from '../common/decorators/permissions.decorator.js';
+import { Permission } from '../common/permissions/permissions.enum.js';
+import { CurrentUser } from '../auth/decorators/current-user.decorator.js';
+import { FeeChargesService } from './fee-charges.service.js';
+import { BillingRunPreviewDto } from './dto/billing-run-preview.dto.js';
+import { BillingRunConfirmDto } from './dto/billing-run-confirm.dto.js';
+import { FeeChargeQueryDto } from './dto/fee-charge-query.dto.js';
+import type { ClubContext } from '../common/decorators/club-context.decorator.js';
+
+@ApiTags('Fee Charges')
+@ApiBearerAuth()
+@Controller('clubs/:slug/fees/charges')
+@RequireClubContext()
+export class FeeChargesController {
+  constructor(private feeChargesService: FeeChargesService) {}
+
+  @Post('billing-run/preview')
+  @RequirePermissions([Permission.FINANCE_CREATE])
+  @ApiOperation({ summary: 'Preview billing run (no side effects)' })
+  @ApiResponse({ status: 200, description: 'Billing run preview with counts and totals' })
+  async previewBillingRun(@GetClubContext() ctx: ClubContext, @Body() dto: BillingRunPreviewDto) {
+    return this.feeChargesService.previewBillingRun(ctx.clubId, dto);
+  }
+
+  @Post('billing-run/confirm')
+  @RequirePermissions([Permission.FINANCE_CREATE])
+  @ApiOperation({ summary: 'Execute billing run and create fee charges' })
+  @ApiResponse({ status: 201, description: 'Billing run executed, charges created' })
+  async confirmBillingRun(
+    @GetClubContext() ctx: ClubContext,
+    @Body() dto: BillingRunConfirmDto,
+    @CurrentUser('id') userId: string
+  ) {
+    return this.feeChargesService.executeBillingRun(ctx.clubId, dto, userId);
+  }
+
+  @Get()
+  @RequirePermissions([Permission.FINANCE_READ])
+  @ApiOperation({ summary: 'List fee charges with computed payment status' })
+  @ApiResponse({ status: 200, description: 'Paginated list of fee charges with status' })
+  async findAll(@GetClubContext() ctx: ClubContext, @Query() query: FeeChargeQueryDto) {
+    return this.feeChargesService.findAllWithStatus(ctx.clubId, query);
+  }
+
+  @Get('member/:memberId')
+  @RequirePermissions([Permission.FINANCE_READ])
+  @ApiOperation({ summary: 'List fee charges for a specific member' })
+  @ApiResponse({ status: 200, description: 'Member fee charges with status' })
+  async findByMember(@GetClubContext() ctx: ClubContext, @Param('memberId') memberId: string) {
+    return this.feeChargesService.findByMember(ctx.clubId, memberId);
+  }
+}

--- a/apps/api/src/fees/fee-charges.controller.ts
+++ b/apps/api/src/fees/fee-charges.controller.ts
@@ -3,7 +3,7 @@ import { ApiTags, ApiBearerAuth, ApiOperation, ApiResponse } from '@nestjs/swagg
 import { RequireClubContext, GetClubContext } from '../common/decorators/club-context.decorator.js';
 import { RequirePermissions } from '../common/decorators/permissions.decorator.js';
 import { Permission } from '../common/permissions/permissions.enum.js';
-import { CurrentUser } from '../auth/decorators/current-user.decorator.js';
+
 import { FeeChargesService } from './fee-charges.service.js';
 import { BillingRunPreviewDto } from './dto/billing-run-preview.dto.js';
 import { BillingRunConfirmDto } from './dto/billing-run-confirm.dto.js';
@@ -29,12 +29,8 @@ export class FeeChargesController {
   @RequirePermissions([Permission.FINANCE_CREATE])
   @ApiOperation({ summary: 'Execute billing run and create fee charges' })
   @ApiResponse({ status: 201, description: 'Billing run executed, charges created' })
-  async confirmBillingRun(
-    @GetClubContext() ctx: ClubContext,
-    @Body() dto: BillingRunConfirmDto,
-    @CurrentUser('id') userId: string
-  ) {
-    return this.feeChargesService.executeBillingRun(ctx.clubId, dto, userId);
+  async confirmBillingRun(@GetClubContext() ctx: ClubContext, @Body() dto: BillingRunConfirmDto) {
+    return this.feeChargesService.executeBillingRun(ctx.clubId, dto);
   }
 
   @Get()

--- a/apps/api/src/fees/fee-charges.service.spec.ts
+++ b/apps/api/src/fees/fee-charges.service.spec.ts
@@ -222,14 +222,16 @@ describe('FeeChargesService', () => {
       (mockPrisma.club.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeClub());
       (mockPrisma.member.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(members);
       (mockDb.feeCategory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
-      (mockPrisma.$transaction as ReturnType<typeof vi.fn>).mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
-        const txClient = {
-          feeCharge: {
-            createMany: vi.fn().mockResolvedValue({ count: 2 }),
-          },
-        };
-        return fn(txClient);
-      });
+      (mockPrisma.$transaction as ReturnType<typeof vi.fn>).mockImplementation(
+        async (fn: (tx: unknown) => Promise<unknown>) => {
+          const txClient = {
+            feeCharge: {
+              createMany: vi.fn().mockResolvedValue({ count: 2 }),
+            },
+          };
+          return fn(txClient);
+        }
+      );
 
       const result = await service.executeBillingRun(CLUB_ID, confirmDto, USER_ID);
 
@@ -267,17 +269,19 @@ describe('FeeChargesService', () => {
       (mockDb.feeCategory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
 
       let capturedData: unknown[] = [];
-      (mockPrisma.$transaction as ReturnType<typeof vi.fn>).mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
-        const txClient = {
-          feeCharge: {
-            createMany: vi.fn().mockImplementation(({ data }: { data: unknown[] }) => {
-              capturedData = data;
-              return { count: data.length };
-            }),
-          },
-        };
-        return fn(txClient);
-      });
+      (mockPrisma.$transaction as ReturnType<typeof vi.fn>).mockImplementation(
+        async (fn: (tx: unknown) => Promise<unknown>) => {
+          const txClient = {
+            feeCharge: {
+              createMany: vi.fn().mockImplementation(({ data }: { data: unknown[] }) => {
+                capturedData = data;
+                return { count: data.length };
+              }),
+            },
+          };
+          return fn(txClient);
+        }
+      );
 
       const result = await service.executeBillingRun(CLUB_ID, confirmDto, USER_ID);
 
@@ -300,17 +304,19 @@ describe('FeeChargesService', () => {
       (mockDb.feeCategory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
 
       let capturedData: unknown[] = [];
-      (mockPrisma.$transaction as ReturnType<typeof vi.fn>).mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
-        const txClient = {
-          feeCharge: {
-            createMany: vi.fn().mockImplementation(({ data }: { data: unknown[] }) => {
-              capturedData = data;
-              return { count: data.length };
-            }),
-          },
-        };
-        return fn(txClient);
-      });
+      (mockPrisma.$transaction as ReturnType<typeof vi.fn>).mockImplementation(
+        async (fn: (tx: unknown) => Promise<unknown>) => {
+          const txClient = {
+            feeCharge: {
+              createMany: vi.fn().mockImplementation(({ data }: { data: unknown[] }) => {
+                capturedData = data;
+                return { count: data.length };
+              }),
+            },
+          };
+          return fn(txClient);
+        }
+      );
 
       await service.executeBillingRun(CLUB_ID, confirmDto, USER_ID);
 
@@ -353,17 +359,19 @@ describe('FeeChargesService', () => {
       (mockDb.feeCategory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
 
       let capturedData: unknown[] = [];
-      (mockPrisma.$transaction as ReturnType<typeof vi.fn>).mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
-        const txClient = {
-          feeCharge: {
-            createMany: vi.fn().mockImplementation(({ data }: { data: unknown[] }) => {
-              capturedData = data;
-              return { count: data.length };
-            }),
-          },
-        };
-        return fn(txClient);
-      });
+      (mockPrisma.$transaction as ReturnType<typeof vi.fn>).mockImplementation(
+        async (fn: (tx: unknown) => Promise<unknown>) => {
+          const txClient = {
+            feeCharge: {
+              createMany: vi.fn().mockImplementation(({ data }: { data: unknown[] }) => {
+                capturedData = data;
+                return { count: data.length };
+              }),
+            },
+          };
+          return fn(txClient);
+        }
+      );
 
       await service.executeBillingRun(CLUB_ID, confirmDto, USER_ID);
 
@@ -390,17 +398,21 @@ describe('FeeChargesService', () => {
       (mockDb.feeCategory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
 
       let skipDuplicatesUsed = false;
-      (mockPrisma.$transaction as ReturnType<typeof vi.fn>).mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
-        const txClient = {
-          feeCharge: {
-            createMany: vi.fn().mockImplementation(({ skipDuplicates }: { skipDuplicates: boolean }) => {
-              skipDuplicatesUsed = skipDuplicates;
-              return { count: 1 };
-            }),
-          },
-        };
-        return fn(txClient);
-      });
+      (mockPrisma.$transaction as ReturnType<typeof vi.fn>).mockImplementation(
+        async (fn: (tx: unknown) => Promise<unknown>) => {
+          const txClient = {
+            feeCharge: {
+              createMany: vi
+                .fn()
+                .mockImplementation(({ skipDuplicates }: { skipDuplicates: boolean }) => {
+                  skipDuplicatesUsed = skipDuplicates;
+                  return { count: 1 };
+                }),
+            },
+          };
+          return fn(txClient);
+        }
+      );
 
       await service.executeBillingRun(CLUB_ID, confirmDto, USER_ID);
 

--- a/apps/api/src/fees/fee-charges.service.spec.ts
+++ b/apps/api/src/fees/fee-charges.service.spec.ts
@@ -1,0 +1,496 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { FeeChargesService } from './fee-charges.service.js';
+import type { PrismaService } from '../prisma/prisma.service.js';
+import { Prisma } from '../../../../prisma/generated/client/index.js';
+
+const { Decimal } = Prisma;
+
+// ─── Mock Data Factories ────────────────────────────────────────────────────
+
+const CLUB_ID = 'club-1';
+const USER_ID = 'user-1';
+
+function makeMember(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'member-1',
+    clubId: CLUB_ID,
+    firstName: 'Max',
+    lastName: 'Mustermann',
+    memberNumber: 'TSV-001',
+    status: 'ACTIVE',
+    householdId: null,
+    householdRole: null,
+    deletedAt: null,
+    membershipPeriods: [
+      {
+        id: 'mp-1',
+        joinDate: new Date('2020-01-01'),
+        leaveDate: null,
+        membershipTypeId: 'mt-1',
+        membershipType: {
+          id: 'mt-1',
+          name: 'Ordentliches Mitglied',
+          feeAmount: new Decimal('120.00'),
+          billingInterval: 'ANNUALLY',
+        },
+      },
+    ],
+    memberFeeOverrides: [],
+    ...overrides,
+  };
+}
+
+function makeMemberWithOverride(overrideType: string, overrides: Record<string, unknown> = {}) {
+  return makeMember({
+    id: 'member-exempt',
+    firstName: 'Exempt',
+    lastName: 'User',
+    memberNumber: 'TSV-003',
+    memberFeeOverrides: [
+      {
+        id: 'override-1',
+        overrideType,
+        customAmount: overrideType === 'CUSTOM_AMOUNT' ? new Decimal('60.00') : null,
+        reason: overrideType === 'EXEMPT' ? 'Ehrenmitglied' : 'Sozialtarif',
+        isBaseFee: true,
+        feeCategoryId: null,
+      },
+    ],
+    ...overrides,
+  });
+}
+
+function makeClub(overrides: Record<string, unknown> = {}) {
+  return {
+    id: CLUB_ID,
+    proRataMode: 'FULL',
+    householdFeeMode: 'NONE',
+    householdDiscountPercent: null,
+    householdFlatAmount: null,
+    ...overrides,
+  };
+}
+
+function makeFeeCharge(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'fc-1',
+    clubId: CLUB_ID,
+    memberId: 'member-1',
+    feeCategoryId: null,
+    membershipTypeId: 'mt-1',
+    description: 'Grundbeitrag 2026',
+    periodStart: new Date('2026-01-01'),
+    periodEnd: new Date('2026-12-31'),
+    amount: new Decimal('120.00'),
+    dueDate: new Date('2026-02-15'),
+    discountAmount: null,
+    discountReason: null,
+    deletedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    member: {
+      id: 'member-1',
+      firstName: 'Max',
+      lastName: 'Mustermann',
+      memberNumber: 'TSV-001',
+    },
+    ...overrides,
+  };
+}
+
+// ─── Mock Prisma ────────────────────────────────────────────────────────────
+
+const mockDb = {
+  feeCategory: {
+    findMany: vi.fn(),
+  },
+  feeCharge: {
+    findMany: vi.fn(),
+    count: vi.fn(),
+    createMany: vi.fn(),
+  },
+};
+
+const mockPrisma = {
+  forClub: vi.fn(() => mockDb),
+  club: {
+    findFirst: vi.fn(),
+  },
+  member: {
+    findMany: vi.fn(),
+  },
+  feeCharge: {
+    findMany: vi.fn(),
+    count: vi.fn(),
+    createMany: vi.fn(),
+  },
+  payment: {
+    groupBy: vi.fn(),
+  },
+  $transaction: vi.fn(),
+} as unknown as PrismaService;
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('FeeChargesService', () => {
+  let service: FeeChargesService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (mockPrisma.forClub as ReturnType<typeof vi.fn>).mockReturnValue(mockDb);
+    service = new FeeChargesService(mockPrisma);
+  });
+
+  // ─── Preview Billing Run ────────────────────────────────────────────
+
+  describe('previewBillingRun()', () => {
+    const previewDto = {
+      periodStart: '2026-01-01',
+      periodEnd: '2026-12-31',
+      billingInterval: 'ANNUALLY' as const,
+    };
+
+    it('should return memberCount=3 and correct totalAmount for 3 active members with annual interval', async () => {
+      const members = [
+        makeMember({ id: 'member-1', memberNumber: 'TSV-001' }),
+        makeMember({ id: 'member-2', firstName: 'Anna', memberNumber: 'TSV-002' }),
+        makeMember({ id: 'member-3', firstName: 'Peter', memberNumber: 'TSV-003' }),
+      ];
+
+      (mockPrisma.club.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeClub());
+      (mockPrisma.member.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(members);
+      (mockDb.feeCategory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+      (mockDb.feeCharge.count as ReturnType<typeof vi.fn>).mockResolvedValue(0);
+
+      const result = await service.previewBillingRun(CLUB_ID, previewDto);
+
+      expect(result.memberCount).toBe(3);
+      expect(result.totalAmount).toBe('360.00');
+      expect(result.exemptions).toBe(0);
+      expect(result.existingCharges).toBe(0);
+    });
+
+    it('should exclude exempt member: memberCount=2, exemptions=1', async () => {
+      const members = [
+        makeMember({ id: 'member-1', memberNumber: 'TSV-001' }),
+        makeMember({ id: 'member-2', firstName: 'Anna', memberNumber: 'TSV-002' }),
+        makeMemberWithOverride('EXEMPT', { id: 'member-3', memberNumber: 'TSV-003' }),
+      ];
+
+      (mockPrisma.club.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeClub());
+      (mockPrisma.member.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(members);
+      (mockDb.feeCategory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+      (mockDb.feeCharge.count as ReturnType<typeof vi.fn>).mockResolvedValue(0);
+
+      const result = await service.previewBillingRun(CLUB_ID, previewDto);
+
+      expect(result.memberCount).toBe(2);
+      expect(result.exemptions).toBe(1);
+      expect(result.totalAmount).toBe('240.00');
+    });
+
+    it('should detect existing charges for same period and report existingCharges count', async () => {
+      const members = [makeMember()];
+
+      (mockPrisma.club.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeClub());
+      (mockPrisma.member.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(members);
+      (mockDb.feeCategory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+      (mockDb.feeCharge.count as ReturnType<typeof vi.fn>).mockResolvedValue(5);
+
+      const result = await service.previewBillingRun(CLUB_ID, previewDto);
+
+      expect(result.existingCharges).toBe(5);
+    });
+  });
+
+  // ─── Execute Billing Run ────────────────────────────────────────────
+
+  describe('executeBillingRun()', () => {
+    const confirmDto = {
+      periodStart: '2026-01-01',
+      periodEnd: '2026-12-31',
+      billingInterval: 'ANNUALLY' as const,
+      dueDate: '2026-02-15',
+    };
+
+    it('should create FeeCharge records for each member in a transaction', async () => {
+      const members = [
+        makeMember({ id: 'member-1', memberNumber: 'TSV-001' }),
+        makeMember({ id: 'member-2', firstName: 'Anna', memberNumber: 'TSV-002' }),
+      ];
+
+      (mockPrisma.club.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeClub());
+      (mockPrisma.member.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(members);
+      (mockDb.feeCategory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+      (mockPrisma.$transaction as ReturnType<typeof vi.fn>).mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+        const txClient = {
+          feeCharge: {
+            createMany: vi.fn().mockResolvedValue({ count: 2 }),
+          },
+        };
+        return fn(txClient);
+      });
+
+      const result = await service.executeBillingRun(CLUB_ID, confirmDto, USER_ID);
+
+      expect(result.chargesCreated).toBe(2);
+      expect(result.totalAmount).toBe('240.00');
+      expect(mockPrisma.$transaction).toHaveBeenCalled();
+    });
+
+    it('should apply MONTHLY_PRO_RATA with mid-year join using HALF_UP rounding', async () => {
+      // Member joined July 1st = 6 months remaining out of 12, so 120 * 6/12 = 60.00
+      const members = [
+        makeMember({
+          id: 'member-prorata',
+          membershipPeriods: [
+            {
+              id: 'mp-prorata',
+              joinDate: new Date('2026-07-01'),
+              leaveDate: null,
+              membershipTypeId: 'mt-1',
+              membershipType: {
+                id: 'mt-1',
+                name: 'Ordentliches Mitglied',
+                feeAmount: new Decimal('120.00'),
+                billingInterval: 'ANNUALLY',
+              },
+            },
+          ],
+        }),
+      ];
+
+      (mockPrisma.club.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(
+        makeClub({ proRataMode: 'MONTHLY_PRO_RATA' })
+      );
+      (mockPrisma.member.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(members);
+      (mockDb.feeCategory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+      let capturedData: unknown[] = [];
+      (mockPrisma.$transaction as ReturnType<typeof vi.fn>).mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+        const txClient = {
+          feeCharge: {
+            createMany: vi.fn().mockImplementation(({ data }: { data: unknown[] }) => {
+              capturedData = data;
+              return { count: data.length };
+            }),
+          },
+        };
+        return fn(txClient);
+      });
+
+      const result = await service.executeBillingRun(CLUB_ID, confirmDto, USER_ID);
+
+      expect(result.chargesCreated).toBe(1);
+      // 120 * 6/12 = 60.00
+      expect(result.totalAmount).toBe('60.00');
+      expect((capturedData[0] as { amount: Prisma.Decimal }).amount.toFixed(2)).toBe('60.00');
+    });
+
+    it('should store discountAmount and discountReason on charges with CUSTOM_AMOUNT overrides', async () => {
+      const members = [
+        makeMemberWithOverride('CUSTOM_AMOUNT', {
+          id: 'member-custom',
+          memberNumber: 'TSV-010',
+        }),
+      ];
+
+      (mockPrisma.club.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeClub());
+      (mockPrisma.member.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(members);
+      (mockDb.feeCategory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+      let capturedData: unknown[] = [];
+      (mockPrisma.$transaction as ReturnType<typeof vi.fn>).mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+        const txClient = {
+          feeCharge: {
+            createMany: vi.fn().mockImplementation(({ data }: { data: unknown[] }) => {
+              capturedData = data;
+              return { count: data.length };
+            }),
+          },
+        };
+        return fn(txClient);
+      });
+
+      await service.executeBillingRun(CLUB_ID, confirmDto, USER_ID);
+
+      const charge = capturedData[0] as {
+        amount: Prisma.Decimal;
+        discountAmount: Prisma.Decimal;
+        discountReason: string;
+      };
+      // Original 120, custom 60 => discount = 60
+      expect(charge.amount.toFixed(2)).toBe('60.00');
+      expect(charge.discountAmount.toFixed(2)).toBe('60.00');
+      expect(charge.discountReason).toContain('Individueller Betrag');
+    });
+
+    it('should apply household PERCENTAGE discount and populate discountAmount', async () => {
+      const headMember = makeMember({
+        id: 'member-head',
+        memberNumber: 'TSV-020',
+        householdId: 'hh-1',
+        householdRole: 'HEAD',
+      });
+      const spouseMember = makeMember({
+        id: 'member-spouse',
+        firstName: 'Anna',
+        memberNumber: 'TSV-021',
+        householdId: 'hh-1',
+        householdRole: 'SPOUSE',
+      });
+
+      (mockPrisma.club.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(
+        makeClub({
+          householdFeeMode: 'PERCENTAGE',
+          householdDiscountPercent: 50,
+        })
+      );
+      (mockPrisma.member.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
+        headMember,
+        spouseMember,
+      ]);
+      (mockDb.feeCategory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+      let capturedData: unknown[] = [];
+      (mockPrisma.$transaction as ReturnType<typeof vi.fn>).mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+        const txClient = {
+          feeCharge: {
+            createMany: vi.fn().mockImplementation(({ data }: { data: unknown[] }) => {
+              capturedData = data;
+              return { count: data.length };
+            }),
+          },
+        };
+        return fn(txClient);
+      });
+
+      await service.executeBillingRun(CLUB_ID, confirmDto, USER_ID);
+
+      // HEAD pays full 120, SPOUSE pays 60 (50% discount)
+      const headCharge = capturedData.find(
+        (c: unknown) => (c as { memberId: string }).memberId === 'member-head'
+      ) as { amount: Prisma.Decimal; discountAmount: Prisma.Decimal | null };
+      const spouseCharge = capturedData.find(
+        (c: unknown) => (c as { memberId: string }).memberId === 'member-spouse'
+      ) as { amount: Prisma.Decimal; discountAmount: Prisma.Decimal; discountReason: string };
+
+      expect(headCharge.amount.toFixed(2)).toBe('120.00');
+      expect(headCharge.discountAmount).toBeNull();
+      expect(spouseCharge.amount.toFixed(2)).toBe('60.00');
+      expect(spouseCharge.discountAmount.toFixed(2)).toBe('60.00');
+      expect(spouseCharge.discountReason).toContain('Haushaltsrabatt');
+    });
+
+    it('should skip duplicates via createMany skipDuplicates (idempotent)', async () => {
+      const members = [makeMember()];
+
+      (mockPrisma.club.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeClub());
+      (mockPrisma.member.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(members);
+      (mockDb.feeCategory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+      let skipDuplicatesUsed = false;
+      (mockPrisma.$transaction as ReturnType<typeof vi.fn>).mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+        const txClient = {
+          feeCharge: {
+            createMany: vi.fn().mockImplementation(({ skipDuplicates }: { skipDuplicates: boolean }) => {
+              skipDuplicatesUsed = skipDuplicates;
+              return { count: 1 };
+            }),
+          },
+        };
+        return fn(txClient);
+      });
+
+      await service.executeBillingRun(CLUB_ID, confirmDto, USER_ID);
+
+      expect(skipDuplicatesUsed).toBe(true);
+    });
+  });
+
+  // ─── findAllWithStatus ──────────────────────────────────────────────
+
+  describe('findAllWithStatus()', () => {
+    it('should return OPEN status when no payments exist', async () => {
+      const charges = [makeFeeCharge()];
+      (mockDb.feeCharge.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(charges);
+      (mockDb.feeCharge.count as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+      (mockPrisma.payment.groupBy as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+      const result = await service.findAllWithStatus(CLUB_ID, {});
+
+      expect(result.data[0]!.status).toBe('OPEN');
+      expect(result.data[0]!.paidAmount).toBe('0.00');
+      expect(result.data[0]!.remainingAmount).toBe('120.00');
+    });
+
+    it('should return PARTIAL status when sum(payments) < amount', async () => {
+      const charges = [makeFeeCharge()];
+      (mockDb.feeCharge.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(charges);
+      (mockDb.feeCharge.count as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+      (mockPrisma.payment.groupBy as ReturnType<typeof vi.fn>).mockResolvedValue([
+        { feeChargeId: 'fc-1', _sum: { amount: new Decimal('50.00') } },
+      ]);
+
+      const result = await service.findAllWithStatus(CLUB_ID, {});
+
+      expect(result.data[0]!.status).toBe('PARTIAL');
+      expect(result.data[0]!.paidAmount).toBe('50.00');
+      expect(result.data[0]!.remainingAmount).toBe('70.00');
+    });
+
+    it('should return PAID status when sum(payments) >= amount', async () => {
+      const charges = [makeFeeCharge()];
+      (mockDb.feeCharge.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(charges);
+      (mockDb.feeCharge.count as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+      (mockPrisma.payment.groupBy as ReturnType<typeof vi.fn>).mockResolvedValue([
+        { feeChargeId: 'fc-1', _sum: { amount: new Decimal('120.00') } },
+      ]);
+
+      const result = await service.findAllWithStatus(CLUB_ID, {});
+
+      expect(result.data[0]!.status).toBe('PAID');
+      expect(result.data[0]!.paidAmount).toBe('120.00');
+      expect(result.data[0]!.remainingAmount).toBe('0.00');
+    });
+
+    it('should set isOverdue=true when dueDate < today and status != PAID', async () => {
+      const pastDueCharge = makeFeeCharge({
+        dueDate: new Date('2020-01-01'), // Well in the past
+      });
+      (mockDb.feeCharge.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([pastDueCharge]);
+      (mockDb.feeCharge.count as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+      (mockPrisma.payment.groupBy as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+      const result = await service.findAllWithStatus(CLUB_ID, {});
+
+      expect(result.data[0]!.isOverdue).toBe(true);
+    });
+
+    it('should filter by status, memberId, and period', async () => {
+      const charges = [
+        makeFeeCharge({ id: 'fc-1', memberId: 'member-1' }),
+        makeFeeCharge({ id: 'fc-2', memberId: 'member-2' }),
+      ];
+      (mockDb.feeCharge.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([charges[0]!]);
+      (mockDb.feeCharge.count as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+      (mockPrisma.payment.groupBy as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+      const result = await service.findAllWithStatus(CLUB_ID, {
+        memberId: 'member-1',
+        periodStart: '2026-01-01',
+        periodEnd: '2026-12-31',
+      });
+
+      expect(result.data).toHaveLength(1);
+      // Check that findMany was called with the correct filters
+      expect(mockDb.feeCharge.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            memberId: 'member-1',
+          }),
+        })
+      );
+    });
+  });
+});

--- a/apps/api/src/fees/fee-charges.service.spec.ts
+++ b/apps/api/src/fees/fee-charges.service.spec.ts
@@ -8,7 +8,6 @@ const { Decimal } = Prisma;
 // ─── Mock Data Factories ────────────────────────────────────────────────────
 
 const CLUB_ID = 'club-1';
-const USER_ID = 'user-1';
 
 function makeMember(overrides: Record<string, unknown> = {}) {
   return {
@@ -233,7 +232,7 @@ describe('FeeChargesService', () => {
         }
       );
 
-      const result = await service.executeBillingRun(CLUB_ID, confirmDto, USER_ID);
+      const result = await service.executeBillingRun(CLUB_ID, confirmDto);
 
       expect(result.chargesCreated).toBe(2);
       expect(result.totalAmount).toBe('240.00');
@@ -283,7 +282,7 @@ describe('FeeChargesService', () => {
         }
       );
 
-      const result = await service.executeBillingRun(CLUB_ID, confirmDto, USER_ID);
+      const result = await service.executeBillingRun(CLUB_ID, confirmDto);
 
       expect(result.chargesCreated).toBe(1);
       // 120 * 6/12 = 60.00
@@ -318,7 +317,7 @@ describe('FeeChargesService', () => {
         }
       );
 
-      await service.executeBillingRun(CLUB_ID, confirmDto, USER_ID);
+      await service.executeBillingRun(CLUB_ID, confirmDto);
 
       const charge = capturedData[0] as {
         amount: Prisma.Decimal;
@@ -373,7 +372,7 @@ describe('FeeChargesService', () => {
         }
       );
 
-      await service.executeBillingRun(CLUB_ID, confirmDto, USER_ID);
+      await service.executeBillingRun(CLUB_ID, confirmDto);
 
       // HEAD pays full 120, SPOUSE pays 60 (50% discount)
       const headCharge = capturedData.find(
@@ -414,7 +413,7 @@ describe('FeeChargesService', () => {
         }
       );
 
-      await service.executeBillingRun(CLUB_ID, confirmDto, USER_ID);
+      await service.executeBillingRun(CLUB_ID, confirmDto);
 
       expect(skipDuplicatesUsed).toBe(true);
     });

--- a/apps/api/src/fees/fee-charges.service.spec.ts
+++ b/apps/api/src/fees/fee-charges.service.spec.ts
@@ -503,5 +503,118 @@ describe('FeeChargesService', () => {
         })
       );
     });
+
+    it('should return correct total when filtering by status (two-pass)', async () => {
+      // 3 charges: 1 OPEN (no payments), 1 PAID (fully paid), 1 OVERDUE (past due, no payments)
+      const openCharge = makeFeeCharge({ id: 'fc-open', dueDate: new Date('2099-12-31') });
+
+      // Pass 1: lightweight query returns all 3 charges (select: id, amount, dueDate)
+      (mockDb.feeCharge.findMany as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce([
+          { id: 'fc-open', amount: new Decimal('120.00'), dueDate: new Date('2099-12-31') },
+          { id: 'fc-paid', amount: new Decimal('120.00'), dueDate: new Date('2099-12-31') },
+          { id: 'fc-overdue', amount: new Decimal('120.00'), dueDate: new Date('2020-01-01') },
+        ])
+        // Pass 2: full data for filtered page (only the OPEN charge)
+        .mockResolvedValueOnce([openCharge]);
+
+      // Payment aggregates: only fc-paid is fully paid
+      (mockPrisma.payment.groupBy as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce([
+          { feeChargeId: 'fc-paid', _sum: { amount: new Decimal('120.00') } },
+        ])
+        // Second call for enrichChargesWithStatus
+        .mockResolvedValueOnce([]);
+
+      const result = await service.findAllWithStatus(CLUB_ID, { status: 'OPEN' });
+
+      // Only fc-open matches OPEN (fc-overdue is OPEN but overdue, not "OPEN" status-wise — it IS open but also overdue)
+      // Actually OPEN means: not paid, not overdue. fc-open is OPEN (future due), fc-overdue has status OPEN but isOverdue=true.
+      // The filter `status === 'OPEN'` matches both since computeChargeStatus returns status='OPEN' for both.
+      // But the status filter checks `status === query.status`, so both fc-open and fc-overdue match 'OPEN'.
+      expect(result.total).toBe(2);
+      expect(result.page).toBe(1);
+    });
+
+    it('should paginate correctly with status filter', async () => {
+      // Create 25 OPEN charges + 5 PAID charges
+      const openChargesLight = Array.from({ length: 25 }, (_, i) => ({
+        id: `fc-open-${i}`,
+        amount: new Decimal('10.00'),
+        dueDate: new Date('2099-12-31'),
+      }));
+      const paidChargesLight = Array.from({ length: 5 }, (_, i) => ({
+        id: `fc-paid-${i}`,
+        amount: new Decimal('10.00'),
+        dueDate: new Date('2099-12-31'),
+      }));
+
+      // Pass 1: all 30 charges
+      (mockDb.feeCharge.findMany as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce([...openChargesLight, ...paidChargesLight])
+        // Pass 2: 5 charges for page 2 (ids fc-open-20 through fc-open-24)
+        .mockResolvedValueOnce(
+          Array.from({ length: 5 }, (_, i) =>
+            makeFeeCharge({
+              id: `fc-open-${20 + i}`,
+              amount: new Decimal('10.00'),
+              dueDate: new Date('2099-12-31'),
+            })
+          )
+        );
+
+      // Payment sums: only paid charges have payments
+      const paidAggregates = Array.from({ length: 5 }, (_, i) => ({
+        feeChargeId: `fc-paid-${i}`,
+        _sum: { amount: new Decimal('10.00') },
+      }));
+
+      (mockPrisma.payment.groupBy as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(paidAggregates)
+        // Second call for enrichChargesWithStatus on page 2 data
+        .mockResolvedValueOnce([]);
+
+      const result = await service.findAllWithStatus(CLUB_ID, {
+        status: 'OPEN',
+        page: 2,
+        limit: 20,
+      });
+
+      expect(result.total).toBe(25);
+      expect(result.data).toHaveLength(5);
+      expect(result.page).toBe(2);
+      expect(result.limit).toBe(20);
+    });
+
+    it('should return correct total when filtering by OVERDUE', async () => {
+      // 2 overdue (past due, unpaid), 1 future OPEN
+      (mockDb.feeCharge.findMany as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce([
+          { id: 'fc-overdue-1', amount: new Decimal('50.00'), dueDate: new Date('2020-01-01') },
+          { id: 'fc-overdue-2', amount: new Decimal('50.00'), dueDate: new Date('2020-06-01') },
+          { id: 'fc-future', amount: new Decimal('50.00'), dueDate: new Date('2099-12-31') },
+        ])
+        .mockResolvedValueOnce([
+          makeFeeCharge({
+            id: 'fc-overdue-1',
+            amount: new Decimal('50.00'),
+            dueDate: new Date('2020-01-01'),
+          }),
+          makeFeeCharge({
+            id: 'fc-overdue-2',
+            amount: new Decimal('50.00'),
+            dueDate: new Date('2020-06-01'),
+          }),
+        ]);
+
+      (mockPrisma.payment.groupBy as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([]);
+
+      const result = await service.findAllWithStatus(CLUB_ID, { status: 'OVERDUE' });
+
+      expect(result.total).toBe(2);
+      expect(result.data).toHaveLength(2);
+    });
   });
 });

--- a/apps/api/src/fees/fee-charges.service.spec.ts
+++ b/apps/api/src/fees/fee-charges.service.spec.ts
@@ -109,6 +109,9 @@ const mockDb = {
   membershipTypeFeeType: {
     findFirst: vi.fn(),
   },
+  feeCategoryMembershipType: {
+    findMany: vi.fn(),
+  },
 };
 
 const mockPrisma = {
@@ -193,6 +196,8 @@ describe('FeeChargesService', () => {
           isOneTime: false,
           isActive: true,
           deletedAt: null,
+          scope: 'ALL_MEMBERS',
+          feeCategoryMembershipTypes: [],
         },
       ];
 
@@ -251,6 +256,202 @@ describe('FeeChargesService', () => {
       const result = await service.previewBillingRun(CLUB_ID, previewDto);
 
       expect(result.existingCharges).toBe(5);
+    });
+
+    it('should return warnings for members without feeTypeId', async () => {
+      const members = [
+        makeMember({ id: 'member-1', memberNumber: 'TSV-001' }),
+        makeMember({
+          id: 'member-no-ft',
+          firstName: 'Anna',
+          lastName: 'Ohne',
+          memberNumber: 'TSV-002',
+          feeTypeId: null,
+          feeType: null,
+        }),
+      ];
+
+      (mockPrisma.club.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeClub());
+      (mockPrisma.member.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(members);
+      (mockDb.feeCategory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+      (mockDb.feeCharge.count as ReturnType<typeof vi.fn>).mockResolvedValue(0);
+
+      const result = await service.previewBillingRun(CLUB_ID, previewDto);
+
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings[0]).toEqual({
+        memberId: 'member-no-ft',
+        memberName: 'Anna Ohne',
+        reason: 'Keine Beitragsart zugewiesen',
+      });
+      expect(result.memberCount).toBe(1);
+      expect(result.exemptions).toBe(1);
+    });
+
+    it('should return warning when no cross-table entry exists for member', async () => {
+      const members = [
+        makeMember({
+          id: 'member-no-entry',
+          firstName: 'Peter',
+          lastName: 'NoEntry',
+          memberNumber: 'TSV-050',
+          feeTypeId: 'ft-unknown',
+          feeType: { id: 'ft-unknown', name: 'Sondertarif' },
+        }),
+      ];
+
+      (mockPrisma.club.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeClub());
+      (mockPrisma.member.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(members);
+      (mockDb.feeCategory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+      (mockDb.feeCharge.count as ReturnType<typeof vi.fn>).mockResolvedValue(0);
+      // No cross-table entry for ft-unknown
+      (mockDb.membershipTypeFeeType.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+      const result = await service.previewBillingRun(CLUB_ID, previewDto);
+
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings[0]!.reason).toContain('Kein Betrag in der Beitragstabelle');
+      expect(result.memberCount).toBe(0);
+    });
+
+    it('should apply FeeCategory with scope ALL_MEMBERS to all members', async () => {
+      const members = [
+        makeMember({ id: 'member-1', memberNumber: 'TSV-001' }),
+        makeMember({
+          id: 'member-2',
+          firstName: 'Anna',
+          memberNumber: 'TSV-002',
+          membershipPeriods: [
+            {
+              id: 'mp-2',
+              joinDate: new Date('2020-01-01'),
+              leaveDate: null,
+              membershipTypeId: 'mt-2',
+              membershipType: { id: 'mt-2', name: 'Passives Mitglied' },
+            },
+          ],
+        }),
+      ];
+      const categories = [
+        {
+          id: 'cat-all',
+          name: 'Vereinszeitung',
+          amount: new Decimal('10.00'),
+          billingInterval: 'ANNUALLY',
+          isActive: true,
+          deletedAt: null,
+          scope: 'ALL_MEMBERS',
+          feeCategoryMembershipTypes: [],
+        },
+      ];
+
+      (mockPrisma.club.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeClub());
+      (mockPrisma.member.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(members);
+      (mockDb.feeCategory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(categories);
+      (mockDb.feeCharge.count as ReturnType<typeof vi.fn>).mockResolvedValue(0);
+      // Both members get cross-table entry
+      (mockDb.membershipTypeFeeType.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'mtft-1',
+        membershipTypeId: 'mt-1',
+        feeTypeId: 'ft-1',
+        amount: new Decimal('120.00'),
+        billingInterval: 'ANNUALLY',
+      });
+
+      const result = await service.previewBillingRun(CLUB_ID, previewDto);
+
+      // 2 base + 2 category = 4 charges
+      expect(result.chargeCount).toBe(4);
+      const catBreakdown = result.breakdown.find((b) => b.membershipType === 'Vereinszeitung');
+      expect(catBreakdown).toEqual({
+        membershipType: 'Vereinszeitung',
+        count: 2,
+        subtotal: '20.00',
+      });
+    });
+
+    it('should apply FeeCategory with scope BY_MEMBERSHIP_TYPE only to matching members', async () => {
+      const members = [
+        makeMember({ id: 'member-1', memberNumber: 'TSV-001' }), // mt-1 (Ordentlich)
+        makeMember({
+          id: 'member-2',
+          firstName: 'Anna',
+          memberNumber: 'TSV-002',
+          membershipPeriods: [
+            {
+              id: 'mp-2',
+              joinDate: new Date('2020-01-01'),
+              leaveDate: null,
+              membershipTypeId: 'mt-2',
+              membershipType: { id: 'mt-2', name: 'Passives Mitglied' },
+            },
+          ],
+        }),
+      ];
+      const categories = [
+        {
+          id: 'cat-mt',
+          name: 'Tennisabteilung',
+          amount: new Decimal('50.00'),
+          billingInterval: 'ANNUALLY',
+          isActive: true,
+          deletedAt: null,
+          scope: 'BY_MEMBERSHIP_TYPE',
+          feeCategoryMembershipTypes: [
+            { id: 'fcmt-1', feeCategoryId: 'cat-mt', membershipTypeId: 'mt-1' },
+          ],
+        },
+      ];
+
+      (mockPrisma.club.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeClub());
+      (mockPrisma.member.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(members);
+      (mockDb.feeCategory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(categories);
+      (mockDb.feeCharge.count as ReturnType<typeof vi.fn>).mockResolvedValue(0);
+      (mockDb.membershipTypeFeeType.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'mtft-1',
+        membershipTypeId: 'mt-1',
+        feeTypeId: 'ft-1',
+        amount: new Decimal('120.00'),
+        billingInterval: 'ANNUALLY',
+      });
+
+      const result = await service.previewBillingRun(CLUB_ID, previewDto);
+
+      // 2 base + 1 category (only member-1 matches mt-1) = 3 charges
+      expect(result.chargeCount).toBe(3);
+      const catBreakdown = result.breakdown.find((b) => b.membershipType === 'Tennisabteilung');
+      expect(catBreakdown).toEqual({
+        membershipType: 'Tennisabteilung',
+        count: 1,
+        subtotal: '50.00',
+      });
+    });
+
+    it('should skip FeeCategory with scope INDIVIDUAL (only via override)', async () => {
+      const members = [makeMember({ id: 'member-1', memberNumber: 'TSV-001' })];
+      const categories = [
+        {
+          id: 'cat-indiv',
+          name: 'Sonderbeitrag',
+          amount: new Decimal('25.00'),
+          billingInterval: 'ANNUALLY',
+          isActive: true,
+          deletedAt: null,
+          scope: 'INDIVIDUAL',
+          feeCategoryMembershipTypes: [],
+        },
+      ];
+
+      (mockPrisma.club.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeClub());
+      (mockPrisma.member.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(members);
+      (mockDb.feeCategory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(categories);
+      (mockDb.feeCharge.count as ReturnType<typeof vi.fn>).mockResolvedValue(0);
+
+      const result = await service.previewBillingRun(CLUB_ID, previewDto);
+
+      // Only base fee, no category charge (INDIVIDUAL skipped)
+      expect(result.chargeCount).toBe(1);
+      expect(result.breakdown.find((b) => b.membershipType === 'Sonderbeitrag')).toBeUndefined();
     });
   });
 
@@ -420,6 +621,34 @@ describe('FeeChargesService', () => {
       // Only member with feeTypeId should be charged
       expect(capturedData).toHaveLength(1);
       expect((capturedData[0] as { memberId: string }).memberId).toBe('member-with');
+    });
+
+    it('should include feeTypeId in charge data', async () => {
+      const members = [makeMember()];
+
+      (mockPrisma.club.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeClub());
+      (mockPrisma.member.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(members);
+      (mockDb.feeCategory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+      let capturedData: unknown[] = [];
+      (mockPrisma.$transaction as ReturnType<typeof vi.fn>).mockImplementation(
+        async (fn: (tx: unknown) => Promise<unknown>) => {
+          const txClient = {
+            feeCharge: {
+              createMany: vi.fn().mockImplementation(({ data }: { data: unknown[] }) => {
+                capturedData = data;
+                return { count: data.length };
+              }),
+            },
+          };
+          return fn(txClient);
+        }
+      );
+
+      await service.executeBillingRun(CLUB_ID, confirmDto);
+
+      expect(capturedData).toHaveLength(1);
+      expect((capturedData[0] as { feeTypeId: string }).feeTypeId).toBe('ft-1');
     });
 
     it('should skip duplicates via createMany skipDuplicates (idempotent)', async () => {

--- a/apps/api/src/fees/fee-charges.service.spec.ts
+++ b/apps/api/src/fees/fee-charges.service.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ConflictException } from '@nestjs/common';
 import { FeeChargesService } from './fee-charges.service.js';
 import type { PrismaService } from '../prisma/prisma.service.js';
 import { Prisma } from '../../../../prisma/generated/client/index.js';
@@ -141,6 +142,8 @@ describe('FeeChargesService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     (mockPrisma.forClub as ReturnType<typeof vi.fn>).mockReturnValue(mockDb);
+    // Default: no existing charges for the period (executeBillingRun re-bill guard)
+    (mockDb.feeCharge.count as ReturnType<typeof vi.fn>).mockResolvedValue(0);
     // Default cross-table entry: mt-1 x ft-1 = 120.00 ANNUALLY
     (mockDb.membershipTypeFeeType.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue({
       id: 'mtft-1',
@@ -218,11 +221,17 @@ describe('FeeChargesService', () => {
       const baseFee = result.breakdown.find((b) => b.membershipType === 'Ordentliches Mitglied');
       const catFee = result.breakdown.find((b) => b.membershipType === 'Tennisabteilung');
       expect(baseFee).toEqual({
+        kind: 'membershipType',
         membershipType: 'Ordentliches Mitglied',
         count: 2,
         subtotal: '240.00',
       });
-      expect(catFee).toEqual({ membershipType: 'Tennisabteilung', count: 2, subtotal: '100.00' });
+      expect(catFee).toEqual({
+        kind: 'category',
+        membershipType: 'Tennisabteilung',
+        count: 2,
+        subtotal: '100.00',
+      });
     });
 
     it('should exclude exempt member: memberCount=2, exemptions=1', async () => {
@@ -364,6 +373,7 @@ describe('FeeChargesService', () => {
       expect(result.chargeCount).toBe(4);
       const catBreakdown = result.breakdown.find((b) => b.membershipType === 'Vereinszeitung');
       expect(catBreakdown).toEqual({
+        kind: 'category',
         membershipType: 'Vereinszeitung',
         count: 2,
         subtotal: '20.00',
@@ -421,6 +431,7 @@ describe('FeeChargesService', () => {
       expect(result.chargeCount).toBe(3);
       const catBreakdown = result.breakdown.find((b) => b.membershipType === 'Tennisabteilung');
       expect(catBreakdown).toEqual({
+        kind: 'category',
         membershipType: 'Tennisabteilung',
         count: 1,
         subtotal: '50.00',
@@ -679,6 +690,58 @@ describe('FeeChargesService', () => {
 
       expect(skipDuplicatesUsed).toBe(true);
     });
+
+    // ─── WR-01/02: reject re-billing a period that already has charges ──
+
+    it('should throw ConflictException when charges already exist for the period (WR-01/02)', async () => {
+      const members = [makeMember()];
+
+      (mockPrisma.club.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeClub());
+      (mockPrisma.member.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(members);
+      (mockDb.feeCategory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+      // A previous run already created charges for this exact period
+      (mockDb.feeCharge.count as ReturnType<typeof vi.fn>).mockResolvedValue(3);
+
+      const txSpy = vi.fn();
+      (mockPrisma.$transaction as ReturnType<typeof vi.fn>).mockImplementation(txSpy);
+
+      await expect(service.executeBillingRun(CLUB_ID, confirmDto)).rejects.toBeInstanceOf(
+        ConflictException
+      );
+      // Guard must run before any write
+      expect(txSpy).not.toHaveBeenCalled();
+      expect(mockDb.feeCharge.count).toHaveBeenCalledWith({
+        where: {
+          deletedAt: null,
+          periodStart: new Date(confirmDto.periodStart),
+          periodEnd: new Date(confirmDto.periodEnd),
+        },
+      });
+    });
+
+    it('should proceed and create charges when no existing charges for the period (WR-01/02)', async () => {
+      const members = [makeMember()];
+
+      (mockPrisma.club.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeClub());
+      (mockPrisma.member.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(members);
+      (mockDb.feeCategory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+      (mockDb.feeCharge.count as ReturnType<typeof vi.fn>).mockResolvedValue(0);
+      (mockPrisma.$transaction as ReturnType<typeof vi.fn>).mockImplementation(
+        async (fn: (tx: unknown) => Promise<unknown>) => {
+          const txClient = {
+            feeCharge: {
+              createMany: vi.fn().mockResolvedValue({ count: 1 }),
+            },
+          };
+          return fn(txClient);
+        }
+      );
+
+      const result = await service.executeBillingRun(CLUB_ID, confirmDto);
+
+      expect(result.chargesCreated).toBe(1);
+      expect(mockPrisma.$transaction).toHaveBeenCalled();
+    });
   });
 
   // ─── findAllWithStatus ──────────────────────────────────────────────
@@ -877,6 +940,142 @@ describe('FeeChargesService', () => {
 
       expect(result.total).toBe(2);
       expect(result.data).toHaveLength(2);
+    });
+  });
+
+  // ─── Pro-rata boundary behavior (WR-03) ─────────────────────────────
+  // Locks in the documented calendar-month-granular rule: day-of-month is ignored,
+  // a member joining any day of a month is treated as joining that whole month.
+
+  describe('pro-rata boundaries (WR-03)', () => {
+    const confirmDto = {
+      periodStart: '2026-01-01',
+      periodEnd: '2026-12-31',
+      billingInterval: 'ANNUALLY' as const,
+      dueDate: '2026-02-15',
+    };
+
+    // Runs a billing execute for a single member with the given join date and
+    // returns the produced charge amount as a fixed-2 string (null if no charge).
+    async function billOne(joinDate: string): Promise<string | null> {
+      const members = [
+        makeMember({
+          id: 'member-prorata',
+          membershipPeriods: [
+            {
+              id: 'mp-prorata',
+              joinDate: new Date(joinDate),
+              leaveDate: null,
+              membershipTypeId: 'mt-1',
+              membershipType: { id: 'mt-1', name: 'Ordentliches Mitglied' },
+            },
+          ],
+        }),
+      ];
+
+      (mockPrisma.club.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(
+        makeClub({ proRataMode: 'MONTHLY_PRO_RATA' })
+      );
+      (mockPrisma.member.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(members);
+      (mockDb.feeCategory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+      (mockDb.feeCharge.count as ReturnType<typeof vi.fn>).mockResolvedValue(0);
+
+      let capturedData: unknown[] = [];
+      (mockPrisma.$transaction as ReturnType<typeof vi.fn>).mockImplementation(
+        async (fn: (tx: unknown) => Promise<unknown>) => {
+          const txClient = {
+            feeCharge: {
+              createMany: vi.fn().mockImplementation(({ data }: { data: unknown[] }) => {
+                capturedData = data;
+                return { count: data.length };
+              }),
+            },
+          };
+          return fn(txClient);
+        }
+      );
+
+      await service.executeBillingRun(CLUB_ID, confirmDto);
+
+      if (capturedData.length === 0) return null;
+      return (capturedData[0] as { amount: Prisma.Decimal }).amount.toFixed(2);
+    }
+
+    it('charges the full amount when joining exactly on periodStart', async () => {
+      expect(await billOne('2026-01-01')).toBe('120.00');
+    });
+
+    it('charges the full amount when joining before periodStart', async () => {
+      expect(await billOne('2020-06-15')).toBe('120.00');
+    });
+
+    it('charges zero when joining after periodEnd', async () => {
+      expect(await billOne('2027-03-01')).toBe('0.00');
+    });
+
+    it('ignores day-of-month: 1st vs last day of the same month yield the same amount', async () => {
+      // July is month index 6 -> monthsElapsed=6 -> 120 * 6/12 = 60.00 for both
+      const firstOfJuly = await billOne('2026-07-01');
+      const lastOfJuly = await billOne('2026-07-31');
+      expect(firstOfJuly).toBe('60.00');
+      expect(lastOfJuly).toBe('60.00');
+      expect(firstOfJuly).toBe(lastOfJuly);
+    });
+
+    it('charges the correct fraction for a mid-period join month (April)', async () => {
+      // April is month index 3 -> monthsElapsed=3 -> remaining 9 -> 120 * 9/12 = 90.00
+      expect(await billOne('2026-04-10')).toBe('90.00');
+    });
+  });
+
+  // ─── Breakdown kind / name collision (WR-04) ────────────────────────
+
+  describe('breakdown kind (WR-04)', () => {
+    const previewDto = {
+      periodStart: '2026-01-01',
+      periodEnd: '2026-12-31',
+      billingInterval: 'ANNUALLY' as const,
+    };
+
+    it('does not merge a category that shares a name with a membership type', async () => {
+      // Membership type and category both named "Ordentliches Mitglied"
+      const members = [makeMember({ id: 'member-1', memberNumber: 'TSV-001' })];
+      const categories = [
+        {
+          id: 'cat-collide',
+          name: 'Ordentliches Mitglied',
+          amount: new Decimal('30.00'),
+          billingInterval: 'ANNUALLY',
+          isActive: true,
+          deletedAt: null,
+          scope: 'ALL_MEMBERS',
+          feeCategoryMembershipTypes: [],
+        },
+      ];
+
+      (mockPrisma.club.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeClub());
+      (mockPrisma.member.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(members);
+      (mockDb.feeCategory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(categories);
+      (mockDb.feeCharge.count as ReturnType<typeof vi.fn>).mockResolvedValue(0);
+
+      const result = await service.previewBillingRun(CLUB_ID, previewDto);
+
+      // Two distinct breakdown rows despite the shared name
+      expect(result.breakdown).toHaveLength(2);
+      const baseRow = result.breakdown.find((b) => b.kind === 'membershipType');
+      const catRow = result.breakdown.find((b) => b.kind === 'category');
+      expect(baseRow).toEqual({
+        kind: 'membershipType',
+        membershipType: 'Ordentliches Mitglied',
+        count: 1,
+        subtotal: '120.00',
+      });
+      expect(catRow).toEqual({
+        kind: 'category',
+        membershipType: 'Ordentliches Mitglied',
+        count: 1,
+        subtotal: '30.00',
+      });
     });
   });
 });

--- a/apps/api/src/fees/fee-charges.service.spec.ts
+++ b/apps/api/src/fees/fee-charges.service.spec.ts
@@ -20,6 +20,8 @@ function makeMember(overrides: Record<string, unknown> = {}) {
     householdId: null,
     householdRole: null,
     deletedAt: null,
+    feeTypeId: 'ft-1',
+    feeType: { id: 'ft-1', name: 'Einzelbeitrag', isActive: true },
     membershipPeriods: [
       {
         id: 'mp-1',
@@ -29,8 +31,6 @@ function makeMember(overrides: Record<string, unknown> = {}) {
         membershipType: {
           id: 'mt-1',
           name: 'Ordentliches Mitglied',
-          feeAmount: new Decimal('120.00'),
-          billingInterval: 'ANNUALLY',
         },
       },
     ],
@@ -63,9 +63,7 @@ function makeClub(overrides: Record<string, unknown> = {}) {
   return {
     id: CLUB_ID,
     proRataMode: 'FULL',
-    householdFeeMode: 'NONE',
-    householdDiscountPercent: null,
-    householdFlatAmount: null,
+    householdBillingModel: 'NONE',
     ...overrides,
   };
 }
@@ -108,6 +106,9 @@ const mockDb = {
     count: vi.fn(),
     createMany: vi.fn(),
   },
+  membershipTypeFeeType: {
+    findFirst: vi.fn(),
+  },
 };
 
 const mockPrisma = {
@@ -137,6 +138,14 @@ describe('FeeChargesService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     (mockPrisma.forClub as ReturnType<typeof vi.fn>).mockReturnValue(mockDb);
+    // Default cross-table entry: mt-1 x ft-1 = 120.00 ANNUALLY
+    (mockDb.membershipTypeFeeType.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: 'mtft-1',
+      membershipTypeId: 'mt-1',
+      feeTypeId: 'ft-1',
+      amount: new Decimal('120.00'),
+      billingInterval: 'ANNUALLY',
+    });
     service = new FeeChargesService(mockPrisma);
   });
 
@@ -164,9 +173,51 @@ describe('FeeChargesService', () => {
       const result = await service.previewBillingRun(CLUB_ID, previewDto);
 
       expect(result.memberCount).toBe(3);
+      expect(result.chargeCount).toBe(3);
       expect(result.totalAmount).toBe('360.00');
       expect(result.exemptions).toBe(0);
       expect(result.existingCharges).toBe(0);
+    });
+
+    it('should include category fees in chargeCount, totalAmount, and breakdown', async () => {
+      const members = [
+        makeMember({ id: 'member-1', memberNumber: 'TSV-001' }),
+        makeMember({ id: 'member-2', firstName: 'Anna', memberNumber: 'TSV-002' }),
+      ];
+      const categories = [
+        {
+          id: 'cat-1',
+          name: 'Tennisabteilung',
+          amount: new Decimal('50.00'),
+          billingInterval: 'ANNUALLY',
+          isOneTime: false,
+          isActive: true,
+          deletedAt: null,
+        },
+      ];
+
+      (mockPrisma.club.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeClub());
+      (mockPrisma.member.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(members);
+      (mockDb.feeCategory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(categories);
+      (mockDb.feeCharge.count as ReturnType<typeof vi.fn>).mockResolvedValue(0);
+
+      const result = await service.previewBillingRun(CLUB_ID, previewDto);
+
+      // 2 members × (1 base + 1 category) = 4 charges
+      expect(result.memberCount).toBe(2);
+      expect(result.chargeCount).toBe(4);
+      // 2 × 120 + 2 × 50 = 340
+      expect(result.totalAmount).toBe('340.00');
+      // Breakdown: base fee type + category
+      expect(result.breakdown).toHaveLength(2);
+      const baseFee = result.breakdown.find((b) => b.membershipType === 'Ordentliches Mitglied');
+      const catFee = result.breakdown.find((b) => b.membershipType === 'Tennisabteilung');
+      expect(baseFee).toEqual({
+        membershipType: 'Ordentliches Mitglied',
+        count: 2,
+        subtotal: '240.00',
+      });
+      expect(catFee).toEqual({ membershipType: 'Tennisabteilung', count: 2, subtotal: '100.00' });
     });
 
     it('should exclude exempt member: memberCount=2, exemptions=1', async () => {
@@ -184,6 +235,7 @@ describe('FeeChargesService', () => {
       const result = await service.previewBillingRun(CLUB_ID, previewDto);
 
       expect(result.memberCount).toBe(2);
+      expect(result.chargeCount).toBe(2);
       expect(result.exemptions).toBe(1);
       expect(result.totalAmount).toBe('240.00');
     });
@@ -253,8 +305,6 @@ describe('FeeChargesService', () => {
               membershipType: {
                 id: 'mt-1',
                 name: 'Ordentliches Mitglied',
-                feeAmount: new Decimal('120.00'),
-                billingInterval: 'ANNUALLY',
               },
             },
           ],
@@ -330,30 +380,23 @@ describe('FeeChargesService', () => {
       expect(charge.discountReason).toContain('Individueller Betrag');
     });
 
-    it('should apply household PERCENTAGE discount and populate discountAmount', async () => {
-      const headMember = makeMember({
-        id: 'member-head',
+    it('should exclude members without feeTypeId (D-17)', async () => {
+      const memberWithFeeType = makeMember({
+        id: 'member-with',
         memberNumber: 'TSV-020',
-        householdId: 'hh-1',
-        householdRole: 'HEAD',
       });
-      const spouseMember = makeMember({
-        id: 'member-spouse',
+      const memberWithoutFeeType = makeMember({
+        id: 'member-without',
         firstName: 'Anna',
         memberNumber: 'TSV-021',
-        householdId: 'hh-1',
-        householdRole: 'SPOUSE',
+        feeTypeId: null,
+        feeType: null,
       });
 
-      (mockPrisma.club.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(
-        makeClub({
-          householdFeeMode: 'PERCENTAGE',
-          householdDiscountPercent: 50,
-        })
-      );
+      (mockPrisma.club.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeClub());
       (mockPrisma.member.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
-        headMember,
-        spouseMember,
+        memberWithFeeType,
+        memberWithoutFeeType,
       ]);
       (mockDb.feeCategory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
 
@@ -374,19 +417,9 @@ describe('FeeChargesService', () => {
 
       await service.executeBillingRun(CLUB_ID, confirmDto);
 
-      // HEAD pays full 120, SPOUSE pays 60 (50% discount)
-      const headCharge = capturedData.find(
-        (c: unknown) => (c as { memberId: string }).memberId === 'member-head'
-      ) as { amount: Prisma.Decimal; discountAmount: Prisma.Decimal | null };
-      const spouseCharge = capturedData.find(
-        (c: unknown) => (c as { memberId: string }).memberId === 'member-spouse'
-      ) as { amount: Prisma.Decimal; discountAmount: Prisma.Decimal; discountReason: string };
-
-      expect(headCharge.amount.toFixed(2)).toBe('120.00');
-      expect(headCharge.discountAmount).toBeNull();
-      expect(spouseCharge.amount.toFixed(2)).toBe('60.00');
-      expect(spouseCharge.discountAmount.toFixed(2)).toBe('60.00');
-      expect(spouseCharge.discountReason).toContain('Haushaltsrabatt');
+      // Only member with feeTypeId should be charged
+      expect(capturedData).toHaveLength(1);
+      expect((capturedData[0] as { memberId: string }).memberId).toBe('member-with');
     });
 
     it('should skip duplicates via createMany skipDuplicates (idempotent)', async () => {

--- a/apps/api/src/fees/fee-charges.service.ts
+++ b/apps/api/src/fees/fee-charges.service.ts
@@ -89,7 +89,7 @@ export class FeeChargesService {
    * Execute billing run and create FeeCharge records in a transaction.
    * Uses createMany with skipDuplicates for idempotency.
    */
-  async executeBillingRun(clubId: string, dto: BillingRunConfirmDto, _userId: string) {
+  async executeBillingRun(clubId: string, dto: BillingRunConfirmDto) {
     if (new Date(dto.periodStart) >= new Date(dto.periodEnd)) {
       throw new BadRequestException('Periodenbeginn muss vor dem Periodenende liegen');
     }
@@ -130,6 +130,11 @@ export class FeeChargesService {
   /**
    * Find all fee charges with computed payment status using SQL-level aggregation.
    * Returns paginated results with OPEN/PARTIAL/PAID status and overdue flag.
+   *
+   * Note: OVERDUE is a computed status (dueDate < today && not fully paid), so
+   * filtering by OVERDUE happens post-query. This means `total` reflects the
+   * unfiltered count and pages may appear partially empty when the OVERDUE filter
+   * is active. A proper fix requires SQL-level status computation.
    */
   async findAllWithStatus(clubId: string, query: FeeChargeQueryDto) {
     const db = this.prisma.forClub(clubId);

--- a/apps/api/src/fees/fee-charges.service.ts
+++ b/apps/api/src/fees/fee-charges.service.ts
@@ -96,7 +96,14 @@ export class FeeChargesService {
     const totalAmount = chargeDataArray.reduce((sum, c) => sum.plus(c.amount), ZERO);
 
     const result = await this.prisma.$transaction(
-      async (tx: { feeCharge: { createMany: (args: { data: ChargeData[]; skipDuplicates: boolean }) => Promise<{ count: number }> } }) => {
+      async (tx: {
+        feeCharge: {
+          createMany: (args: {
+            data: ChargeData[];
+            skipDuplicates: boolean;
+          }) => Promise<{ count: number }>;
+        };
+      }) => {
         return tx.feeCharge.createMany({
           data: chargeDataArray,
           skipDuplicates: true,
@@ -161,10 +168,12 @@ export class FeeChargesService {
         : [];
 
     const paymentSumMap = new Map(
-      paymentAggregates.map((pa: { feeChargeId: string; _sum: { amount: Prisma.Decimal | null } }) => [
-        pa.feeChargeId,
-        pa._sum.amount ?? ZERO,
-      ])
+      paymentAggregates.map(
+        (pa: { feeChargeId: string; _sum: { amount: Prisma.Decimal | null } }) => [
+          pa.feeChargeId,
+          pa._sum.amount ?? ZERO,
+        ]
+      )
     );
 
     const today = new Date();
@@ -173,7 +182,10 @@ export class FeeChargesService {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let enrichedCharges = charges.map((charge: any) => {
       const paidAmount = paymentSumMap.get(charge.id) ?? ZERO;
-      const amount = charge.amount instanceof Prisma.Decimal ? charge.amount : new Prisma.Decimal(String(charge.amount));
+      const amount =
+        charge.amount instanceof Prisma.Decimal
+          ? charge.amount
+          : new Prisma.Decimal(String(charge.amount));
       const status = paidAmount.gte(amount) ? 'PAID' : paidAmount.gt(ZERO) ? 'PARTIAL' : 'OPEN';
       const dueDate = new Date(charge.dueDate);
       dueDate.setHours(0, 0, 0, 0);
@@ -194,11 +206,22 @@ export class FeeChargesService {
         remainingAmount: roundMoney(remainingAmount).toFixed(DECIMAL_PLACES),
         status,
         isOverdue,
-        periodStart: charge.periodStart instanceof Date ? charge.periodStart.toISOString().split('T')[0] : charge.periodStart,
-        periodEnd: charge.periodEnd instanceof Date ? charge.periodEnd.toISOString().split('T')[0] : charge.periodEnd,
-        dueDate: charge.dueDate instanceof Date ? charge.dueDate.toISOString().split('T')[0] : charge.dueDate,
-        createdAt: charge.createdAt instanceof Date ? charge.createdAt.toISOString() : charge.createdAt,
-        updatedAt: charge.updatedAt instanceof Date ? charge.updatedAt.toISOString() : charge.updatedAt,
+        periodStart:
+          charge.periodStart instanceof Date
+            ? charge.periodStart.toISOString().split('T')[0]
+            : charge.periodStart,
+        periodEnd:
+          charge.periodEnd instanceof Date
+            ? charge.periodEnd.toISOString().split('T')[0]
+            : charge.periodEnd,
+        dueDate:
+          charge.dueDate instanceof Date
+            ? charge.dueDate.toISOString().split('T')[0]
+            : charge.dueDate,
+        createdAt:
+          charge.createdAt instanceof Date ? charge.createdAt.toISOString() : charge.createdAt,
+        updatedAt:
+          charge.updatedAt instanceof Date ? charge.updatedAt.toISOString() : charge.updatedAt,
       };
     });
 
@@ -206,10 +229,13 @@ export class FeeChargesService {
     if (query.status) {
       if (query.status === 'OVERDUE') {
         enrichedCharges = enrichedCharges.filter(
-          (c: { isOverdue: boolean; status: string }) => c.isOverdue && (c.status === 'OPEN' || c.status === 'PARTIAL')
+          (c: { isOverdue: boolean; status: string }) =>
+            c.isOverdue && (c.status === 'OPEN' || c.status === 'PARTIAL')
         );
       } else {
-        enrichedCharges = enrichedCharges.filter((c: { status: string }) => c.status === query.status);
+        enrichedCharges = enrichedCharges.filter(
+          (c: { status: string }) => c.status === query.status
+        );
       }
     }
 
@@ -390,7 +416,12 @@ export class FeeChargesService {
         baseFee = roundMoney(baseFee);
 
         const typeName = membershipType.name;
-        const description = this.generateChargeDescription(typeName, periodStart, periodEnd, dto.billingInterval);
+        const description = this.generateChargeDescription(
+          typeName,
+          periodStart,
+          periodEnd,
+          dto.billingInterval
+        );
 
         charges.push({
           clubId,
@@ -480,7 +511,7 @@ export class FeeChargesService {
     joinDate: Date,
     periodStart: Date,
     periodEnd: Date,
-    billingInterval: string
+    _billingInterval: string
   ): Prisma.Decimal {
     const join = new Date(joinDate);
 
@@ -507,9 +538,7 @@ export class FeeChargesService {
 
     // Pro-rata: feeAmount * remainingMonths / totalMonths
     return roundMoney(
-      feeAmount
-        .mul(new Prisma.Decimal(remainingMonths))
-        .div(new Prisma.Decimal(totalMonths))
+      feeAmount.mul(new Prisma.Decimal(remainingMonths)).div(new Prisma.Decimal(totalMonths))
     );
   }
 

--- a/apps/api/src/fees/fee-charges.service.ts
+++ b/apps/api/src/fees/fee-charges.service.ts
@@ -1,0 +1,551 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { Prisma } from '../../../../prisma/generated/client/index.js';
+import type { BillingRunPreviewDto } from './dto/billing-run-preview.dto.js';
+import type { BillingRunConfirmDto } from './dto/billing-run-confirm.dto.js';
+import type { FeeChargeQueryDto } from './dto/fee-charge-query.dto.js';
+
+// Explicit rounding strategy for all money calculations
+// HALF_UP is the standard banker's rounding: 0.5 rounds up to 1
+const ROUNDING_MODE = Prisma.Decimal.ROUND_HALF_UP;
+const DECIMAL_PLACES = 2;
+
+function roundMoney(value: Prisma.Decimal): Prisma.Decimal {
+  return value.toDecimalPlaces(DECIMAL_PLACES, ROUNDING_MODE);
+}
+
+const ZERO = new Prisma.Decimal(0);
+
+/** Charge data prepared from billing calculation */
+interface ChargeData {
+  clubId: string;
+  memberId: string;
+  feeCategoryId: string | null;
+  membershipTypeId: string | null;
+  description: string;
+  periodStart: Date;
+  periodEnd: Date;
+  amount: Prisma.Decimal;
+  dueDate: Date;
+  discountAmount: Prisma.Decimal | null;
+  discountReason: string | null;
+}
+
+/** Breakdown entry per membership type for preview */
+interface BreakdownEntry {
+  membershipType: string;
+  count: number;
+  subtotal: Prisma.Decimal;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type MemberWithRelations = any;
+
+@Injectable()
+export class FeeChargesService {
+  constructor(private prisma: PrismaService) {}
+
+  // ─── Billing Run: Preview ───────────────────────────────────────────
+
+  /**
+   * Preview billing run without side effects.
+   * Calculates what each active member owes for the specified period.
+   */
+  async previewBillingRun(clubId: string, dto: BillingRunPreviewDto) {
+    const { charges, exemptions, breakdown } = await this.calculateBillingCharges(clubId, dto);
+
+    // Check for existing charges for duplicate detection
+    const db = this.prisma.forClub(clubId);
+    const existingCharges = await db.feeCharge.count({
+      where: {
+        deletedAt: null,
+        periodStart: new Date(dto.periodStart),
+        periodEnd: new Date(dto.periodEnd),
+      },
+    });
+
+    const totalAmount = charges.reduce((sum, c) => sum.plus(c.amount), ZERO);
+
+    return {
+      memberCount: charges.length,
+      totalAmount: roundMoney(totalAmount).toFixed(DECIMAL_PLACES),
+      exemptions,
+      breakdown: breakdown.map((b) => ({
+        membershipType: b.membershipType,
+        count: b.count,
+        subtotal: roundMoney(b.subtotal).toFixed(DECIMAL_PLACES),
+      })),
+      existingCharges,
+    };
+  }
+
+  // ─── Billing Run: Execute ───────────────────────────────────────────
+
+  /**
+   * Execute billing run and create FeeCharge records in a transaction.
+   * Uses createMany with skipDuplicates for idempotency.
+   */
+  async executeBillingRun(clubId: string, dto: BillingRunConfirmDto, _userId: string) {
+    const { charges } = await this.calculateBillingCharges(clubId, dto);
+
+    const chargeDataArray: ChargeData[] = charges.map((c) => ({
+      ...c,
+      dueDate: new Date(dto.dueDate),
+    }));
+
+    const totalAmount = chargeDataArray.reduce((sum, c) => sum.plus(c.amount), ZERO);
+
+    const result = await this.prisma.$transaction(
+      async (tx: { feeCharge: { createMany: (args: { data: ChargeData[]; skipDuplicates: boolean }) => Promise<{ count: number }> } }) => {
+        return tx.feeCharge.createMany({
+          data: chargeDataArray,
+          skipDuplicates: true,
+        });
+      }
+    );
+
+    return {
+      chargesCreated: result.count,
+      totalAmount: roundMoney(totalAmount).toFixed(DECIMAL_PLACES),
+    };
+  }
+
+  // ─── FeeCharge Queries ──────────────────────────────────────────────
+
+  /**
+   * Find all fee charges with computed payment status using SQL-level aggregation.
+   * Returns paginated results with OPEN/PARTIAL/PAID status and overdue flag.
+   */
+  async findAllWithStatus(clubId: string, query: FeeChargeQueryDto) {
+    const db = this.prisma.forClub(clubId);
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 20;
+    const skip = (page - 1) * limit;
+
+    // Build filter conditions
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const where: any = {
+      deletedAt: null,
+      ...(query.memberId && { memberId: query.memberId }),
+      ...(query.periodStart && { periodStart: { gte: new Date(query.periodStart) } }),
+      ...(query.periodEnd && { periodEnd: { lte: new Date(query.periodEnd) } }),
+    };
+
+    const [charges, total] = await Promise.all([
+      db.feeCharge.findMany({
+        where,
+        include: {
+          member: {
+            select: { id: true, firstName: true, lastName: true, memberNumber: true },
+          },
+        },
+        orderBy: { dueDate: 'desc' },
+        skip,
+        take: limit,
+      }),
+      db.feeCharge.count({ where }),
+    ]);
+
+    // Batch-fetch payment aggregates for all charge IDs (SQL-level aggregation)
+    const chargeIds = charges.map((c: { id: string }) => c.id);
+    const paymentAggregates =
+      chargeIds.length > 0
+        ? await this.prisma.payment.groupBy({
+            by: ['feeChargeId'],
+            where: {
+              feeChargeId: { in: chargeIds },
+              deletedAt: null,
+            },
+            _sum: { amount: true },
+          })
+        : [];
+
+    const paymentSumMap = new Map(
+      paymentAggregates.map((pa: { feeChargeId: string; _sum: { amount: Prisma.Decimal | null } }) => [
+        pa.feeChargeId,
+        pa._sum.amount ?? ZERO,
+      ])
+    );
+
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let enrichedCharges = charges.map((charge: any) => {
+      const paidAmount = paymentSumMap.get(charge.id) ?? ZERO;
+      const amount = charge.amount instanceof Prisma.Decimal ? charge.amount : new Prisma.Decimal(String(charge.amount));
+      const status = paidAmount.gte(amount) ? 'PAID' : paidAmount.gt(ZERO) ? 'PARTIAL' : 'OPEN';
+      const dueDate = new Date(charge.dueDate);
+      dueDate.setHours(0, 0, 0, 0);
+      const isOverdue = status !== 'PAID' && dueDate < today;
+      const remaining = amount.minus(paidAmount);
+      const remainingAmount = remaining.lt(ZERO) ? ZERO : remaining;
+
+      return {
+        ...charge,
+        amount: amount.toFixed(DECIMAL_PLACES),
+        discountAmount: charge.discountAmount
+          ? (charge.discountAmount instanceof Prisma.Decimal
+              ? charge.discountAmount
+              : new Prisma.Decimal(String(charge.discountAmount))
+            ).toFixed(DECIMAL_PLACES)
+          : null,
+        paidAmount: paidAmount.toFixed(DECIMAL_PLACES),
+        remainingAmount: roundMoney(remainingAmount).toFixed(DECIMAL_PLACES),
+        status,
+        isOverdue,
+        periodStart: charge.periodStart instanceof Date ? charge.periodStart.toISOString().split('T')[0] : charge.periodStart,
+        periodEnd: charge.periodEnd instanceof Date ? charge.periodEnd.toISOString().split('T')[0] : charge.periodEnd,
+        dueDate: charge.dueDate instanceof Date ? charge.dueDate.toISOString().split('T')[0] : charge.dueDate,
+        createdAt: charge.createdAt instanceof Date ? charge.createdAt.toISOString() : charge.createdAt,
+        updatedAt: charge.updatedAt instanceof Date ? charge.updatedAt.toISOString() : charge.updatedAt,
+      };
+    });
+
+    // Post-query status filter (OVERDUE is a special computed status)
+    if (query.status) {
+      if (query.status === 'OVERDUE') {
+        enrichedCharges = enrichedCharges.filter(
+          (c: { isOverdue: boolean; status: string }) => c.isOverdue && (c.status === 'OPEN' || c.status === 'PARTIAL')
+        );
+      } else {
+        enrichedCharges = enrichedCharges.filter((c: { status: string }) => c.status === query.status);
+      }
+    }
+
+    return {
+      data: enrichedCharges,
+      total,
+      page,
+      limit,
+    };
+  }
+
+  // ─── findByMember ───────────────────────────────────────────────────
+
+  /**
+   * Find charges for a specific member with computed status.
+   * Used for member detail section.
+   */
+  async findByMember(clubId: string, memberId: string, options?: { limit?: number }) {
+    return this.findAllWithStatus(clubId, {
+      memberId,
+      limit: options?.limit ?? 20,
+    });
+  }
+
+  // ─── Private: Billing Calculation Logic ─────────────────────────────
+
+  /**
+   * Core billing calculation used by both preview and confirm.
+   * Returns charge data, exemption count, and breakdown by membership type.
+   */
+  private async calculateBillingCharges(
+    clubId: string,
+    dto: BillingRunPreviewDto
+  ): Promise<{
+    charges: Omit<ChargeData, 'dueDate'>[];
+    exemptions: number;
+    breakdown: BreakdownEntry[];
+  }> {
+    const db = this.prisma.forClub(clubId);
+
+    // 1. Get club settings
+    const club = await this.prisma.club.findFirst({
+      where: { id: clubId },
+      select: {
+        proRataMode: true,
+        householdFeeMode: true,
+        householdDiscountPercent: true,
+        householdFlatAmount: true,
+      },
+    });
+
+    // 2. Get active members with membership info and overrides
+    const members = await this.prisma.member.findMany({
+      where: {
+        clubId,
+        status: 'ACTIVE',
+        deletedAt: null,
+      },
+      include: {
+        membershipPeriods: {
+          where: { leaveDate: null },
+          include: {
+            membershipType: {
+              select: {
+                id: true,
+                name: true,
+                feeAmount: true,
+                billingInterval: true,
+              },
+            },
+          },
+          orderBy: { joinDate: 'desc' },
+          take: 1,
+        },
+        memberFeeOverrides: true,
+      },
+    });
+
+    // 3. Get active fee categories matching the billing interval
+    const feeCategories = await db.feeCategory.findMany({
+      where: {
+        deletedAt: null,
+        isActive: true,
+        billingInterval: dto.billingInterval,
+      },
+    });
+
+    const periodStart = new Date(dto.periodStart);
+    const periodEnd = new Date(dto.periodEnd);
+
+    const charges: Omit<ChargeData, 'dueDate'>[] = [];
+    let exemptions = 0;
+    const breakdownMap = new Map<string, BreakdownEntry>();
+
+    for (const member of members) {
+      const currentPeriod = member.membershipPeriods[0];
+      if (!currentPeriod?.membershipType) continue;
+
+      const membershipType = currentPeriod.membershipType;
+      const baseFeeOverrides = member.memberFeeOverrides.filter(
+        (o: MemberWithRelations) => o.isBaseFee && !o.feeCategoryId
+      );
+
+      // Check for base fee exemption
+      const isExempt = baseFeeOverrides.some(
+        (o: MemberWithRelations) => o.overrideType === 'EXEMPT'
+      );
+
+      if (isExempt) {
+        exemptions++;
+        continue;
+      }
+
+      // Calculate base fee if membership type has a fee and matches interval
+      if (membershipType.feeAmount && membershipType.billingInterval === dto.billingInterval) {
+        let baseFee = new Prisma.Decimal(membershipType.feeAmount.toString());
+        let discountAmount: Prisma.Decimal | null = null;
+        let discountReason: string | null = null;
+
+        // Check for CUSTOM_AMOUNT override
+        const customOverride = baseFeeOverrides.find(
+          (o: MemberWithRelations) => o.overrideType === 'CUSTOM_AMOUNT'
+        );
+        if (customOverride?.customAmount) {
+          const originalFee = baseFee;
+          baseFee = new Prisma.Decimal(customOverride.customAmount.toString());
+          discountAmount = roundMoney(originalFee.minus(baseFee));
+          discountReason = `Individueller Betrag: ${customOverride.reason ?? ''}`.trim();
+        }
+
+        // Apply pro-rata if configured
+        if (club?.proRataMode === 'MONTHLY_PRO_RATA') {
+          baseFee = this.calculateProRata(
+            baseFee,
+            currentPeriod.joinDate,
+            periodStart,
+            periodEnd,
+            dto.billingInterval
+          );
+          // Recalculate discount if pro-rata was applied and there was a custom override
+          if (customOverride?.customAmount) {
+            const originalProRata = this.calculateProRata(
+              new Prisma.Decimal(membershipType.feeAmount.toString()),
+              currentPeriod.joinDate,
+              periodStart,
+              periodEnd,
+              dto.billingInterval
+            );
+            discountAmount = roundMoney(originalProRata.minus(baseFee));
+          }
+        }
+
+        // Apply household discount
+        if (
+          club?.householdFeeMode === 'PERCENTAGE' &&
+          member.householdId &&
+          member.householdRole &&
+          member.householdRole !== 'HEAD' &&
+          club.householdDiscountPercent
+        ) {
+          const discountPercent = new Prisma.Decimal(club.householdDiscountPercent);
+          const discount = roundMoney(baseFee.mul(discountPercent).div(100));
+          discountAmount = discount;
+          discountReason = `Haushaltsrabatt ${club.householdDiscountPercent}%`;
+          baseFee = roundMoney(baseFee.minus(discount));
+        } else if (
+          club?.householdFeeMode === 'FLAT' &&
+          member.householdId &&
+          member.householdRole === 'HEAD' &&
+          club.householdFlatAmount
+        ) {
+          const flatAmount = new Prisma.Decimal(club.householdFlatAmount.toString());
+          discountAmount = roundMoney(baseFee.minus(flatAmount));
+          discountReason = 'Haushaltspauschale';
+          baseFee = flatAmount;
+        }
+
+        baseFee = roundMoney(baseFee);
+
+        const typeName = membershipType.name;
+        const description = this.generateChargeDescription(typeName, periodStart, periodEnd, dto.billingInterval);
+
+        charges.push({
+          clubId,
+          memberId: member.id,
+          feeCategoryId: null,
+          membershipTypeId: membershipType.id,
+          description,
+          periodStart,
+          periodEnd,
+          amount: baseFee,
+          discountAmount,
+          discountReason,
+        });
+
+        // Track breakdown
+        const existing = breakdownMap.get(typeName);
+        if (existing) {
+          existing.count++;
+          existing.subtotal = existing.subtotal.plus(baseFee);
+        } else {
+          breakdownMap.set(typeName, {
+            membershipType: typeName,
+            count: 1,
+            subtotal: baseFee,
+          });
+        }
+      }
+
+      // Calculate additional category fees
+      for (const category of feeCategories) {
+        const categoryOverride = member.memberFeeOverrides.find(
+          (o: MemberWithRelations) => o.feeCategoryId === category.id
+        );
+        if (categoryOverride?.overrideType === 'EXEMPT') continue;
+
+        let categoryFee = new Prisma.Decimal(category.amount.toString());
+        let catDiscountAmount: Prisma.Decimal | null = null;
+        let catDiscountReason: string | null = null;
+
+        if (categoryOverride?.overrideType === 'CUSTOM_AMOUNT' && categoryOverride.customAmount) {
+          const originalFee = categoryFee;
+          categoryFee = new Prisma.Decimal(categoryOverride.customAmount.toString());
+          catDiscountAmount = roundMoney(originalFee.minus(categoryFee));
+          catDiscountReason = `Individueller Betrag: ${categoryOverride.reason ?? ''}`.trim();
+        }
+
+        categoryFee = roundMoney(categoryFee);
+
+        const description = this.generateChargeDescription(
+          category.name,
+          periodStart,
+          periodEnd,
+          dto.billingInterval
+        );
+
+        charges.push({
+          clubId,
+          memberId: member.id,
+          feeCategoryId: category.id,
+          membershipTypeId: null,
+          description,
+          periodStart,
+          periodEnd,
+          amount: categoryFee,
+          discountAmount: catDiscountAmount,
+          discountReason: catDiscountReason,
+        });
+      }
+    }
+
+    return {
+      charges,
+      exemptions,
+      breakdown: Array.from(breakdownMap.values()),
+    };
+  }
+
+  // ─── Private: Pro-Rata Calculation ──────────────────────────────────
+
+  /**
+   * Calculate pro-rata fee based on member join date vs billing period.
+   * For MONTHLY_PRO_RATA mode with ANNUALLY billing:
+   *   amount = feeAmount * (totalMonths - monthsElapsed) / totalMonths
+   */
+  private calculateProRata(
+    feeAmount: Prisma.Decimal,
+    joinDate: Date,
+    periodStart: Date,
+    periodEnd: Date,
+    billingInterval: string
+  ): Prisma.Decimal {
+    const join = new Date(joinDate);
+
+    // If member joined before the period start, they owe the full amount
+    if (join <= periodStart) {
+      return feeAmount;
+    }
+
+    // If member joined after the period end, they owe nothing
+    if (join > periodEnd) {
+      return ZERO;
+    }
+
+    // Calculate total months in the period (inclusive: Jan-Dec = 12 months)
+    const totalMonths = this.monthDiff(periodStart, periodEnd) + 1;
+
+    // Calculate months elapsed from period start to join date
+    const monthsElapsed = this.monthDiff(periodStart, join);
+
+    // Remaining months
+    const remainingMonths = totalMonths - monthsElapsed;
+
+    if (remainingMonths <= 0) return ZERO;
+
+    // Pro-rata: feeAmount * remainingMonths / totalMonths
+    return roundMoney(
+      feeAmount
+        .mul(new Prisma.Decimal(remainingMonths))
+        .div(new Prisma.Decimal(totalMonths))
+    );
+  }
+
+  /**
+   * Calculate the number of months between two dates (1-indexed from period start).
+   */
+  private monthDiff(start: Date, end: Date): number {
+    return (end.getFullYear() - start.getFullYear()) * 12 + (end.getMonth() - start.getMonth());
+  }
+
+  // ─── Private: Description Generator ─────────────────────────────────
+
+  /**
+   * Generate a human-readable description for a fee charge.
+   */
+  private generateChargeDescription(
+    name: string,
+    periodStart: Date,
+    periodEnd: Date,
+    billingInterval: string
+  ): string {
+    const year = periodStart.getFullYear();
+
+    switch (billingInterval) {
+      case 'ANNUALLY':
+        return `${name} ${year}`;
+      case 'QUARTERLY': {
+        const quarter = Math.floor(periodStart.getMonth() / 3) + 1;
+        return `${name} Q${quarter}/${year}`;
+      }
+      case 'MONTHLY': {
+        const month = periodStart.toLocaleString('de-DE', { month: 'long' });
+        return `${name} ${month} ${year}`;
+      }
+      default:
+        return `${name} ${year}`;
+    }
+  }
+}

--- a/apps/api/src/fees/fee-charges.service.ts
+++ b/apps/api/src/fees/fee-charges.service.ts
@@ -131,16 +131,15 @@ export class FeeChargesService {
    * Find all fee charges with computed payment status using SQL-level aggregation.
    * Returns paginated results with OPEN/PARTIAL/PAID status and overdue flag.
    *
-   * Note: OVERDUE is a computed status (dueDate < today && not fully paid), so
-   * filtering by OVERDUE happens post-query. This means `total` reflects the
-   * unfiltered count and pages may appear partially empty when the OVERDUE filter
-   * is active. A proper fix requires SQL-level status computation.
+   * When a status filter is active, uses a two-pass approach:
+   * 1. Fetch all matching charge IDs + amounts (lightweight), compute statuses
+   * 2. Filter by status, paginate, then fetch full data for the page
+   * This ensures correct `total` and pagination for computed status filters.
    */
   async findAllWithStatus(clubId: string, query: FeeChargeQueryDto) {
     const db = this.prisma.forClub(clubId);
     const page = query.page ?? 1;
     const limit = query.limit ?? 20;
-    const skip = (page - 1) * limit;
 
     // Build filter conditions
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -151,36 +150,134 @@ export class FeeChargesService {
       ...(query.periodEnd && { periodEnd: { lte: new Date(query.periodEnd) } }),
     };
 
-    const [charges, total] = await Promise.all([
-      db.feeCharge.findMany({
-        where,
-        include: {
-          member: {
-            select: { id: true, firstName: true, lastName: true, memberNumber: true },
-          },
-        },
-        orderBy: { dueDate: 'desc' },
-        skip,
-        take: limit,
-      }),
-      db.feeCharge.count({ where }),
-    ]);
-
-    // Batch-fetch payment aggregates for all charge IDs (SQL-level aggregation)
-    const chargeIds = charges.map((c: { id: string }) => c.id);
-    const paymentAggregates =
-      chargeIds.length > 0
-        ? await this.prisma.payment.groupBy({
-            by: ['feeChargeId'],
-            where: {
-              feeChargeId: { in: chargeIds },
-              deletedAt: null,
+    // No status filter: fast single-query path (existing behavior)
+    if (!query.status) {
+      const skip = (page - 1) * limit;
+      const [charges, total] = await Promise.all([
+        db.feeCharge.findMany({
+          where,
+          include: {
+            member: {
+              select: { id: true, firstName: true, lastName: true, memberNumber: true },
             },
-            _sum: { amount: true },
-          })
-        : [];
+          },
+          orderBy: { dueDate: 'desc' },
+          skip,
+          take: limit,
+        }),
+        db.feeCharge.count({ where }),
+      ]);
 
-    const paymentSumMap = new Map(
+      const enrichedCharges = await this.enrichChargesWithStatus(charges);
+      return { data: enrichedCharges, total, page, limit };
+    }
+
+    // Status filter active: two-pass approach for correct pagination
+    // Pass 1: Fetch all charge IDs + amounts (lightweight)
+    const allCharges = await db.feeCharge.findMany({
+      where,
+      select: { id: true, amount: true, dueDate: true },
+      orderBy: { dueDate: 'desc' },
+    });
+
+    const allChargeIds = allCharges.map((c: { id: string }) => c.id);
+    const paymentSumMap = await this.fetchPaymentSums(allChargeIds);
+
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    // Compute status for each charge and filter
+    const filteredIds = allCharges
+      .filter((charge: { id: string; amount: Prisma.Decimal | number; dueDate: Date }) => {
+        const amount =
+          charge.amount instanceof Prisma.Decimal
+            ? charge.amount
+            : new Prisma.Decimal(String(charge.amount));
+        const paidAmount = paymentSumMap.get(charge.id) ?? ZERO;
+        const { status, isOverdue } = this.computeChargeStatus(
+          amount,
+          paidAmount,
+          charge.dueDate,
+          today
+        );
+
+        if (query.status === 'OVERDUE') return isOverdue;
+        return status === query.status;
+      })
+      .map((c: { id: string }) => c.id);
+
+    const filteredTotal = filteredIds.length;
+
+    // Paginate the filtered IDs
+    const skip = (page - 1) * limit;
+    const pageIds = filteredIds.slice(skip, skip + limit);
+
+    if (pageIds.length === 0) {
+      return { data: [], total: filteredTotal, page, limit };
+    }
+
+    // Pass 2: Fetch full data for this page only
+    const charges = await db.feeCharge.findMany({
+      where: { id: { in: pageIds } },
+      include: {
+        member: {
+          select: { id: true, firstName: true, lastName: true, memberNumber: true },
+        },
+      },
+      orderBy: { dueDate: 'desc' },
+    });
+
+    const enrichedCharges = await this.enrichChargesWithStatus(charges);
+    return { data: enrichedCharges, total: filteredTotal, page, limit };
+  }
+
+  // ─── findByMember ───────────────────────────────────────────────────
+
+  /**
+   * Find charges for a specific member with computed status.
+   * Used for member detail section.
+   */
+  async findByMember(clubId: string, memberId: string, options?: { limit?: number }) {
+    return this.findAllWithStatus(clubId, {
+      memberId,
+      limit: options?.limit ?? 20,
+    });
+  }
+
+  // ─── Private: Status Computation Helpers ────────────────────────────
+
+  /**
+   * Compute payment status for a single charge.
+   */
+  private computeChargeStatus(
+    amount: Prisma.Decimal,
+    paidAmount: Prisma.Decimal,
+    dueDate: Date,
+    today: Date
+  ): { status: string; isOverdue: boolean } {
+    const status = paidAmount.gte(amount) ? 'PAID' : paidAmount.gt(ZERO) ? 'PARTIAL' : 'OPEN';
+    const due = new Date(dueDate);
+    due.setHours(0, 0, 0, 0);
+    const isOverdue = status !== 'PAID' && due < today;
+    return { status, isOverdue };
+  }
+
+  /**
+   * Batch-fetch payment sums for a list of charge IDs.
+   */
+  private async fetchPaymentSums(chargeIds: string[]): Promise<Map<string, Prisma.Decimal>> {
+    if (chargeIds.length === 0) return new Map();
+
+    const paymentAggregates = await this.prisma.payment.groupBy({
+      by: ['feeChargeId'],
+      where: {
+        feeChargeId: { in: chargeIds },
+        deletedAt: null,
+      },
+      _sum: { amount: true },
+    });
+
+    return new Map(
       paymentAggregates.map(
         (pa: { feeChargeId: string; _sum: { amount: Prisma.Decimal | null } }) => [
           pa.feeChargeId,
@@ -188,21 +285,31 @@ export class FeeChargesService {
         ]
       )
     );
+  }
+
+  /**
+   * Enrich charge records with computed payment status fields.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private async enrichChargesWithStatus(charges: any[]) {
+    const chargeIds = charges.map((c: { id: string }) => c.id);
+    const paymentSumMap = await this.fetchPaymentSums(chargeIds);
 
     const today = new Date();
     today.setHours(0, 0, 0, 0);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let enrichedCharges = charges.map((charge: any) => {
+    return charges.map((charge) => {
       const paidAmount = paymentSumMap.get(charge.id) ?? ZERO;
       const amount =
         charge.amount instanceof Prisma.Decimal
           ? charge.amount
           : new Prisma.Decimal(String(charge.amount));
-      const status = paidAmount.gte(amount) ? 'PAID' : paidAmount.gt(ZERO) ? 'PARTIAL' : 'OPEN';
-      const dueDate = new Date(charge.dueDate);
-      dueDate.setHours(0, 0, 0, 0);
-      const isOverdue = status !== 'PAID' && dueDate < today;
+      const { status, isOverdue } = this.computeChargeStatus(
+        amount,
+        paidAmount,
+        charge.dueDate,
+        today
+      );
       const remaining = amount.minus(paidAmount);
       const remainingAmount = remaining.lt(ZERO) ? ZERO : remaining;
 
@@ -236,40 +343,6 @@ export class FeeChargesService {
         updatedAt:
           charge.updatedAt instanceof Date ? charge.updatedAt.toISOString() : charge.updatedAt,
       };
-    });
-
-    // Post-query status filter (OVERDUE is a special computed status)
-    if (query.status) {
-      if (query.status === 'OVERDUE') {
-        enrichedCharges = enrichedCharges.filter(
-          (c: { isOverdue: boolean; status: string }) =>
-            c.isOverdue && (c.status === 'OPEN' || c.status === 'PARTIAL')
-        );
-      } else {
-        enrichedCharges = enrichedCharges.filter(
-          (c: { status: string }) => c.status === query.status
-        );
-      }
-    }
-
-    return {
-      data: enrichedCharges,
-      total,
-      page,
-      limit,
-    };
-  }
-
-  // ─── findByMember ───────────────────────────────────────────────────
-
-  /**
-   * Find charges for a specific member with computed status.
-   * Used for member detail section.
-   */
-  async findByMember(clubId: string, memberId: string, options?: { limit?: number }) {
-    return this.findAllWithStatus(clubId, {
-      memberId,
-      limit: options?.limit ?? 20,
     });
   }
 

--- a/apps/api/src/fees/fee-charges.service.ts
+++ b/apps/api/src/fees/fee-charges.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, BadRequestException } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service.js';
 import { Prisma } from '../../../../prisma/generated/client/index.js';
 import type { BillingRunPreviewDto } from './dto/billing-run-preview.dto.js';
@@ -52,6 +52,10 @@ export class FeeChargesService {
    * Calculates what each active member owes for the specified period.
    */
   async previewBillingRun(clubId: string, dto: BillingRunPreviewDto) {
+    if (new Date(dto.periodStart) >= new Date(dto.periodEnd)) {
+      throw new BadRequestException('Periodenbeginn muss vor dem Periodenende liegen');
+    }
+
     const { charges, exemptions, breakdown } = await this.calculateBillingCharges(clubId, dto);
 
     // Check for existing charges for duplicate detection
@@ -86,6 +90,10 @@ export class FeeChargesService {
    * Uses createMany with skipDuplicates for idempotency.
    */
   async executeBillingRun(clubId: string, dto: BillingRunConfirmDto, _userId: string) {
+    if (new Date(dto.periodStart) >= new Date(dto.periodEnd)) {
+      throw new BadRequestException('Periodenbeginn muss vor dem Periodenende liegen');
+    }
+
     const { charges } = await this.calculateBillingCharges(clubId, dto);
 
     const chargeDataArray: ChargeData[] = charges.map((c) => ({

--- a/apps/api/src/fees/fee-charges.service.ts
+++ b/apps/api/src/fees/fee-charges.service.ts
@@ -16,12 +16,20 @@ function roundMoney(value: Prisma.Decimal): Prisma.Decimal {
 
 const ZERO = new Prisma.Decimal(0);
 
+/** Warning for members excluded from billing */
+interface BillingWarning {
+  memberId: string;
+  memberName: string;
+  reason: string;
+}
+
 /** Charge data prepared from billing calculation */
 interface ChargeData {
   clubId: string;
   memberId: string;
   feeCategoryId: string | null;
   membershipTypeId: string | null;
+  feeTypeId: string | null;
   description: string;
   periodStart: Date;
   periodEnd: Date;
@@ -56,7 +64,8 @@ export class FeeChargesService {
       throw new BadRequestException('Periodenbeginn muss vor dem Periodenende liegen');
     }
 
-    const { charges, exemptions, breakdown } = await this.calculateBillingCharges(clubId, dto);
+    const { charges, exemptions, warnings, breakdown } =
+      await this.calculateBillingCharges(clubId, dto);
 
     // Check for existing charges for duplicate detection
     const db = this.prisma.forClub(clubId);
@@ -76,6 +85,7 @@ export class FeeChargesService {
       chargeCount: charges.length,
       totalAmount: roundMoney(totalAmount).toFixed(DECIMAL_PLACES),
       exemptions,
+      warnings,
       breakdown: breakdown.map((b) => ({
         membershipType: b.membershipType,
         count: b.count,
@@ -360,6 +370,7 @@ export class FeeChargesService {
   ): Promise<{
     charges: Omit<ChargeData, 'dueDate'>[];
     exemptions: number;
+    warnings: BillingWarning[];
     breakdown: BreakdownEntry[];
   }> {
     const db = this.prisma.forClub(clubId);
@@ -369,7 +380,6 @@ export class FeeChargesService {
       where: { id: clubId },
       select: {
         proRataMode: true,
-        householdBillingModel: true,
       },
     });
 
@@ -395,16 +405,19 @@ export class FeeChargesService {
           take: 1,
         },
         memberFeeOverrides: true,
-        feeType: true,
+        feeType: { select: { id: true, name: true } },
       },
     });
 
-    // 3. Get active fee categories matching the billing interval
+    // 3. Get active fee categories matching the billing interval with scope join
     const feeCategories = await db.feeCategory.findMany({
       where: {
         deletedAt: null,
         isActive: true,
         billingInterval: dto.billingInterval,
+      },
+      include: {
+        feeCategoryMembershipTypes: true,
       },
     });
 
@@ -412,6 +425,7 @@ export class FeeChargesService {
     const periodEnd = new Date(dto.periodEnd);
 
     const charges: Omit<ChargeData, 'dueDate'>[] = [];
+    const warnings: BillingWarning[] = [];
     let exemptions = 0;
     const breakdownMap = new Map<string, BreakdownEntry>();
 
@@ -434,8 +448,13 @@ export class FeeChargesService {
         continue;
       }
 
-      // D-17: Members without feeTypeId are excluded from billing
+      // D-17: Members without feeTypeId are excluded from billing with warning
       if (!member.feeTypeId) {
+        warnings.push({
+          memberId: member.id,
+          memberName: `${member.firstName} ${member.lastName}`,
+          reason: 'Keine Beitragsart zugewiesen',
+        });
         exemptions++;
         continue;
       }
@@ -449,7 +468,16 @@ export class FeeChargesService {
         },
       });
 
-      if (crossTableEntry) {
+      if (!crossTableEntry) {
+        warnings.push({
+          memberId: member.id,
+          memberName: `${member.firstName} ${member.lastName}`,
+          reason: `Kein Betrag in der Beitragstabelle für ${membershipType.name} × ${member.feeType?.name ?? 'Unbekannt'}`,
+        });
+        continue;
+      }
+
+      {
         let baseFee = new Prisma.Decimal(crossTableEntry.amount.toString());
         let discountAmount: Prisma.Decimal | null = null;
         let discountReason: string | null = null;
@@ -489,9 +517,9 @@ export class FeeChargesService {
 
         baseFee = roundMoney(baseFee);
 
-        const typeName = membershipType.name;
+        const feeTypeName = member.feeType?.name ?? '';
         const description = this.generateChargeDescription(
-          typeName,
+          `${membershipType.name} × ${feeTypeName}`,
           periodStart,
           periodEnd,
           dto.billingInterval
@@ -502,6 +530,7 @@ export class FeeChargesService {
           memberId: member.id,
           feeCategoryId: null,
           membershipTypeId: membershipType.id,
+          feeTypeId: member.feeTypeId,
           description,
           periodStart,
           periodEnd,
@@ -511,6 +540,7 @@ export class FeeChargesService {
         });
 
         // Track breakdown
+        const typeName = membershipType.name;
         const existing = breakdownMap.get(typeName);
         if (existing) {
           existing.count++;
@@ -524,8 +554,19 @@ export class FeeChargesService {
         }
       }
 
-      // Calculate additional category fees
+      // Calculate additional category fees with scope filtering
       for (const category of feeCategories) {
+        // Scope filtering per FeeCategoryScope
+        if (category.scope === 'INDIVIDUAL') continue; // Only via MemberFeeOverride
+        if (category.scope === 'BY_MEMBERSHIP_TYPE') {
+          const matchesMT = category.feeCategoryMembershipTypes.some(
+            (mt: { membershipTypeId: string }) =>
+              mt.membershipTypeId === membershipType.id
+          );
+          if (!matchesMT) continue;
+        }
+        // ALL_MEMBERS: always apply (existing behavior)
+
         const categoryOverride = member.memberFeeOverrides.find(
           (o: MemberWithRelations) => o.feeCategoryId === category.id
         );
@@ -556,6 +597,7 @@ export class FeeChargesService {
           memberId: member.id,
           feeCategoryId: category.id,
           membershipTypeId: null,
+          feeTypeId: null,
           description,
           periodStart,
           periodEnd,
@@ -583,6 +625,7 @@ export class FeeChargesService {
     return {
       charges,
       exemptions,
+      warnings,
       breakdown: Array.from(breakdownMap.values()),
     };
   }

--- a/apps/api/src/fees/fee-charges.service.ts
+++ b/apps/api/src/fees/fee-charges.service.ts
@@ -17,7 +17,7 @@ function roundMoney(value: Prisma.Decimal): Prisma.Decimal {
 const ZERO = new Prisma.Decimal(0);
 
 /** Warning for members excluded from billing */
-interface BillingWarning {
+export interface BillingWarning {
   memberId: string;
   memberName: string;
   reason: string;
@@ -64,8 +64,10 @@ export class FeeChargesService {
       throw new BadRequestException('Periodenbeginn muss vor dem Periodenende liegen');
     }
 
-    const { charges, exemptions, warnings, breakdown } =
-      await this.calculateBillingCharges(clubId, dto);
+    const { charges, exemptions, warnings, breakdown } = await this.calculateBillingCharges(
+      clubId,
+      dto
+    );
 
     // Check for existing charges for duplicate detection
     const db = this.prisma.forClub(clubId);
@@ -560,8 +562,7 @@ export class FeeChargesService {
         if (category.scope === 'INDIVIDUAL') continue; // Only via MemberFeeOverride
         if (category.scope === 'BY_MEMBERSHIP_TYPE') {
           const matchesMT = category.feeCategoryMembershipTypes.some(
-            (mt: { membershipTypeId: string }) =>
-              mt.membershipTypeId === membershipType.id
+            (mt: { membershipTypeId: string }) => mt.membershipTypeId === membershipType.id
           );
           if (!matchesMT) continue;
         }

--- a/apps/api/src/fees/fee-charges.service.ts
+++ b/apps/api/src/fees/fee-charges.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, BadRequestException } from '@nestjs/common';
+import { Injectable, BadRequestException, ConflictException } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service.js';
 import { Prisma } from '../../../../prisma/generated/client/index.js';
 import type { BillingRunPreviewDto } from './dto/billing-run-preview.dto.js';
@@ -39,8 +39,11 @@ interface ChargeData {
   discountReason: string | null;
 }
 
-/** Breakdown entry per membership type for preview */
+/** Breakdown entry per membership type or category for preview */
 interface BreakdownEntry {
+  /** Distinguishes base-fee rows (membership type) from category rows so identically named entries do not merge */
+  kind: 'membershipType' | 'category';
+  /** Display name: the membership type name for base fees, the category name for category rows */
   membershipType: string;
   count: number;
   subtotal: Prisma.Decimal;
@@ -89,6 +92,7 @@ export class FeeChargesService {
       exemptions,
       warnings,
       breakdown: breakdown.map((b) => ({
+        kind: b.kind,
         membershipType: b.membershipType,
         count: b.count,
         subtotal: roundMoney(b.subtotal).toFixed(DECIMAL_PLACES),
@@ -106,6 +110,23 @@ export class FeeChargesService {
   async executeBillingRun(clubId: string, dto: BillingRunConfirmDto) {
     if (new Date(dto.periodStart) >= new Date(dto.periodEnd)) {
       throw new BadRequestException('Periodenbeginn muss vor dem Periodenende liegen');
+    }
+
+    // Reject re-billing a period that already has charges. The unique dedupe index
+    // alone is unreliable because NULL key columns are not deduplicated reliably,
+    // so guard explicitly before creating any new charges (WR-01/02).
+    const db = this.prisma.forClub(clubId);
+    const existing = await db.feeCharge.count({
+      where: {
+        deletedAt: null,
+        periodStart: new Date(dto.periodStart),
+        periodEnd: new Date(dto.periodEnd),
+      },
+    });
+    if (existing > 0) {
+      throw new ConflictException(
+        'Für diesen Zeitraum wurden bereits Beiträge berechnet. Bitte storniere die vorhandenen Beiträge, bevor du erneut abrechnest.'
+      );
     }
 
     const { charges } = await this.calculateBillingCharges(clubId, dto);
@@ -282,6 +303,10 @@ export class FeeChargesService {
   private async fetchPaymentSums(chargeIds: string[]): Promise<Map<string, Prisma.Decimal>> {
     if (chargeIds.length === 0) return new Map();
 
+    // Tenant-safe: Payment has no clubId and is excluded from the tenant extension by design.
+    // This unscoped groupBy is safe because chargeIds always originate from a club-scoped
+    // feeCharge query (forClub(clubId)) at every call site, so no cross-tenant payment ids
+    // can reach this filter.
     const paymentAggregates = await this.prisma.payment.groupBy({
       by: ['feeChargeId'],
       where: {
@@ -378,6 +403,11 @@ export class FeeChargesService {
     const db = this.prisma.forClub(clubId);
 
     // 1. Get club settings
+    // NOTE: householdBillingModel is intentionally NOT applied at billing time in this
+    // milestone. It currently only drives the FeeType suggestion in the member form.
+    // Automatic household-discount application (grouping by householdId, reduced/payer
+    // logic, populating discountAmount/discountReason) is deferred to a dedicated future
+    // phase, so it is deliberately not added to this select and the billing math is unchanged.
     const club = await this.prisma.club.findFirst({
       where: { id: clubId },
       select: {
@@ -541,14 +571,17 @@ export class FeeChargesService {
           discountReason,
         });
 
-        // Track breakdown
+        // Track breakdown (keyed by kind+name so a category sharing a name with a
+        // membership type does not collide into the same row)
         const typeName = membershipType.name;
-        const existing = breakdownMap.get(typeName);
+        const typeKey = `membershipType:${typeName}`;
+        const existing = breakdownMap.get(typeKey);
         if (existing) {
           existing.count++;
           existing.subtotal = existing.subtotal.plus(baseFee);
         } else {
-          breakdownMap.set(typeName, {
+          breakdownMap.set(typeKey, {
+            kind: 'membershipType',
             membershipType: typeName,
             count: 1,
             subtotal: baseFee,
@@ -607,14 +640,17 @@ export class FeeChargesService {
           discountReason: catDiscountReason,
         });
 
-        // Track category in breakdown
+        // Track category in breakdown (keyed by kind+name to avoid collisions
+        // with same-named membership types)
         const catName = category.name;
-        const existingCat = breakdownMap.get(catName);
+        const catKey = `category:${catName}`;
+        const existingCat = breakdownMap.get(catKey);
         if (existingCat) {
           existingCat.count++;
           existingCat.subtotal = existingCat.subtotal.plus(categoryFee);
         } else {
-          breakdownMap.set(catName, {
+          breakdownMap.set(catKey, {
+            kind: 'category',
             membershipType: catName,
             count: 1,
             subtotal: categoryFee,
@@ -637,6 +673,16 @@ export class FeeChargesService {
    * Calculate pro-rata fee based on member join date vs billing period.
    * For MONTHLY_PRO_RATA mode with ANNUALLY billing:
    *   amount = feeAmount * (totalMonths - monthsElapsed) / totalMonths
+   *
+   * PRO-RATA RULE (calendar-month granular, day-of-month intentionally ignored):
+   * The calculation works on whole calendar months via `monthDiff`. A member joining
+   * on any day of a month is treated as joining that entire month - joining on the
+   * 1st and joining on the last day of the same month produce the identical amount.
+   * Boundary behavior: join on/before periodStart => full amount, join after periodEnd => zero.
+   *
+   * Finer day-precision pro-rata is a deferred future enhancement. It is intentionally
+   * NOT implemented here because different clubs have different requirements, so it must
+   * become a PER-CLUB setting rather than a global change. See the .planning backlog.
    */
   private calculateProRata(
     feeAmount: Prisma.Decimal,
@@ -675,7 +721,10 @@ export class FeeChargesService {
   }
 
   /**
-   * Calculate the number of months between two dates (1-indexed from period start).
+   * Calculate the number of whole calendar months between two dates (year/month only).
+   * Day-of-month is intentionally ignored: this is the calendar-month-granular building
+   * block for `calculateProRata`. See that method's note for the documented rule and the
+   * deferred day-precision (per-club) enhancement.
    */
   private monthDiff(start: Date, end: Date): number {
     return (end.getFullYear() - start.getFullYear()) * 12 + (end.getMonth() - start.getMonth());

--- a/apps/api/src/fees/fee-charges.service.ts
+++ b/apps/api/src/fees/fee-charges.service.ts
@@ -69,9 +69,11 @@ export class FeeChargesService {
     });
 
     const totalAmount = charges.reduce((sum, c) => sum.plus(c.amount), ZERO);
+    const uniqueMembers = new Set(charges.map((c) => c.memberId)).size;
 
     return {
-      memberCount: charges.length,
+      memberCount: uniqueMembers,
+      chargeCount: charges.length,
       totalAmount: roundMoney(totalAmount).toFixed(DECIMAL_PLACES),
       exemptions,
       breakdown: breakdown.map((b) => ({
@@ -367,13 +369,11 @@ export class FeeChargesService {
       where: { id: clubId },
       select: {
         proRataMode: true,
-        householdFeeMode: true,
-        householdDiscountPercent: true,
-        householdFlatAmount: true,
+        householdBillingModel: true,
       },
     });
 
-    // 2. Get active members with membership info and overrides
+    // 2. Get active members with membership info, fee type, and overrides
     const members = await this.prisma.member.findMany({
       where: {
         clubId,
@@ -388,8 +388,6 @@ export class FeeChargesService {
               select: {
                 id: true,
                 name: true,
-                feeAmount: true,
-                billingInterval: true,
               },
             },
           },
@@ -397,6 +395,7 @@ export class FeeChargesService {
           take: 1,
         },
         memberFeeOverrides: true,
+        feeType: true,
       },
     });
 
@@ -435,9 +434,23 @@ export class FeeChargesService {
         continue;
       }
 
-      // Calculate base fee if membership type has a fee and matches interval
-      if (membershipType.feeAmount && membershipType.billingInterval === dto.billingInterval) {
-        let baseFee = new Prisma.Decimal(membershipType.feeAmount.toString());
+      // D-17: Members without feeTypeId are excluded from billing
+      if (!member.feeTypeId) {
+        exemptions++;
+        continue;
+      }
+
+      // Look up base fee from cross-table (MembershipType x FeeType)
+      const crossTableEntry = await db.membershipTypeFeeType.findFirst({
+        where: {
+          membershipTypeId: membershipType.id,
+          feeTypeId: member.feeTypeId,
+          billingInterval: dto.billingInterval,
+        },
+      });
+
+      if (crossTableEntry) {
+        let baseFee = new Prisma.Decimal(crossTableEntry.amount.toString());
         let discountAmount: Prisma.Decimal | null = null;
         let discountReason: string | null = null;
 
@@ -464,7 +477,7 @@ export class FeeChargesService {
           // Recalculate discount if pro-rata was applied and there was a custom override
           if (customOverride?.customAmount) {
             const originalProRata = this.calculateProRata(
-              new Prisma.Decimal(membershipType.feeAmount.toString()),
+              new Prisma.Decimal(crossTableEntry.amount.toString()),
               currentPeriod.joinDate,
               periodStart,
               periodEnd,
@@ -472,31 +485,6 @@ export class FeeChargesService {
             );
             discountAmount = roundMoney(originalProRata.minus(baseFee));
           }
-        }
-
-        // Apply household discount
-        if (
-          club?.householdFeeMode === 'PERCENTAGE' &&
-          member.householdId &&
-          member.householdRole &&
-          member.householdRole !== 'HEAD' &&
-          club.householdDiscountPercent
-        ) {
-          const discountPercent = new Prisma.Decimal(club.householdDiscountPercent);
-          const discount = roundMoney(baseFee.mul(discountPercent).div(100));
-          discountAmount = discount;
-          discountReason = `Haushaltsrabatt ${club.householdDiscountPercent}%`;
-          baseFee = roundMoney(baseFee.minus(discount));
-        } else if (
-          club?.householdFeeMode === 'FLAT' &&
-          member.householdId &&
-          member.householdRole === 'HEAD' &&
-          club.householdFlatAmount
-        ) {
-          const flatAmount = new Prisma.Decimal(club.householdFlatAmount.toString());
-          discountAmount = roundMoney(baseFee.minus(flatAmount));
-          discountReason = 'Haushaltspauschale';
-          baseFee = flatAmount;
         }
 
         baseFee = roundMoney(baseFee);
@@ -575,6 +563,20 @@ export class FeeChargesService {
           discountAmount: catDiscountAmount,
           discountReason: catDiscountReason,
         });
+
+        // Track category in breakdown
+        const catName = category.name;
+        const existingCat = breakdownMap.get(catName);
+        if (existingCat) {
+          existingCat.count++;
+          existingCat.subtotal = existingCat.subtotal.plus(categoryFee);
+        } else {
+          breakdownMap.set(catName, {
+            membershipType: catName,
+            count: 1,
+            subtotal: categoryFee,
+          });
+        }
       }
     }
 

--- a/apps/api/src/fees/fee-types.controller.ts
+++ b/apps/api/src/fees/fee-types.controller.ts
@@ -31,8 +31,11 @@ export class FeeTypesController {
   @RequirePermissions([Permission.FINANCE_UPDATE])
   @ApiOperation({ summary: 'Upsert a cross-table entry (create or update)' })
   @ApiResponse({ status: 200, description: 'Cross-table entry upserted' })
-  async upsertCrossTableEntry(@Body() dto: UpsertCrossTableEntryDto) {
-    return this.feeTypesService.upsertCrossTableEntry(dto);
+  async upsertCrossTableEntry(
+    @GetClubContext() ctx: ClubContext,
+    @Body() dto: UpsertCrossTableEntryDto
+  ) {
+    return this.feeTypesService.upsertCrossTableEntry(ctx.clubId, dto);
   }
 
   @Delete('cross-table/:id')
@@ -40,8 +43,11 @@ export class FeeTypesController {
   @RequirePermissions([Permission.FINANCE_DELETE])
   @ApiOperation({ summary: 'Delete a cross-table entry' })
   @ApiResponse({ status: 204, description: 'Cross-table entry deleted' })
-  async removeCrossTableEntry(@Param('id') id: string): Promise<void> {
-    await this.feeTypesService.deleteCrossTableEntry(id);
+  async removeCrossTableEntry(
+    @GetClubContext() ctx: ClubContext,
+    @Param('id') id: string
+  ): Promise<void> {
+    await this.feeTypesService.deleteCrossTableEntry(ctx.clubId, id);
   }
 
   // ─── FeeType CRUD (parametric :id routes — AFTER static routes) ───

--- a/apps/api/src/fees/fee-types.controller.ts
+++ b/apps/api/src/fees/fee-types.controller.ts
@@ -1,0 +1,117 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Delete,
+  Put,
+  Param,
+  Body,
+  HttpCode,
+} from '@nestjs/common';
+import { ApiTags, ApiBearerAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import {
+  RequireClubContext,
+  GetClubContext,
+} from '../common/decorators/club-context.decorator.js';
+import { RequirePermissions } from '../common/decorators/permissions.decorator.js';
+import { Permission } from '../common/permissions/permissions.enum.js';
+import { CurrentUser } from '../auth/decorators/current-user.decorator.js';
+import { FeeTypesService } from './fee-types.service.js';
+import { CreateFeeTypeDto } from './dto/create-fee-type.dto.js';
+import { UpdateFeeTypeDto } from './dto/update-fee-type.dto.js';
+import { UpsertCrossTableEntryDto } from './dto/upsert-cross-table-entry.dto.js';
+import type { ClubContext } from '../common/decorators/club-context.decorator.js';
+
+@ApiTags('Fee Types')
+@ApiBearerAuth()
+@Controller('clubs/:slug/fees/types')
+@RequireClubContext()
+export class FeeTypesController {
+  constructor(private feeTypesService: FeeTypesService) {}
+
+  // ─── Cross-Table Endpoints (static path — BEFORE :id routes) ──────
+
+  @Get('cross-table')
+  @RequirePermissions([Permission.FINANCE_READ])
+  @ApiOperation({ summary: 'Get the MembershipType x FeeType fee matrix' })
+  @ApiResponse({ status: 200, description: 'Cross-table entries' })
+  async getCrossTable(@GetClubContext() ctx: ClubContext) {
+    return this.feeTypesService.findCrossTable(ctx.clubId);
+  }
+
+  @Put('cross-table')
+  @RequirePermissions([Permission.FINANCE_UPDATE])
+  @ApiOperation({ summary: 'Upsert a cross-table entry (create or update)' })
+  @ApiResponse({ status: 200, description: 'Cross-table entry upserted' })
+  async upsertCrossTableEntry(@Body() dto: UpsertCrossTableEntryDto) {
+    return this.feeTypesService.upsertCrossTableEntry(dto);
+  }
+
+  @Delete('cross-table/:id')
+  @HttpCode(204)
+  @RequirePermissions([Permission.FINANCE_DELETE])
+  @ApiOperation({ summary: 'Delete a cross-table entry' })
+  @ApiResponse({ status: 204, description: 'Cross-table entry deleted' })
+  async removeCrossTableEntry(@Param('id') id: string): Promise<void> {
+    await this.feeTypesService.deleteCrossTableEntry(id);
+  }
+
+  // ─── FeeType CRUD (parametric :id routes — AFTER static routes) ───
+
+  @Get()
+  @RequirePermissions([Permission.FINANCE_READ])
+  @ApiOperation({ summary: 'List all fee types for club' })
+  @ApiResponse({ status: 200, description: 'List of fee types' })
+  async findAll(@GetClubContext() ctx: ClubContext) {
+    return this.feeTypesService.findAll(ctx.clubId);
+  }
+
+  @Get(':id')
+  @RequirePermissions([Permission.FINANCE_READ])
+  @ApiOperation({ summary: 'Get a single fee type' })
+  @ApiResponse({ status: 200, description: 'Fee type details' })
+  @ApiResponse({ status: 404, description: 'Fee type not found' })
+  async findOne(@GetClubContext() ctx: ClubContext, @Param('id') id: string) {
+    return this.feeTypesService.findOne(ctx.clubId, id);
+  }
+
+  @Post()
+  @RequirePermissions([Permission.FINANCE_CREATE])
+  @ApiOperation({ summary: 'Create a new fee type' })
+  @ApiResponse({ status: 201, description: 'Fee type created' })
+  @ApiResponse({ status: 409, description: 'Fee type name already exists' })
+  async create(
+    @GetClubContext() ctx: ClubContext,
+    @Body() dto: CreateFeeTypeDto
+  ) {
+    return this.feeTypesService.create(ctx.clubId, dto);
+  }
+
+  @Patch(':id')
+  @RequirePermissions([Permission.FINANCE_UPDATE])
+  @ApiOperation({ summary: 'Update a fee type' })
+  @ApiResponse({ status: 200, description: 'Fee type updated' })
+  @ApiResponse({ status: 404, description: 'Fee type not found' })
+  async update(
+    @GetClubContext() ctx: ClubContext,
+    @Param('id') id: string,
+    @Body() dto: UpdateFeeTypeDto
+  ) {
+    return this.feeTypesService.update(ctx.clubId, id, dto);
+  }
+
+  @Delete(':id')
+  @HttpCode(204)
+  @RequirePermissions([Permission.FINANCE_DELETE])
+  @ApiOperation({ summary: 'Soft-delete a fee type' })
+  @ApiResponse({ status: 204, description: 'Fee type deleted' })
+  @ApiResponse({ status: 404, description: 'Fee type not found' })
+  async remove(
+    @GetClubContext() ctx: ClubContext,
+    @Param('id') id: string,
+    @CurrentUser('id') userId: string
+  ): Promise<void> {
+    await this.feeTypesService.softDelete(ctx.clubId, id, userId);
+  }
+}

--- a/apps/api/src/fees/fee-types.controller.ts
+++ b/apps/api/src/fees/fee-types.controller.ts
@@ -1,19 +1,6 @@
-import {
-  Controller,
-  Get,
-  Post,
-  Patch,
-  Delete,
-  Put,
-  Param,
-  Body,
-  HttpCode,
-} from '@nestjs/common';
+import { Controller, Get, Post, Patch, Delete, Put, Param, Body, HttpCode } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
-import {
-  RequireClubContext,
-  GetClubContext,
-} from '../common/decorators/club-context.decorator.js';
+import { RequireClubContext, GetClubContext } from '../common/decorators/club-context.decorator.js';
 import { RequirePermissions } from '../common/decorators/permissions.decorator.js';
 import { Permission } from '../common/permissions/permissions.enum.js';
 import { CurrentUser } from '../auth/decorators/current-user.decorator.js';
@@ -81,10 +68,7 @@ export class FeeTypesController {
   @ApiOperation({ summary: 'Create a new fee type' })
   @ApiResponse({ status: 201, description: 'Fee type created' })
   @ApiResponse({ status: 409, description: 'Fee type name already exists' })
-  async create(
-    @GetClubContext() ctx: ClubContext,
-    @Body() dto: CreateFeeTypeDto
-  ) {
+  async create(@GetClubContext() ctx: ClubContext, @Body() dto: CreateFeeTypeDto) {
     return this.feeTypesService.create(ctx.clubId, dto);
   }
 

--- a/apps/api/src/fees/fee-types.service.spec.ts
+++ b/apps/api/src/fees/fee-types.service.spec.ts
@@ -18,8 +18,16 @@ const mockDb = {
 
 const mockPrisma = {
   forClub: vi.fn(() => mockDb),
+  // Raw (non-tenant-scoped) clients used by cross-table write/delete paths.
+  feeType: {
+    findFirst: vi.fn(),
+  },
+  membershipType: {
+    findFirst: vi.fn(),
+  },
   membershipTypeFeeType: {
     findMany: vi.fn(),
+    findFirst: vi.fn(),
     upsert: vi.fn(),
     delete: vi.fn(),
   },
@@ -260,12 +268,18 @@ describe('FeeTypesService', () => {
 
   describe('upsertCrossTableEntry()', () => {
     it('should upsert a cross-table entry', async () => {
+      (mockPrisma.feeType.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeFeeType());
+      (mockPrisma.membershipType.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'mt-1',
+        clubId: CLUB_ID,
+        name: 'Erwachsene',
+      });
       const entry = makeCrossTableEntry();
       (mockPrisma.membershipTypeFeeType.upsert as ReturnType<typeof vi.fn>).mockResolvedValue(
         entry
       );
 
-      const result = await service.upsertCrossTableEntry({
+      const result = await service.upsertCrossTableEntry(CLUB_ID, {
         membershipTypeId: 'mt-1',
         feeTypeId: 'ft-1',
         amount: '120.00',
@@ -294,12 +308,18 @@ describe('FeeTypesService', () => {
     });
 
     it('should accept amount "0.00" (Beitragsfrei)', async () => {
+      (mockPrisma.feeType.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeFeeType());
+      (mockPrisma.membershipType.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'mt-1',
+        clubId: CLUB_ID,
+        name: 'Erwachsene',
+      });
       const entry = makeCrossTableEntry({ amount: new Decimal('0.00') });
       (mockPrisma.membershipTypeFeeType.upsert as ReturnType<typeof vi.fn>).mockResolvedValue(
         entry
       );
 
-      const result = await service.upsertCrossTableEntry({
+      const result = await service.upsertCrossTableEntry(CLUB_ID, {
         membershipTypeId: 'mt-1',
         feeTypeId: 'ft-1',
         amount: '0.00',
@@ -307,17 +327,83 @@ describe('FeeTypesService', () => {
 
       expect(result.amount).toBe('0.00');
     });
+
+    // ─── Regression (CR-01): cross-tenant write rejection ─────────────
+    it('should throw NotFoundException and not write when feeType belongs to another club', async () => {
+      // Foreign-club feeType: scoped findFirst returns null.
+      (mockPrisma.feeType.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+      (mockPrisma.membershipType.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'mt-1',
+        clubId: CLUB_ID,
+        name: 'Erwachsene',
+      });
+
+      await expect(
+        service.upsertCrossTableEntry(CLUB_ID, {
+          membershipTypeId: 'mt-1',
+          feeTypeId: 'ft-foreign',
+          amount: '120.00',
+        })
+      ).rejects.toThrow(NotFoundException);
+
+      expect(mockPrisma.feeType.findFirst).toHaveBeenCalledWith({
+        where: { id: 'ft-foreign', clubId: CLUB_ID, deletedAt: null },
+      });
+      expect(mockPrisma.membershipTypeFeeType.upsert).not.toHaveBeenCalled();
+    });
+
+    it('should throw NotFoundException and not write when membershipType belongs to another club', async () => {
+      (mockPrisma.feeType.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeFeeType());
+      // Foreign-club membershipType: scoped findFirst returns null.
+      (mockPrisma.membershipType.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+      await expect(
+        service.upsertCrossTableEntry(CLUB_ID, {
+          membershipTypeId: 'mt-foreign',
+          feeTypeId: 'ft-1',
+          amount: '120.00',
+        })
+      ).rejects.toThrow(NotFoundException);
+
+      expect(mockPrisma.membershipType.findFirst).toHaveBeenCalledWith({
+        where: { id: 'mt-foreign', clubId: CLUB_ID },
+      });
+      expect(mockPrisma.membershipTypeFeeType.upsert).not.toHaveBeenCalled();
+    });
   });
 
   describe('deleteCrossTableEntry()', () => {
     it('should delete a cross-table entry by id', async () => {
+      (mockPrisma.membershipTypeFeeType.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(
+        makeCrossTableEntry()
+      );
       (mockPrisma.membershipTypeFeeType.delete as ReturnType<typeof vi.fn>).mockResolvedValue({});
 
-      await service.deleteCrossTableEntry('ct-1');
+      await service.deleteCrossTableEntry(CLUB_ID, 'ct-1');
 
+      expect(mockPrisma.membershipTypeFeeType.findFirst).toHaveBeenCalledWith({
+        where: { id: 'ct-1', feeType: { clubId: CLUB_ID } },
+      });
       expect(mockPrisma.membershipTypeFeeType.delete).toHaveBeenCalledWith({
         where: { id: 'ct-1' },
       });
+    });
+
+    // ─── Regression (CR-01): cross-tenant delete rejection ────────────
+    it('should throw NotFoundException and not delete when entry belongs to another club', async () => {
+      // Entry not found within club scope (belongs to a foreign club).
+      (mockPrisma.membershipTypeFeeType.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(
+        null
+      );
+
+      await expect(service.deleteCrossTableEntry(CLUB_ID, 'ct-foreign')).rejects.toThrow(
+        NotFoundException
+      );
+
+      expect(mockPrisma.membershipTypeFeeType.findFirst).toHaveBeenCalledWith({
+        where: { id: 'ct-foreign', feeType: { clubId: CLUB_ID } },
+      });
+      expect(mockPrisma.membershipTypeFeeType.delete).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/fees/fee-types.service.spec.ts
+++ b/apps/api/src/fees/fee-types.service.spec.ts
@@ -156,9 +156,9 @@ describe('FeeTypesService', () => {
       });
       (mockDb.feeType.create as ReturnType<typeof vi.fn>).mockRejectedValue(prismaError);
 
-      await expect(
-        service.create(CLUB_ID, { name: 'Einzelbeitrag' })
-      ).rejects.toThrow(ConflictException);
+      await expect(service.create(CLUB_ID, { name: 'Einzelbeitrag' })).rejects.toThrow(
+        ConflictException
+      );
     });
   });
 

--- a/apps/api/src/fees/fee-types.service.spec.ts
+++ b/apps/api/src/fees/fee-types.service.spec.ts
@@ -1,0 +1,323 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { FeeTypesService } from './fee-types.service.js';
+import type { PrismaService } from '../prisma/prisma.service.js';
+import { NotFoundException, ConflictException } from '@nestjs/common';
+import { Prisma } from '../../../../prisma/generated/client/index.js';
+
+const { Decimal } = Prisma;
+
+// Mock forClub() scoped DB — FeeType is tenant-scoped
+const mockDb = {
+  feeType: {
+    findMany: vi.fn(),
+    findFirst: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+  },
+};
+
+const mockPrisma = {
+  forClub: vi.fn(() => mockDb),
+  membershipTypeFeeType: {
+    findMany: vi.fn(),
+    upsert: vi.fn(),
+    delete: vi.fn(),
+  },
+} as unknown as PrismaService;
+
+const CLUB_ID = 'club-1';
+
+function makeFeeType(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'ft-1',
+    clubId: CLUB_ID,
+    name: 'Einzelbeitrag',
+    description: null,
+    isActive: true,
+    deletedAt: null,
+    deletedBy: null,
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+    membershipTypeFees: [],
+    _count: { members: 0 },
+    ...overrides,
+  };
+}
+
+function makeCrossTableEntry(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'ct-1',
+    membershipTypeId: 'mt-1',
+    feeTypeId: 'ft-1',
+    amount: new Decimal('120.00'),
+    billingInterval: 'ANNUALLY',
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+    membershipType: { id: 'mt-1', name: 'Erwachsene' },
+    feeType: { id: 'ft-1', name: 'Einzelbeitrag' },
+    ...overrides,
+  };
+}
+
+describe('FeeTypesService', () => {
+  let service: FeeTypesService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (mockPrisma.forClub as ReturnType<typeof vi.fn>).mockReturnValue(mockDb);
+    service = new FeeTypesService(mockPrisma);
+  });
+
+  // ─── FeeType CRUD ───────────────────────────────────────────────────
+
+  describe('findAll()', () => {
+    it('should return all active, non-deleted fee types ordered by name', async () => {
+      const feeTypes = [
+        makeFeeType({ id: 'ft-1', name: 'Einzelbeitrag' }),
+        makeFeeType({ id: 'ft-2', name: 'Familientarif' }),
+      ];
+      (mockDb.feeType.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(feeTypes);
+
+      const result = await service.findAll(CLUB_ID);
+
+      expect(result).toHaveLength(2);
+      expect(mockPrisma.forClub).toHaveBeenCalledWith(CLUB_ID);
+      expect(mockDb.feeType.findMany).toHaveBeenCalledWith({
+        where: { deletedAt: null },
+        include: {
+          membershipTypeFees: true,
+          _count: { select: { members: true } },
+        },
+        orderBy: { name: 'asc' },
+      });
+    });
+
+    it('should include membershipTypeFees relation count', async () => {
+      const feeTypes = [
+        makeFeeType({
+          membershipTypeFees: [
+            { id: 'ct-1', amount: new Decimal('120.00') },
+            { id: 'ct-2', amount: new Decimal('60.00') },
+          ],
+        }),
+      ];
+      (mockDb.feeType.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(feeTypes);
+
+      const result = await service.findAll(CLUB_ID);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]!.membershipTypeFees).toHaveLength(2);
+    });
+  });
+
+  describe('findOne()', () => {
+    it('should return a single fee type', async () => {
+      (mockDb.feeType.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeFeeType());
+
+      const result = await service.findOne(CLUB_ID, 'ft-1');
+
+      expect(result.id).toBe('ft-1');
+      expect(result.name).toBe('Einzelbeitrag');
+    });
+
+    it('should throw NotFoundException for non-existent fee type', async () => {
+      (mockDb.feeType.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+      await expect(service.findOne(CLUB_ID, 'nonexistent')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('create()', () => {
+    it('should create a fee type and return result', async () => {
+      const created = makeFeeType({ id: 'ft-new' });
+      (mockDb.feeType.create as ReturnType<typeof vi.fn>).mockResolvedValue(created);
+
+      const result = await service.create(CLUB_ID, {
+        name: 'Einzelbeitrag',
+        description: 'Standard',
+        isActive: true,
+      });
+
+      expect(result.id).toBe('ft-new');
+      expect(result.name).toBe('Einzelbeitrag');
+      expect(mockDb.feeType.create).toHaveBeenCalledWith({
+        data: {
+          name: 'Einzelbeitrag',
+          description: 'Standard',
+          isActive: true,
+        } as Prisma.FeeTypeUncheckedCreateInput,
+      });
+    });
+
+    it('should throw ConflictException on duplicate name within club', async () => {
+      const prismaError = new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
+        code: 'P2002',
+        clientVersion: '7.0.0',
+      });
+      (mockDb.feeType.create as ReturnType<typeof vi.fn>).mockRejectedValue(prismaError);
+
+      await expect(
+        service.create(CLUB_ID, { name: 'Einzelbeitrag' })
+      ).rejects.toThrow(ConflictException);
+    });
+  });
+
+  describe('update()', () => {
+    it('should update fee type fields and return result', async () => {
+      (mockDb.feeType.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeFeeType());
+      (mockDb.feeType.update as ReturnType<typeof vi.fn>).mockResolvedValue(
+        makeFeeType({ name: 'Familientarif' })
+      );
+
+      const result = await service.update(CLUB_ID, 'ft-1', { name: 'Familientarif' });
+
+      expect(result.name).toBe('Familientarif');
+    });
+
+    it('should throw NotFoundException for non-existent fee type', async () => {
+      (mockDb.feeType.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+      await expect(service.update(CLUB_ID, 'nonexistent', { name: 'X' })).rejects.toThrow(
+        NotFoundException
+      );
+    });
+  });
+
+  describe('softDelete()', () => {
+    it('should set deletedAt and deletedBy', async () => {
+      (mockDb.feeType.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeFeeType());
+      (mockDb.feeType.update as ReturnType<typeof vi.fn>).mockResolvedValue(
+        makeFeeType({ deletedAt: new Date(), deletedBy: 'user-1' })
+      );
+
+      await service.softDelete(CLUB_ID, 'ft-1', 'user-1');
+
+      expect(mockDb.feeType.update).toHaveBeenCalledWith({
+        where: { id: 'ft-1' },
+        data: {
+          deletedAt: expect.any(Date),
+          deletedBy: 'user-1',
+        },
+      });
+    });
+
+    it('should still soft-delete when assigned to members (D-10)', async () => {
+      (mockDb.feeType.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(
+        makeFeeType({ _count: { members: 5 } })
+      );
+      (mockDb.feeType.update as ReturnType<typeof vi.fn>).mockResolvedValue(
+        makeFeeType({ deletedAt: new Date(), deletedBy: 'user-1' })
+      );
+
+      await service.softDelete(CLUB_ID, 'ft-1', 'user-1');
+
+      expect(mockDb.feeType.update).toHaveBeenCalledWith({
+        where: { id: 'ft-1' },
+        data: {
+          deletedAt: expect.any(Date),
+          deletedBy: 'user-1',
+        },
+      });
+    });
+
+    it('should throw NotFoundException if fee type not found', async () => {
+      (mockDb.feeType.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+      await expect(service.softDelete(CLUB_ID, 'nonexistent', 'user-1')).rejects.toThrow(
+        NotFoundException
+      );
+    });
+  });
+
+  // ─── Cross-Table CRUD ───────────────────────────────────────────────
+
+  describe('findCrossTable()', () => {
+    it('should return full matrix of MembershipType x FeeType entries', async () => {
+      const entries = [
+        makeCrossTableEntry({ id: 'ct-1' }),
+        makeCrossTableEntry({ id: 'ct-2', amount: new Decimal('60.00') }),
+      ];
+      (mockPrisma.membershipTypeFeeType.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(
+        entries
+      );
+
+      const result = await service.findCrossTable(CLUB_ID);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]!.amount).toBe('120.00');
+      expect(result[1]!.amount).toBe('60.00');
+      expect(mockPrisma.membershipTypeFeeType.findMany).toHaveBeenCalledWith({
+        where: {
+          feeType: { clubId: CLUB_ID, deletedAt: null },
+        },
+        include: {
+          membershipType: { select: { id: true, name: true } },
+          feeType: { select: { id: true, name: true } },
+        },
+      });
+    });
+  });
+
+  describe('upsertCrossTableEntry()', () => {
+    it('should upsert a cross-table entry', async () => {
+      const entry = makeCrossTableEntry();
+      (mockPrisma.membershipTypeFeeType.upsert as ReturnType<typeof vi.fn>).mockResolvedValue(
+        entry
+      );
+
+      const result = await service.upsertCrossTableEntry({
+        membershipTypeId: 'mt-1',
+        feeTypeId: 'ft-1',
+        amount: '120.00',
+        billingInterval: 'ANNUALLY',
+      });
+
+      expect(result.amount).toBe('120.00');
+      expect(mockPrisma.membershipTypeFeeType.upsert).toHaveBeenCalledWith({
+        where: {
+          membershipTypeId_feeTypeId: {
+            membershipTypeId: 'mt-1',
+            feeTypeId: 'ft-1',
+          },
+        },
+        update: {
+          amount: expect.any(Decimal),
+          billingInterval: 'ANNUALLY',
+        },
+        create: {
+          membershipTypeId: 'mt-1',
+          feeTypeId: 'ft-1',
+          amount: expect.any(Decimal),
+          billingInterval: 'ANNUALLY',
+        },
+      });
+    });
+
+    it('should accept amount "0.00" (Beitragsfrei)', async () => {
+      const entry = makeCrossTableEntry({ amount: new Decimal('0.00') });
+      (mockPrisma.membershipTypeFeeType.upsert as ReturnType<typeof vi.fn>).mockResolvedValue(
+        entry
+      );
+
+      const result = await service.upsertCrossTableEntry({
+        membershipTypeId: 'mt-1',
+        feeTypeId: 'ft-1',
+        amount: '0.00',
+      });
+
+      expect(result.amount).toBe('0.00');
+    });
+  });
+
+  describe('deleteCrossTableEntry()', () => {
+    it('should delete a cross-table entry by id', async () => {
+      (mockPrisma.membershipTypeFeeType.delete as ReturnType<typeof vi.fn>).mockResolvedValue({});
+
+      await service.deleteCrossTableEntry('ct-1');
+
+      expect(mockPrisma.membershipTypeFeeType.delete).toHaveBeenCalledWith({
+        where: { id: 'ct-1' },
+      });
+    });
+  });
+});

--- a/apps/api/src/fees/fee-types.service.ts
+++ b/apps/api/src/fees/fee-types.service.ts
@@ -1,0 +1,219 @@
+import { Injectable, NotFoundException, ConflictException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { CreateFeeTypeDto } from './dto/create-fee-type.dto.js';
+import { UpdateFeeTypeDto } from './dto/update-fee-type.dto.js';
+import { UpsertCrossTableEntryDto } from './dto/upsert-cross-table-entry.dto.js';
+import { Prisma } from '../../../../prisma/generated/client/index.js';
+
+const { Decimal } = Prisma;
+
+@Injectable()
+export class FeeTypesService {
+  constructor(private prisma: PrismaService) {}
+
+  // ─── FeeType CRUD ───────────────────────────────────────────────────
+
+  /**
+   * List all active, non-deleted fee types for a club.
+   * Includes membershipTypeFees relation and member count.
+   * Ordered by name ascending.
+   */
+  async findAll(clubId: string) {
+    const db = this.prisma.forClub(clubId);
+    const feeTypes = await db.feeType.findMany({
+      where: { deletedAt: null },
+      include: {
+        membershipTypeFees: true,
+        _count: { select: { members: true } },
+      },
+      orderBy: { name: 'asc' },
+    });
+
+    return feeTypes.map((ft) => this.serializeFeeType(ft));
+  }
+
+  /**
+   * Get a single fee type by ID within club scope.
+   */
+  async findOne(clubId: string, id: string) {
+    const db = this.prisma.forClub(clubId);
+    const feeType = await db.feeType.findFirst({
+      where: { id, deletedAt: null },
+      include: { membershipTypeFees: true },
+    });
+
+    if (!feeType) {
+      throw new NotFoundException('Beitragsart nicht gefunden');
+    }
+
+    return this.serializeFeeType(feeType);
+  }
+
+  /**
+   * Create a new fee type.
+   * Catches Prisma unique constraint error (P2002) for duplicate name within club.
+   */
+  async create(clubId: string, dto: CreateFeeTypeDto) {
+    const db = this.prisma.forClub(clubId);
+    try {
+      const feeType = await db.feeType.create({
+        data: {
+          name: dto.name,
+          description: dto.description,
+          isActive: dto.isActive ?? true,
+        } as Prisma.FeeTypeUncheckedCreateInput,
+      });
+
+      return this.serializeFeeType(feeType);
+    } catch (error) {
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === 'P2002'
+      ) {
+        throw new ConflictException(
+          'Eine Beitragsart mit diesem Namen existiert bereits'
+        );
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Update an existing fee type.
+   * Throws NotFoundException if not found or deleted.
+   */
+  async update(clubId: string, id: string, dto: UpdateFeeTypeDto) {
+    const db = this.prisma.forClub(clubId);
+    const existing = await db.feeType.findFirst({
+      where: { id, deletedAt: null },
+    });
+
+    if (!existing) {
+      throw new NotFoundException('Beitragsart nicht gefunden');
+    }
+
+    const feeType = await db.feeType.update({
+      where: { id },
+      data: {
+        ...(dto.name !== undefined && { name: dto.name }),
+        ...(dto.description !== undefined && { description: dto.description }),
+        ...(dto.isActive !== undefined && { isActive: dto.isActive }),
+      },
+    });
+
+    return this.serializeFeeType(feeType);
+  }
+
+  /**
+   * Soft-delete a fee type (CONV-006).
+   * Sets deletedAt/deletedBy. Fee type excluded from future findAll.
+   * Per D-10: still soft-deletes even when assigned to members.
+   */
+  async softDelete(clubId: string, id: string, deletedBy: string) {
+    const db = this.prisma.forClub(clubId);
+    const existing = await db.feeType.findFirst({
+      where: { id, deletedAt: null },
+    });
+
+    if (!existing) {
+      throw new NotFoundException('Beitragsart nicht gefunden');
+    }
+
+    await db.feeType.update({
+      where: { id },
+      data: {
+        deletedAt: new Date(),
+        deletedBy,
+      },
+    });
+  }
+
+  // ─── Cross-Table CRUD ───────────────────────────────────────────────
+
+  /**
+   * Return full matrix of MembershipType x FeeType entries for a club.
+   * Scoped by feeType.clubId to ensure tenant isolation.
+   */
+  async findCrossTable(clubId: string) {
+    const entries = await this.prisma.membershipTypeFeeType.findMany({
+      where: {
+        feeType: { clubId, deletedAt: null },
+      },
+      include: {
+        membershipType: { select: { id: true, name: true } },
+        feeType: { select: { id: true, name: true } },
+      },
+    });
+
+    return entries.map((entry) => this.serializeCrossTableEntry(entry));
+  }
+
+  /**
+   * Upsert a cross-table entry (create or update by membershipTypeId + feeTypeId unique).
+   * Amount "0.00" is valid (Beitragsfrei).
+   */
+  async upsertCrossTableEntry(dto: UpsertCrossTableEntryDto) {
+    const amount = new Decimal(dto.amount);
+    const billingInterval = dto.billingInterval ?? 'ANNUALLY';
+
+    const entry = await this.prisma.membershipTypeFeeType.upsert({
+      where: {
+        membershipTypeId_feeTypeId: {
+          membershipTypeId: dto.membershipTypeId,
+          feeTypeId: dto.feeTypeId,
+        },
+      },
+      update: {
+        amount,
+        billingInterval,
+      },
+      create: {
+        membershipTypeId: dto.membershipTypeId,
+        feeTypeId: dto.feeTypeId,
+        amount,
+        billingInterval,
+      },
+    });
+
+    return this.serializeCrossTableEntry(entry);
+  }
+
+  /**
+   * Delete a cross-table entry by ID (hard delete — join table, not domain entity).
+   */
+  async deleteCrossTableEntry(id: string) {
+    await this.prisma.membershipTypeFeeType.delete({
+      where: { id },
+    });
+  }
+
+  // ─── Private Helpers ────────────────────────────────────────────────
+
+  /**
+   * Serialize a fee type record, converting Decimal fields in nested relations.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private serializeFeeType(feeType: any) {
+    return {
+      ...feeType,
+      membershipTypeFees: feeType.membershipTypeFees?.map(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (entry: any) => this.serializeCrossTableEntry(entry)
+      ),
+    };
+  }
+
+  /**
+   * Serialize a cross-table entry, converting Decimal amount to string.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private serializeCrossTableEntry(entry: any) {
+    return {
+      ...entry,
+      amount:
+        entry.amount instanceof Decimal
+          ? entry.amount.toFixed(2)
+          : String(entry.amount),
+    };
+  }
+}

--- a/apps/api/src/fees/fee-types.service.ts
+++ b/apps/api/src/fees/fee-types.service.ts
@@ -146,8 +146,23 @@ export class FeeTypesService {
   /**
    * Upsert a cross-table entry (create or update by membershipTypeId + feeTypeId unique).
    * Amount "0.00" is valid (Beitragsfrei).
+   * MembershipTypeFeeType has no clubId; tenant isolation is enforced by verifying
+   * both the feeType and membershipType belong to clubId before writing.
    */
-  async upsertCrossTableEntry(dto: UpsertCrossTableEntryDto) {
+  async upsertCrossTableEntry(clubId: string, dto: UpsertCrossTableEntryDto) {
+    const [feeType, membershipType] = await Promise.all([
+      this.prisma.feeType.findFirst({
+        where: { id: dto.feeTypeId, clubId, deletedAt: null },
+      }),
+      this.prisma.membershipType.findFirst({
+        where: { id: dto.membershipTypeId, clubId },
+      }),
+    ]);
+
+    if (!feeType || !membershipType) {
+      throw new NotFoundException('Beitragsart oder Mitgliedsart nicht gefunden');
+    }
+
     const amount = new Decimal(dto.amount);
     const billingInterval = dto.billingInterval ?? 'ANNUALLY';
 
@@ -175,8 +190,18 @@ export class FeeTypesService {
 
   /**
    * Delete a cross-table entry by ID (hard delete — join table, not domain entity).
+   * Tenant isolation: verify the entry belongs to clubId via the feeType relation
+   * before deleting, since MembershipTypeFeeType has no clubId column.
    */
-  async deleteCrossTableEntry(id: string) {
+  async deleteCrossTableEntry(clubId: string, id: string) {
+    const entry = await this.prisma.membershipTypeFeeType.findFirst({
+      where: { id, feeType: { clubId } },
+    });
+
+    if (!entry) {
+      throw new NotFoundException('Eintrag nicht gefunden');
+    }
+
     await this.prisma.membershipTypeFeeType.delete({
       where: { id },
     });

--- a/apps/api/src/fees/fee-types.service.ts
+++ b/apps/api/src/fees/fee-types.service.ts
@@ -66,13 +66,8 @@ export class FeeTypesService {
 
       return this.serializeFeeType(feeType);
     } catch (error) {
-      if (
-        error instanceof Prisma.PrismaClientKnownRequestError &&
-        error.code === 'P2002'
-      ) {
-        throw new ConflictException(
-          'Eine Beitragsart mit diesem Namen existiert bereits'
-        );
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+        throw new ConflictException('Eine Beitragsart mit diesem Namen existiert bereits');
       }
       throw error;
     }
@@ -210,10 +205,7 @@ export class FeeTypesService {
   private serializeCrossTableEntry(entry: any) {
     return {
       ...entry,
-      amount:
-        entry.amount instanceof Decimal
-          ? entry.amount.toFixed(2)
-          : String(entry.amount),
+      amount: entry.amount instanceof Decimal ? entry.amount.toFixed(2) : String(entry.amount),
     };
   }
 }

--- a/apps/api/src/fees/fees.controller.ts
+++ b/apps/api/src/fees/fees.controller.ts
@@ -1,0 +1,110 @@
+import { Controller, Get, Post, Patch, Delete, Param, Body, HttpCode } from '@nestjs/common';
+import { ApiTags, ApiBearerAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { RequireClubContext, GetClubContext } from '../common/decorators/club-context.decorator.js';
+import { RequirePermissions } from '../common/decorators/permissions.decorator.js';
+import { Permission } from '../common/permissions/permissions.enum.js';
+import { CurrentUser } from '../auth/decorators/current-user.decorator.js';
+import { FeesService } from './fees.service.js';
+import { CreateFeeCategoryDto } from './dto/create-fee-category.dto.js';
+import { UpdateFeeCategoryDto } from './dto/update-fee-category.dto.js';
+import { CreateMemberFeeOverrideDto } from './dto/create-member-fee-override.dto.js';
+import type { ClubContext } from '../common/decorators/club-context.decorator.js';
+
+@ApiTags('Fee Categories')
+@ApiBearerAuth()
+@Controller('clubs/:slug/fees')
+@RequireClubContext()
+export class FeesController {
+  constructor(private feesService: FeesService) {}
+
+  // ─── Fee Category Endpoints ─────────────────────────────────────────
+
+  @Get('categories')
+  @RequirePermissions([Permission.FINANCE_READ])
+  @ApiOperation({ summary: 'List all fee categories for club' })
+  @ApiResponse({ status: 200, description: 'List of fee categories' })
+  async findAllCategories(@GetClubContext() ctx: ClubContext) {
+    return this.feesService.findAll(ctx.clubId);
+  }
+
+  @Get('categories/:id')
+  @RequirePermissions([Permission.FINANCE_READ])
+  @ApiOperation({ summary: 'Get a single fee category' })
+  @ApiResponse({ status: 200, description: 'Fee category details' })
+  @ApiResponse({ status: 404, description: 'Fee category not found' })
+  async findOneCategory(@GetClubContext() ctx: ClubContext, @Param('id') id: string) {
+    return this.feesService.findOne(ctx.clubId, id);
+  }
+
+  @Post('categories')
+  @RequirePermissions([Permission.FINANCE_CREATE])
+  @ApiOperation({ summary: 'Create a new fee category' })
+  @ApiResponse({ status: 201, description: 'Fee category created' })
+  async createCategory(@GetClubContext() ctx: ClubContext, @Body() dto: CreateFeeCategoryDto) {
+    return this.feesService.create(ctx.clubId, dto);
+  }
+
+  @Patch('categories/:id')
+  @RequirePermissions([Permission.FINANCE_UPDATE])
+  @ApiOperation({ summary: 'Update a fee category' })
+  @ApiResponse({ status: 200, description: 'Fee category updated' })
+  @ApiResponse({ status: 404, description: 'Fee category not found' })
+  async updateCategory(
+    @GetClubContext() ctx: ClubContext,
+    @Param('id') id: string,
+    @Body() dto: UpdateFeeCategoryDto
+  ) {
+    return this.feesService.update(ctx.clubId, id, dto);
+  }
+
+  @Delete('categories/:id')
+  @HttpCode(204)
+  @RequirePermissions([Permission.FINANCE_DELETE])
+  @ApiOperation({ summary: 'Soft-delete a fee category' })
+  @ApiResponse({ status: 204, description: 'Fee category deleted' })
+  @ApiResponse({ status: 404, description: 'Fee category not found' })
+  async deleteCategory(
+    @GetClubContext() ctx: ClubContext,
+    @Param('id') id: string,
+    @CurrentUser('id') userId: string
+  ): Promise<void> {
+    await this.feesService.softDelete(ctx.clubId, id, userId);
+  }
+
+  // ─── Member Fee Override Endpoints ──────────────────────────────────
+
+  @Post('overrides')
+  @RequirePermissions([Permission.FINANCE_CREATE])
+  @ApiOperation({ summary: 'Create a member fee override' })
+  @ApiResponse({ status: 201, description: 'Override created' })
+  @ApiResponse({ status: 403, description: 'Member does not belong to this club' })
+  async createOverride(
+    @GetClubContext() ctx: ClubContext,
+    @Body() dto: CreateMemberFeeOverrideDto
+  ) {
+    return this.feesService.createOverride(ctx.clubId, dto);
+  }
+
+  @Get('overrides/member/:memberId')
+  @RequirePermissions([Permission.FINANCE_READ])
+  @ApiOperation({ summary: 'Get all fee overrides for a member' })
+  @ApiResponse({ status: 200, description: 'List of member fee overrides' })
+  @ApiResponse({ status: 403, description: 'Member does not belong to this club' })
+  async findOverridesForMember(
+    @GetClubContext() ctx: ClubContext,
+    @Param('memberId') memberId: string
+  ) {
+    return this.feesService.findOverridesForMember(ctx.clubId, memberId);
+  }
+
+  @Delete('overrides/:id')
+  @HttpCode(204)
+  @RequirePermissions([Permission.FINANCE_DELETE])
+  @ApiOperation({ summary: 'Delete a member fee override' })
+  @ApiResponse({ status: 204, description: 'Override deleted' })
+  @ApiResponse({ status: 403, description: 'Override belongs to member in different club' })
+  @ApiResponse({ status: 404, description: 'Override not found' })
+  async deleteOverride(@GetClubContext() ctx: ClubContext, @Param('id') id: string): Promise<void> {
+    await this.feesService.deleteOverride(ctx.clubId, id);
+  }
+}

--- a/apps/api/src/fees/fees.module.ts
+++ b/apps/api/src/fees/fees.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { FeesController } from './fees.controller.js';
+import { FeesService } from './fees.service.js';
+
+@Module({
+  controllers: [FeesController],
+  providers: [FeesService],
+  exports: [FeesService],
+})
+export class FeesModule {}

--- a/apps/api/src/fees/fees.module.ts
+++ b/apps/api/src/fees/fees.module.ts
@@ -1,10 +1,14 @@
 import { Module } from '@nestjs/common';
 import { FeesController } from './fees.controller.js';
 import { FeesService } from './fees.service.js';
+import { FeeChargesController } from './fee-charges.controller.js';
+import { FeeChargesService } from './fee-charges.service.js';
+import { PaymentsController } from './payments.controller.js';
+import { PaymentsService } from './payments.service.js';
 
 @Module({
-  controllers: [FeesController],
-  providers: [FeesService],
-  exports: [FeesService],
+  controllers: [FeesController, FeeChargesController, PaymentsController],
+  providers: [FeesService, FeeChargesService, PaymentsService],
+  exports: [FeesService, FeeChargesService, PaymentsService],
 })
 export class FeesModule {}

--- a/apps/api/src/fees/fees.module.ts
+++ b/apps/api/src/fees/fees.module.ts
@@ -3,12 +3,14 @@ import { FeesController } from './fees.controller.js';
 import { FeesService } from './fees.service.js';
 import { FeeChargesController } from './fee-charges.controller.js';
 import { FeeChargesService } from './fee-charges.service.js';
+import { FeeTypesController } from './fee-types.controller.js';
+import { FeeTypesService } from './fee-types.service.js';
 import { PaymentsController } from './payments.controller.js';
 import { PaymentsService } from './payments.service.js';
 
 @Module({
-  controllers: [FeesController, FeeChargesController, PaymentsController],
-  providers: [FeesService, FeeChargesService, PaymentsService],
-  exports: [FeesService, FeeChargesService, PaymentsService],
+  controllers: [FeesController, FeeChargesController, FeeTypesController, PaymentsController],
+  providers: [FeesService, FeeChargesService, FeeTypesService, PaymentsService],
+  exports: [FeesService, FeeChargesService, FeeTypesService, PaymentsService],
 })
 export class FeesModule {}

--- a/apps/api/src/fees/fees.service.spec.ts
+++ b/apps/api/src/fees/fees.service.spec.ts
@@ -1,0 +1,344 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { FeesService } from './fees.service.js';
+import type { PrismaService } from '../prisma/prisma.service.js';
+import { NotFoundException, ForbiddenException } from '@nestjs/common';
+import { Prisma } from '../../../../prisma/generated/client/index.js';
+
+const { Decimal } = Prisma;
+
+// Mock forClub() scoped DB — FeeCategory is tenant-scoped
+const mockDb = {
+  feeCategory: {
+    findMany: vi.fn(),
+    findFirst: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+  },
+};
+
+const mockPrisma = {
+  forClub: vi.fn(() => mockDb),
+  member: {
+    findFirst: vi.fn(),
+  },
+  memberFeeOverride: {
+    create: vi.fn(),
+    findMany: vi.fn(),
+    findFirst: vi.fn(),
+    delete: vi.fn(),
+  },
+} as unknown as PrismaService;
+
+const CLUB_ID = 'club-1';
+const OTHER_CLUB_ID = 'club-2';
+
+function makeCategory(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'fc-1',
+    clubId: CLUB_ID,
+    name: 'Aufnahmegebuehr',
+    description: null,
+    amount: new Decimal('50.00'),
+    billingInterval: 'ANNUALLY',
+    isActive: true,
+    isOneTime: true,
+    sortOrder: 0,
+    deletedAt: null,
+    deletedBy: null,
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+    ...overrides,
+  };
+}
+
+describe('FeesService', () => {
+  let service: FeesService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (mockPrisma.forClub as ReturnType<typeof vi.fn>).mockReturnValue(mockDb);
+    service = new FeesService(mockPrisma);
+  });
+
+  describe('findAll()', () => {
+    it('should return only active, non-deleted categories with Decimal as string', async () => {
+      const categories = [
+        makeCategory({ id: 'fc-1', name: 'Aufnahmegebuehr' }),
+        makeCategory({ id: 'fc-2', name: 'Tennisabteilung', amount: new Decimal('120.00') }),
+      ];
+      (mockDb.feeCategory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(categories);
+
+      const result = await service.findAll(CLUB_ID);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].amount).toBe('50.00');
+      expect(result[1].amount).toBe('120.00');
+      expect(mockPrisma.forClub).toHaveBeenCalledWith(CLUB_ID);
+      expect(mockDb.feeCategory.findMany).toHaveBeenCalledWith({
+        where: { deletedAt: null },
+        orderBy: [{ sortOrder: 'asc' }, { name: 'asc' }],
+      });
+    });
+  });
+
+  describe('findOne()', () => {
+    it('should return a single category with Decimal as string', async () => {
+      (mockDb.feeCategory.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeCategory());
+
+      const result = await service.findOne(CLUB_ID, 'fc-1');
+
+      expect(result.amount).toBe('50.00');
+      expect(result.id).toBe('fc-1');
+    });
+
+    it('should throw NotFoundException for non-existent or deleted category', async () => {
+      (mockDb.feeCategory.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+      await expect(service.findOne(CLUB_ID, 'nonexistent')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('create()', () => {
+    it('should create a fee category and return with Decimal as string', async () => {
+      const created = makeCategory({ id: 'fc-new' });
+      (mockDb.feeCategory.create as ReturnType<typeof vi.fn>).mockResolvedValue(created);
+
+      const result = await service.create(CLUB_ID, {
+        name: 'Aufnahmegebuehr',
+        amount: '50.00',
+        billingInterval: 'ANNUALLY',
+        isOneTime: true,
+      });
+
+      expect(result.id).toBe('fc-new');
+      expect(result.amount).toBe('50.00');
+      expect(mockDb.feeCategory.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          name: 'Aufnahmegebuehr',
+          amount: expect.any(Decimal),
+          billingInterval: 'ANNUALLY',
+          isOneTime: true,
+        }),
+      });
+    });
+  });
+
+  describe('update()', () => {
+    it('should update fee category amount and return with Decimal as string', async () => {
+      (mockDb.feeCategory.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeCategory());
+      (mockDb.feeCategory.update as ReturnType<typeof vi.fn>).mockResolvedValue(
+        makeCategory({ amount: new Decimal('75.00') })
+      );
+
+      const result = await service.update(CLUB_ID, 'fc-1', { amount: '75.00' });
+
+      expect(result.amount).toBe('75.00');
+    });
+
+    it('should throw NotFoundException if category not found or deleted', async () => {
+      (mockDb.feeCategory.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+      await expect(service.update(CLUB_ID, 'nonexistent', { name: 'X' })).rejects.toThrow(
+        NotFoundException
+      );
+    });
+  });
+
+  describe('softDelete()', () => {
+    it('should set deletedAt and deletedBy', async () => {
+      (mockDb.feeCategory.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeCategory());
+      const now = new Date();
+      (mockDb.feeCategory.update as ReturnType<typeof vi.fn>).mockResolvedValue(
+        makeCategory({ deletedAt: now, deletedBy: 'user-1' })
+      );
+
+      await service.softDelete(CLUB_ID, 'fc-1', 'user-1');
+
+      expect(mockDb.feeCategory.update).toHaveBeenCalledWith({
+        where: { id: 'fc-1' },
+        data: {
+          deletedAt: expect.any(Date),
+          deletedBy: 'user-1',
+        },
+      });
+    });
+
+    it('should throw NotFoundException if category not found', async () => {
+      (mockDb.feeCategory.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+      await expect(service.softDelete(CLUB_ID, 'nonexistent', 'user-1')).rejects.toThrow(
+        NotFoundException
+      );
+    });
+
+    it('should exclude soft-deleted categories from findAll', async () => {
+      (mockDb.feeCategory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+      const result = await service.findAll(CLUB_ID);
+
+      expect(result).toHaveLength(0);
+      expect(mockDb.feeCategory.findMany).toHaveBeenCalledWith({
+        where: { deletedAt: null },
+        orderBy: [{ sortOrder: 'asc' }, { name: 'asc' }],
+      });
+    });
+  });
+
+  describe('createOverride()', () => {
+    it('should create a member fee override with EXEMPT type', async () => {
+      // Member belongs to this club
+      (mockPrisma.member.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'member-1',
+        clubId: CLUB_ID,
+      });
+      (mockPrisma.memberFeeOverride.create as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'override-1',
+        memberId: 'member-1',
+        overrideType: 'EXEMPT',
+        customAmount: null,
+        reason: 'Ehrenmitglied',
+        isBaseFee: true,
+        feeCategoryId: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const result = await service.createOverride(CLUB_ID, {
+        memberId: 'member-1',
+        overrideType: 'EXEMPT',
+        reason: 'Ehrenmitglied',
+        isBaseFee: true,
+      });
+
+      expect(result.id).toBe('override-1');
+      expect(result.overrideType).toBe('EXEMPT');
+    });
+
+    it('should create a member fee override with CUSTOM_AMOUNT and store amount as string', async () => {
+      (mockPrisma.member.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'member-1',
+        clubId: CLUB_ID,
+      });
+      (mockPrisma.memberFeeOverride.create as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'override-2',
+        memberId: 'member-1',
+        overrideType: 'CUSTOM_AMOUNT',
+        customAmount: new Decimal('25.00'),
+        reason: 'Sozialtarif',
+        isBaseFee: false,
+        feeCategoryId: 'fc-1',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const result = await service.createOverride(CLUB_ID, {
+        memberId: 'member-1',
+        overrideType: 'CUSTOM_AMOUNT',
+        customAmount: '25.00',
+        feeCategoryId: 'fc-1',
+        reason: 'Sozialtarif',
+      });
+
+      expect(result.id).toBe('override-2');
+      expect(result.customAmount).toBe('25.00');
+    });
+
+    it('should reject memberId belonging to a different club (tenant isolation)', async () => {
+      // Member belongs to a DIFFERENT club
+      (mockPrisma.member.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+      await expect(
+        service.createOverride(CLUB_ID, {
+          memberId: 'member-other-club',
+          overrideType: 'EXEMPT',
+        })
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  describe('findOverridesForMember()', () => {
+    it('should return all overrides for a specific member with Decimal serialized', async () => {
+      (mockPrisma.member.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'member-1',
+        clubId: CLUB_ID,
+      });
+      (mockPrisma.memberFeeOverride.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
+        {
+          id: 'override-1',
+          memberId: 'member-1',
+          overrideType: 'EXEMPT',
+          customAmount: null,
+          reason: 'Ehrenmitglied',
+          isBaseFee: true,
+          feeCategoryId: null,
+          feeCategory: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          id: 'override-2',
+          memberId: 'member-1',
+          overrideType: 'CUSTOM_AMOUNT',
+          customAmount: new Decimal('25.00'),
+          reason: 'Sozialtarif',
+          isBaseFee: false,
+          feeCategoryId: 'fc-1',
+          feeCategory: { id: 'fc-1', name: 'Tennisabteilung' },
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ]);
+
+      const result = await service.findOverridesForMember(CLUB_ID, 'member-1');
+
+      expect(result).toHaveLength(2);
+      expect(result[0].customAmount).toBeNull();
+      expect(result[1].customAmount).toBe('25.00');
+    });
+
+    it('should reject if member belongs to different club', async () => {
+      (mockPrisma.member.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+      await expect(service.findOverridesForMember(CLUB_ID, 'member-other')).rejects.toThrow(
+        ForbiddenException
+      );
+    });
+  });
+
+  describe('deleteOverride()', () => {
+    it('should hard-delete an override', async () => {
+      (mockPrisma.memberFeeOverride.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'override-1',
+        memberId: 'member-1',
+        member: { id: 'member-1', clubId: CLUB_ID },
+      });
+      (mockPrisma.memberFeeOverride.delete as ReturnType<typeof vi.fn>).mockResolvedValue({});
+
+      await service.deleteOverride(CLUB_ID, 'override-1');
+
+      expect(mockPrisma.memberFeeOverride.delete).toHaveBeenCalledWith({
+        where: { id: 'override-1' },
+      });
+    });
+
+    it('should reject overrideId belonging to a member in a different club (tenant isolation)', async () => {
+      (mockPrisma.memberFeeOverride.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'override-1',
+        memberId: 'member-other',
+        member: { id: 'member-other', clubId: OTHER_CLUB_ID },
+      });
+
+      await expect(service.deleteOverride(CLUB_ID, 'override-1')).rejects.toThrow(
+        ForbiddenException
+      );
+    });
+
+    it('should throw NotFoundException if override does not exist', async () => {
+      (mockPrisma.memberFeeOverride.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+      await expect(service.deleteOverride(CLUB_ID, 'nonexistent')).rejects.toThrow(
+        NotFoundException
+      );
+    });
+  });
+});

--- a/apps/api/src/fees/fees.service.spec.ts
+++ b/apps/api/src/fees/fees.service.spec.ts
@@ -71,8 +71,8 @@ describe('FeesService', () => {
       const result = await service.findAll(CLUB_ID);
 
       expect(result).toHaveLength(2);
-      expect(result[0].amount).toBe('50.00');
-      expect(result[1].amount).toBe('120.00');
+      expect(result[0]!.amount).toBe('50.00');
+      expect(result[1]!.amount).toBe('120.00');
       expect(mockPrisma.forClub).toHaveBeenCalledWith(CLUB_ID);
       expect(mockDb.feeCategory.findMany).toHaveBeenCalledWith({
         where: { deletedAt: null },
@@ -292,8 +292,8 @@ describe('FeesService', () => {
       const result = await service.findOverridesForMember(CLUB_ID, 'member-1');
 
       expect(result).toHaveLength(2);
-      expect(result[0].customAmount).toBeNull();
-      expect(result[1].customAmount).toBe('25.00');
+      expect(result[0]!.customAmount).toBeNull();
+      expect(result[1]!.customAmount).toBe('25.00');
     });
 
     it('should reject if member belongs to different club', async () => {

--- a/apps/api/src/fees/fees.service.spec.ts
+++ b/apps/api/src/fees/fees.service.spec.ts
@@ -11,6 +11,7 @@ const mockDb = {
   feeCategory: {
     findMany: vi.fn(),
     findFirst: vi.fn(),
+    findUnique: vi.fn(),
     create: vi.fn(),
     update: vi.fn(),
   },
@@ -27,6 +28,11 @@ const mockPrisma = {
     findFirst: vi.fn(),
     delete: vi.fn(),
   },
+  feeCategoryMembershipType: {
+    createMany: vi.fn(),
+    deleteMany: vi.fn(),
+  },
+  $transaction: vi.fn(),
 } as unknown as PrismaService;
 
 const CLUB_ID = 'club-1';
@@ -36,13 +42,15 @@ function makeCategory(overrides: Record<string, unknown> = {}) {
   return {
     id: 'fc-1',
     clubId: CLUB_ID,
-    name: 'Aufnahmegebuehr',
+    name: 'Aufnahmegebühr',
     description: null,
     amount: new Decimal('50.00'),
     billingInterval: 'ANNUALLY',
     isActive: true,
     isOneTime: true,
     sortOrder: 0,
+    scope: 'ALL_MEMBERS',
+    feeCategoryMembershipTypes: [],
     deletedAt: null,
     deletedBy: null,
     createdAt: new Date('2026-01-01'),
@@ -61,9 +69,9 @@ describe('FeesService', () => {
   });
 
   describe('findAll()', () => {
-    it('should return only active, non-deleted categories with Decimal as string', async () => {
+    it('should return only active, non-deleted categories with Decimal as string and scope', async () => {
       const categories = [
-        makeCategory({ id: 'fc-1', name: 'Aufnahmegebuehr' }),
+        makeCategory({ id: 'fc-1', name: 'Aufnahmegebühr' }),
         makeCategory({ id: 'fc-2', name: 'Tennisabteilung', amount: new Decimal('120.00') }),
       ];
       (mockDb.feeCategory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(categories);
@@ -72,11 +80,14 @@ describe('FeesService', () => {
 
       expect(result).toHaveLength(2);
       expect(result[0]!.amount).toBe('50.00');
+      expect(result[0]!.scope).toBe('ALL_MEMBERS');
+      expect(result[0]!.membershipTypes).toEqual([]);
       expect(result[1]!.amount).toBe('120.00');
       expect(mockPrisma.forClub).toHaveBeenCalledWith(CLUB_ID);
       expect(mockDb.feeCategory.findMany).toHaveBeenCalledWith({
         where: { deletedAt: null },
         orderBy: [{ sortOrder: 'asc' }, { name: 'asc' }],
+        include: { feeCategoryMembershipTypes: true },
       });
     });
   });
@@ -99,12 +110,20 @@ describe('FeesService', () => {
   });
 
   describe('create()', () => {
+    beforeEach(() => {
+      // Default transaction mock — runs the callback with mockPrisma as tx
+      (mockPrisma.$transaction as ReturnType<typeof vi.fn>).mockImplementation(
+        async (fn: (tx: unknown) => Promise<unknown>) => fn(mockPrisma)
+      );
+    });
+
     it('should create a fee category and return with Decimal as string', async () => {
       const created = makeCategory({ id: 'fc-new' });
       (mockDb.feeCategory.create as ReturnType<typeof vi.fn>).mockResolvedValue(created);
+      (mockDb.feeCategory.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(created);
 
       const result = await service.create(CLUB_ID, {
-        name: 'Aufnahmegebuehr',
+        name: 'Aufnahmegebühr',
         amount: '50.00',
         billingInterval: 'ANNUALLY',
         isOneTime: true,
@@ -112,23 +131,62 @@ describe('FeesService', () => {
 
       expect(result.id).toBe('fc-new');
       expect(result.amount).toBe('50.00');
+      expect(result.scope).toBe('ALL_MEMBERS');
+      expect(result.membershipTypes).toEqual([]);
       expect(mockDb.feeCategory.create).toHaveBeenCalledWith({
         data: expect.objectContaining({
-          name: 'Aufnahmegebuehr',
+          name: 'Aufnahmegebühr',
           amount: expect.any(Decimal),
           billingInterval: 'ANNUALLY',
           isOneTime: true,
+          scope: 'ALL_MEMBERS',
         }),
+      });
+    });
+
+    it('should create join records when scope is BY_MEMBERSHIP_TYPE', async () => {
+      const created = makeCategory({
+        id: 'fc-mt',
+        scope: 'BY_MEMBERSHIP_TYPE',
+        feeCategoryMembershipTypes: [
+          { id: 'fcmt-1', feeCategoryId: 'fc-mt', membershipTypeId: 'mt-1' },
+        ],
+      });
+      (mockDb.feeCategory.create as ReturnType<typeof vi.fn>).mockResolvedValue(created);
+      (mockDb.feeCategory.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(created);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (
+        (mockPrisma as any).feeCategoryMembershipType.createMany as ReturnType<typeof vi.fn>
+      ).mockResolvedValue({ count: 1 });
+
+      const result = await service.create(CLUB_ID, {
+        name: 'Tennisabteilung',
+        amount: '50.00',
+        scope: 'BY_MEMBERSHIP_TYPE' as 'ALL_MEMBERS' | 'BY_MEMBERSHIP_TYPE' | 'INDIVIDUAL',
+        membershipTypeIds: ['mt-1'],
+      });
+
+      expect(result.scope).toBe('BY_MEMBERSHIP_TYPE');
+      expect(result.membershipTypes).toHaveLength(1);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((mockPrisma as any).feeCategoryMembershipType.createMany).toHaveBeenCalledWith({
+        data: [{ feeCategoryId: 'fc-mt', membershipTypeId: 'mt-1' }],
       });
     });
   });
 
   describe('update()', () => {
-    it('should update fee category amount and return with Decimal as string', async () => {
-      (mockDb.feeCategory.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeCategory());
-      (mockDb.feeCategory.update as ReturnType<typeof vi.fn>).mockResolvedValue(
-        makeCategory({ amount: new Decimal('75.00') })
+    beforeEach(() => {
+      (mockPrisma.$transaction as ReturnType<typeof vi.fn>).mockImplementation(
+        async (fn: (tx: unknown) => Promise<unknown>) => fn(mockPrisma)
       );
+    });
+
+    it('should update fee category amount and return with Decimal as string', async () => {
+      const updated = makeCategory({ amount: new Decimal('75.00') });
+      (mockDb.feeCategory.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeCategory());
+      (mockDb.feeCategory.update as ReturnType<typeof vi.fn>).mockResolvedValue(updated);
+      (mockDb.feeCategory.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(updated);
 
       const result = await service.update(CLUB_ID, 'fc-1', { amount: '75.00' });
 
@@ -141,6 +199,34 @@ describe('FeesService', () => {
       await expect(service.update(CLUB_ID, 'nonexistent', { name: 'X' })).rejects.toThrow(
         NotFoundException
       );
+    });
+
+    it('should update scope and manage join records', async () => {
+      const updated = makeCategory({
+        scope: 'BY_MEMBERSHIP_TYPE',
+        feeCategoryMembershipTypes: [
+          { id: 'fcmt-1', feeCategoryId: 'fc-1', membershipTypeId: 'mt-1' },
+        ],
+      });
+      (mockDb.feeCategory.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeCategory());
+      (mockDb.feeCategory.update as ReturnType<typeof vi.fn>).mockResolvedValue(updated);
+      (mockDb.feeCategory.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(updated);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (
+        (mockPrisma as any).feeCategoryMembershipType.deleteMany as ReturnType<typeof vi.fn>
+      ).mockResolvedValue({ count: 0 });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (
+        (mockPrisma as any).feeCategoryMembershipType.createMany as ReturnType<typeof vi.fn>
+      ).mockResolvedValue({ count: 1 });
+
+      const result = await service.update(CLUB_ID, 'fc-1', {
+        scope: 'BY_MEMBERSHIP_TYPE' as 'ALL_MEMBERS' | 'BY_MEMBERSHIP_TYPE' | 'INDIVIDUAL',
+        membershipTypeIds: ['mt-1'],
+      });
+
+      expect(result.scope).toBe('BY_MEMBERSHIP_TYPE');
+      expect(result.membershipTypes).toHaveLength(1);
     });
   });
 
@@ -180,6 +266,7 @@ describe('FeesService', () => {
       expect(mockDb.feeCategory.findMany).toHaveBeenCalledWith({
         where: { deletedAt: null },
         orderBy: [{ sortOrder: 'asc' }, { name: 'asc' }],
+        include: { feeCategoryMembershipTypes: true },
       });
     });
   });

--- a/apps/api/src/fees/fees.service.spec.ts
+++ b/apps/api/src/fees/fees.service.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { FeesService } from './fees.service.js';
 import type { PrismaService } from '../prisma/prisma.service.js';
-import { NotFoundException, ForbiddenException } from '@nestjs/common';
+import { NotFoundException, ForbiddenException, BadRequestException } from '@nestjs/common';
 import { Prisma } from '../../../../prisma/generated/client/index.js';
 
 const { Decimal } = Prisma;
@@ -17,8 +17,17 @@ const mockDb = {
   },
 };
 
+// Join-table mock (tenant-unscoped delegate) — typed so tests call .mockResolvedValue without casts
+const mockJoinTable = {
+  createMany: vi.fn(),
+  deleteMany: vi.fn(),
+};
+
 const mockPrisma = {
   forClub: vi.fn(() => mockDb),
+  // tx-based writes (CR-03) call tx.feeCategory.* — point at the same mock
+  // functions used by the forClub-scoped mockDb so existing setups apply.
+  feeCategory: mockDb.feeCategory,
   member: {
     findFirst: vi.fn(),
   },
@@ -28,10 +37,7 @@ const mockPrisma = {
     findFirst: vi.fn(),
     delete: vi.fn(),
   },
-  feeCategoryMembershipType: {
-    createMany: vi.fn(),
-    deleteMany: vi.fn(),
-  },
+  feeCategoryMembershipType: mockJoinTable,
   $transaction: vi.fn(),
 } as unknown as PrismaService;
 
@@ -154,10 +160,7 @@ describe('FeesService', () => {
       });
       (mockDb.feeCategory.create as ReturnType<typeof vi.fn>).mockResolvedValue(created);
       (mockDb.feeCategory.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(created);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (
-        (mockPrisma as any).feeCategoryMembershipType.createMany as ReturnType<typeof vi.fn>
-      ).mockResolvedValue({ count: 1 });
+      mockJoinTable.createMany.mockResolvedValue({ count: 1 });
 
       const result = await service.create(CLUB_ID, {
         name: 'Tennisabteilung',
@@ -168,8 +171,7 @@ describe('FeesService', () => {
 
       expect(result.scope).toBe('BY_MEMBERSHIP_TYPE');
       expect(result.membershipTypes).toHaveLength(1);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      expect((mockPrisma as any).feeCategoryMembershipType.createMany).toHaveBeenCalledWith({
+      expect(mockJoinTable.createMany).toHaveBeenCalledWith({
         data: [{ feeCategoryId: 'fc-mt', membershipTypeId: 'mt-1' }],
       });
     });
@@ -211,14 +213,8 @@ describe('FeesService', () => {
       (mockDb.feeCategory.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeCategory());
       (mockDb.feeCategory.update as ReturnType<typeof vi.fn>).mockResolvedValue(updated);
       (mockDb.feeCategory.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(updated);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (
-        (mockPrisma as any).feeCategoryMembershipType.deleteMany as ReturnType<typeof vi.fn>
-      ).mockResolvedValue({ count: 0 });
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (
-        (mockPrisma as any).feeCategoryMembershipType.createMany as ReturnType<typeof vi.fn>
-      ).mockResolvedValue({ count: 1 });
+      mockJoinTable.deleteMany.mockResolvedValue({ count: 0 });
+      mockJoinTable.createMany.mockResolvedValue({ count: 1 });
 
       const result = await service.update(CLUB_ID, 'fc-1', {
         scope: 'BY_MEMBERSHIP_TYPE' as 'ALL_MEMBERS' | 'BY_MEMBERSHIP_TYPE' | 'INDIVIDUAL',
@@ -306,6 +302,10 @@ describe('FeesService', () => {
         id: 'member-1',
         clubId: CLUB_ID,
       });
+      // feeCategoryId is set -> club ownership lookup must succeed
+      (mockDb.feeCategory.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(
+        makeCategory({ id: 'fc-1' })
+      );
       (mockPrisma.memberFeeOverride.create as ReturnType<typeof vi.fn>).mockResolvedValue({
         id: 'override-2',
         memberId: 'member-1',
@@ -328,6 +328,27 @@ describe('FeesService', () => {
 
       expect(result.id).toBe('override-2');
       expect(result.customAmount).toBe('25.00');
+    });
+
+    it('should reject a feeCategoryId belonging to a different club (CR-02 tenant isolation)', async () => {
+      // Member belongs to this club...
+      (mockPrisma.member.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'member-1',
+        clubId: CLUB_ID,
+      });
+      // ...but the fee category lookup scoped to this club finds nothing
+      (mockDb.feeCategory.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+      await expect(
+        service.createOverride(CLUB_ID, {
+          memberId: 'member-1',
+          overrideType: 'CUSTOM_AMOUNT',
+          customAmount: '25.00',
+          feeCategoryId: 'fc-other-club',
+          reason: 'Sozialtarif',
+        })
+      ).rejects.toThrow(BadRequestException);
+      expect(mockPrisma.memberFeeOverride.create).not.toHaveBeenCalled();
     });
 
     it('should reject memberId belonging to a different club (tenant isolation)', async () => {

--- a/apps/api/src/fees/fees.service.ts
+++ b/apps/api/src/fees/fees.service.ts
@@ -1,0 +1,223 @@
+import { Injectable, NotFoundException, ForbiddenException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { CreateFeeCategoryDto } from './dto/create-fee-category.dto.js';
+import { UpdateFeeCategoryDto } from './dto/update-fee-category.dto.js';
+import { CreateMemberFeeOverrideDto } from './dto/create-member-fee-override.dto.js';
+import { Prisma } from '../../../../prisma/generated/client/index.js';
+
+const { Decimal } = Prisma;
+
+@Injectable()
+export class FeesService {
+  constructor(private prisma: PrismaService) {}
+
+  // ─── Fee Category CRUD ──────────────────────────────────────────────
+
+  /**
+   * List all active, non-deleted fee categories for a club.
+   * Ordered by sortOrder then name.
+   */
+  async findAll(clubId: string) {
+    const db = this.prisma.forClub(clubId);
+    const categories = await db.feeCategory.findMany({
+      where: { deletedAt: null },
+      orderBy: [{ sortOrder: 'asc' }, { name: 'asc' }],
+    });
+
+    return categories.map((c) => this.serializeCategory(c));
+  }
+
+  /**
+   * Get a single fee category by ID within club scope.
+   */
+  async findOne(clubId: string, id: string) {
+    const db = this.prisma.forClub(clubId);
+    const category = await db.feeCategory.findFirst({
+      where: { id, deletedAt: null },
+    });
+
+    if (!category) {
+      throw new NotFoundException('Beitragskategorie nicht gefunden');
+    }
+
+    return this.serializeCategory(category);
+  }
+
+  /**
+   * Create a new fee category.
+   * Converts amount string to Decimal for storage.
+   */
+  async create(clubId: string, dto: CreateFeeCategoryDto) {
+    const db = this.prisma.forClub(clubId);
+    const category = await db.feeCategory.create({
+      data: {
+        name: dto.name,
+        description: dto.description,
+        amount: new Decimal(dto.amount),
+        billingInterval: dto.billingInterval ?? 'ANNUALLY',
+        isOneTime: dto.isOneTime ?? false,
+        sortOrder: dto.sortOrder ?? 0,
+      },
+    });
+
+    return this.serializeCategory(category);
+  }
+
+  /**
+   * Update an existing fee category.
+   * Throws NotFoundException if not found or deleted.
+   */
+  async update(clubId: string, id: string, dto: UpdateFeeCategoryDto) {
+    const db = this.prisma.forClub(clubId);
+    const existing = await db.feeCategory.findFirst({
+      where: { id, deletedAt: null },
+    });
+
+    if (!existing) {
+      throw new NotFoundException('Beitragskategorie nicht gefunden');
+    }
+
+    const category = await db.feeCategory.update({
+      where: { id },
+      data: {
+        ...(dto.name !== undefined && { name: dto.name }),
+        ...(dto.description !== undefined && { description: dto.description }),
+        ...(dto.amount !== undefined && { amount: new Decimal(dto.amount) }),
+        ...(dto.billingInterval !== undefined && { billingInterval: dto.billingInterval }),
+        ...(dto.isOneTime !== undefined && { isOneTime: dto.isOneTime }),
+        ...(dto.isActive !== undefined && { isActive: dto.isActive }),
+        ...(dto.sortOrder !== undefined && { sortOrder: dto.sortOrder }),
+      },
+    });
+
+    return this.serializeCategory(category);
+  }
+
+  /**
+   * Soft-delete a fee category (CONV-006).
+   * Sets deletedAt/deletedBy. Category excluded from future findAll.
+   */
+  async softDelete(clubId: string, id: string, userId: string) {
+    const db = this.prisma.forClub(clubId);
+    const existing = await db.feeCategory.findFirst({
+      where: { id, deletedAt: null },
+    });
+
+    if (!existing) {
+      throw new NotFoundException('Beitragskategorie nicht gefunden');
+    }
+
+    await db.feeCategory.update({
+      where: { id },
+      data: {
+        deletedAt: new Date(),
+        deletedBy: userId,
+      },
+    });
+  }
+
+  // ─── Member Fee Overrides ───────────────────────────────────────────
+
+  /**
+   * Create a per-member fee override.
+   * Validates tenant isolation: member must belong to the specified club.
+   */
+  async createOverride(clubId: string, dto: CreateMemberFeeOverrideDto) {
+    await this.validateMemberBelongsToClub(clubId, dto.memberId);
+
+    const override = await this.prisma.memberFeeOverride.create({
+      data: {
+        memberId: dto.memberId,
+        feeCategoryId: dto.feeCategoryId,
+        overrideType: dto.overrideType,
+        customAmount: dto.customAmount ? new Decimal(dto.customAmount) : undefined,
+        reason: dto.reason,
+        isBaseFee: dto.isBaseFee ?? false,
+      },
+    });
+
+    return this.serializeOverride(override);
+  }
+
+  /**
+   * Find all overrides for a specific member.
+   * Validates tenant isolation: member must belong to the specified club.
+   */
+  async findOverridesForMember(clubId: string, memberId: string) {
+    await this.validateMemberBelongsToClub(clubId, memberId);
+
+    const overrides = await this.prisma.memberFeeOverride.findMany({
+      where: { memberId },
+      include: { feeCategory: true },
+    });
+
+    return overrides.map((o) => this.serializeOverride(o));
+  }
+
+  /**
+   * Delete a member fee override (hard delete).
+   * Validates tenant isolation: override's member must belong to the specified club.
+   */
+  async deleteOverride(clubId: string, overrideId: string) {
+    const override = await this.prisma.memberFeeOverride.findFirst({
+      where: { id: overrideId },
+      include: { member: true },
+    });
+
+    if (!override) {
+      throw new NotFoundException('Override nicht gefunden');
+    }
+
+    if (override.member.clubId !== clubId) {
+      throw new ForbiddenException('Zugriff verweigert: Mitglied gehoert nicht zu diesem Verein');
+    }
+
+    await this.prisma.memberFeeOverride.delete({
+      where: { id: overrideId },
+    });
+  }
+
+  // ─── Private Helpers ────────────────────────────────────────────────
+
+  /**
+   * Validate that a member belongs to the specified club.
+   * Throws ForbiddenException if the member is not found in this club.
+   */
+  private async validateMemberBelongsToClub(clubId: string, memberId: string) {
+    const member = await this.prisma.member.findFirst({
+      where: { id: memberId, clubId },
+    });
+
+    if (!member) {
+      throw new ForbiddenException('Zugriff verweigert: Mitglied gehoert nicht zu diesem Verein');
+    }
+  }
+
+  /**
+   * Serialize a fee category record, converting Decimal fields to strings.
+   * (Pitfall 1 from RESEARCH.md)
+   */
+  private serializeCategory(category: Record<string, unknown>) {
+    return {
+      ...category,
+      amount:
+        category.amount instanceof Decimal ? category.amount.toFixed(2) : String(category.amount),
+    };
+  }
+
+  /**
+   * Serialize a member fee override record, converting Decimal fields to strings.
+   */
+  private serializeOverride(override: Record<string, unknown>) {
+    const customAmount = override.customAmount;
+    return {
+      ...override,
+      customAmount:
+        customAmount === null || customAmount === undefined
+          ? customAmount
+          : customAmount instanceof Decimal
+            ? customAmount.toFixed(2)
+            : String(customAmount),
+    };
+  }
+}

--- a/apps/api/src/fees/fees.service.ts
+++ b/apps/api/src/fees/fees.service.ts
@@ -49,6 +49,7 @@ export class FeesService {
    */
   async create(clubId: string, dto: CreateFeeCategoryDto) {
     const db = this.prisma.forClub(clubId);
+    // clubId is injected by forClub() tenant extension at runtime
     const category = await db.feeCategory.create({
       data: {
         name: dto.name,
@@ -57,7 +58,7 @@ export class FeesService {
         billingInterval: dto.billingInterval ?? 'ANNUALLY',
         isOneTime: dto.isOneTime ?? false,
         sortOrder: dto.sortOrder ?? 0,
-      },
+      } as Prisma.FeeCategoryUncheckedCreateInput,
     });
 
     return this.serializeCategory(category);
@@ -197,7 +198,8 @@ export class FeesService {
    * Serialize a fee category record, converting Decimal fields to strings.
    * (Pitfall 1 from RESEARCH.md)
    */
-  private serializeCategory(category: Record<string, unknown>) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private serializeCategory(category: any) {
     return {
       ...category,
       amount:
@@ -208,7 +210,8 @@ export class FeesService {
   /**
    * Serialize a member fee override record, converting Decimal fields to strings.
    */
-  private serializeOverride(override: Record<string, unknown>) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private serializeOverride(override: any) {
     const customAmount = override.customAmount;
     return {
       ...override,

--- a/apps/api/src/fees/fees.service.ts
+++ b/apps/api/src/fees/fees.service.ts
@@ -22,6 +22,9 @@ export class FeesService {
     const categories = await db.feeCategory.findMany({
       where: { deletedAt: null },
       orderBy: [{ sortOrder: 'asc' }, { name: 'asc' }],
+      include: {
+        feeCategoryMembershipTypes: true,
+      },
     });
 
     return categories.map((c) => this.serializeCategory(c));
@@ -34,6 +37,9 @@ export class FeesService {
     const db = this.prisma.forClub(clubId);
     const category = await db.feeCategory.findFirst({
       where: { id, deletedAt: null },
+      include: {
+        feeCategoryMembershipTypes: true,
+      },
     });
 
     if (!category) {
@@ -49,19 +55,39 @@ export class FeesService {
    */
   async create(clubId: string, dto: CreateFeeCategoryDto) {
     const db = this.prisma.forClub(clubId);
-    // clubId is injected by forClub() tenant extension at runtime
-    const category = await db.feeCategory.create({
-      data: {
-        name: dto.name,
-        description: dto.description,
-        amount: new Decimal(dto.amount),
-        billingInterval: dto.billingInterval ?? 'ANNUALLY',
-        isOneTime: dto.isOneTime ?? false,
-        sortOrder: dto.sortOrder ?? 0,
-      } as Prisma.FeeCategoryUncheckedCreateInput,
+
+    // Use transaction when scope requires join table records
+    const result = await this.prisma.$transaction(async (tx) => {
+      const category = await db.feeCategory.create({
+        data: {
+          name: dto.name,
+          description: dto.description,
+          amount: new Decimal(dto.amount),
+          billingInterval: dto.billingInterval ?? 'ANNUALLY',
+          isOneTime: dto.isOneTime ?? false,
+          sortOrder: dto.sortOrder ?? 0,
+          scope: dto.scope ?? 'ALL_MEMBERS',
+        } as Prisma.FeeCategoryUncheckedCreateInput,
+      });
+
+      // Create join records for BY_MEMBERSHIP_TYPE scope
+      if (dto.scope === 'BY_MEMBERSHIP_TYPE' && dto.membershipTypeIds?.length) {
+        await tx.feeCategoryMembershipType.createMany({
+          data: dto.membershipTypeIds.map((mtId: string) => ({
+            feeCategoryId: category.id,
+            membershipTypeId: mtId,
+          })),
+        });
+      }
+
+      // Re-fetch with relations
+      return db.feeCategory.findUnique({
+        where: { id: category.id },
+        include: { feeCategoryMembershipTypes: true },
+      });
     });
 
-    return this.serializeCategory(category);
+    return this.serializeCategory(result);
   }
 
   /**
@@ -78,20 +104,47 @@ export class FeesService {
       throw new NotFoundException('Beitragskategorie nicht gefunden');
     }
 
-    const category = await db.feeCategory.update({
-      where: { id },
-      data: {
-        ...(dto.name !== undefined && { name: dto.name }),
-        ...(dto.description !== undefined && { description: dto.description }),
-        ...(dto.amount !== undefined && { amount: new Decimal(dto.amount) }),
-        ...(dto.billingInterval !== undefined && { billingInterval: dto.billingInterval }),
-        ...(dto.isOneTime !== undefined && { isOneTime: dto.isOneTime }),
-        ...(dto.isActive !== undefined && { isActive: dto.isActive }),
-        ...(dto.sortOrder !== undefined && { sortOrder: dto.sortOrder }),
-      },
+    const result = await this.prisma.$transaction(async (tx) => {
+      const category = await db.feeCategory.update({
+        where: { id },
+        data: {
+          ...(dto.name !== undefined && { name: dto.name }),
+          ...(dto.description !== undefined && { description: dto.description }),
+          ...(dto.amount !== undefined && { amount: new Decimal(dto.amount) }),
+          ...(dto.billingInterval !== undefined && { billingInterval: dto.billingInterval }),
+          ...(dto.isOneTime !== undefined && { isOneTime: dto.isOneTime }),
+          ...(dto.isActive !== undefined && { isActive: dto.isActive }),
+          ...(dto.sortOrder !== undefined && { sortOrder: dto.sortOrder }),
+          ...(dto.scope !== undefined && { scope: dto.scope }),
+        },
+      });
+
+      // Update join records if membershipTypeIds is provided
+      if (dto.membershipTypeIds !== undefined) {
+        // Delete existing join records
+        await tx.feeCategoryMembershipType.deleteMany({
+          where: { feeCategoryId: id },
+        });
+
+        // Create new join records
+        if (dto.membershipTypeIds.length > 0) {
+          await tx.feeCategoryMembershipType.createMany({
+            data: dto.membershipTypeIds.map((mtId: string) => ({
+              feeCategoryId: id,
+              membershipTypeId: mtId,
+            })),
+          });
+        }
+      }
+
+      // Re-fetch with relations
+      return db.feeCategory.findUnique({
+        where: { id: category.id },
+        include: { feeCategoryMembershipTypes: true },
+      });
     });
 
-    return this.serializeCategory(category);
+    return this.serializeCategory(result);
   }
 
   /**
@@ -200,10 +253,13 @@ export class FeesService {
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private serializeCategory(category: any) {
+    const { feeCategoryMembershipTypes, ...rest } = category ?? {};
     return {
-      ...category,
+      ...rest,
       amount:
         category.amount instanceof Decimal ? category.amount.toFixed(2) : String(category.amount),
+      scope: category.scope ?? 'ALL_MEMBERS',
+      membershipTypes: feeCategoryMembershipTypes ?? [],
     };
   }
 

--- a/apps/api/src/fees/fees.service.ts
+++ b/apps/api/src/fees/fees.service.ts
@@ -1,4 +1,9 @@
-import { Injectable, NotFoundException, ForbiddenException } from '@nestjs/common';
+import {
+  Injectable,
+  NotFoundException,
+  ForbiddenException,
+  BadRequestException,
+} from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service.js';
 import { CreateFeeCategoryDto } from './dto/create-fee-category.dto.js';
 import { UpdateFeeCategoryDto } from './dto/update-fee-category.dto.js';
@@ -54,12 +59,13 @@ export class FeesService {
    * Converts amount string to Decimal for storage.
    */
   async create(clubId: string, dto: CreateFeeCategoryDto) {
-    const db = this.prisma.forClub(clubId);
-
-    // Use transaction when scope requires join table records
+    // All writes run through `tx` so the category and its join records are
+    // committed atomically. `tx` is NOT club-extended, so clubId is injected
+    // explicitly via FeeCategoryUncheckedCreateInput.
     const result = await this.prisma.$transaction(async (tx) => {
-      const category = await db.feeCategory.create({
+      const category = await tx.feeCategory.create({
         data: {
+          clubId,
           name: dto.name,
           description: dto.description,
           amount: new Decimal(dto.amount),
@@ -81,7 +87,7 @@ export class FeesService {
       }
 
       // Re-fetch with relations
-      return db.feeCategory.findUnique({
+      return tx.feeCategory.findUnique({
         where: { id: category.id },
         include: { feeCategoryMembershipTypes: true },
       });
@@ -104,8 +110,11 @@ export class FeesService {
       throw new NotFoundException('Beitragskategorie nicht gefunden');
     }
 
+    // The pre-check findFirst above already enforced club ownership, so an
+    // update/find by id inside `tx` is club-safe. All writes run through `tx`
+    // so the entity update and join-record rewrite are committed atomically.
     const result = await this.prisma.$transaction(async (tx) => {
-      const category = await db.feeCategory.update({
+      const category = await tx.feeCategory.update({
         where: { id },
         data: {
           ...(dto.name !== undefined && { name: dto.name }),
@@ -138,7 +147,7 @@ export class FeesService {
       }
 
       // Re-fetch with relations
-      return db.feeCategory.findUnique({
+      return tx.feeCategory.findUnique({
         where: { id: category.id },
         include: { feeCategoryMembershipTypes: true },
       });
@@ -179,6 +188,22 @@ export class FeesService {
   async createOverride(clubId: string, dto: CreateMemberFeeOverrideDto) {
     await this.validateMemberBelongsToClub(clubId, dto.memberId);
 
+    // Validate the referenced fee category belongs to this club, mirroring the
+    // member check. forClub() enforces the tenant scope on the lookup.
+    if (dto.feeCategoryId) {
+      const feeCategory = await this.prisma.forClub(clubId).feeCategory.findFirst({
+        where: { id: dto.feeCategoryId, deletedAt: null },
+      });
+      if (!feeCategory) {
+        throw new BadRequestException(
+          'Die gewählte Beitragskategorie gehört nicht zu diesem Verein'
+        );
+      }
+    }
+
+    // Tenant-safe: memberId is validated via validateMemberBelongsToClub above
+    // and feeCategoryId is validated against the club scope above, so this
+    // unscoped-model write cannot cross tenant boundaries.
     const override = await this.prisma.memberFeeOverride.create({
       data: {
         memberId: dto.memberId,
@@ -200,6 +225,8 @@ export class FeesService {
   async findOverridesForMember(clubId: string, memberId: string) {
     await this.validateMemberBelongsToClub(clubId, memberId);
 
+    // Tenant-safe: memberId is validated via validateMemberBelongsToClub above,
+    // so this unscoped-model query only returns overrides for an in-club member.
     const overrides = await this.prisma.memberFeeOverride.findMany({
       where: { memberId },
       include: { feeCategory: true },
@@ -213,6 +240,9 @@ export class FeesService {
    * Validates tenant isolation: override's member must belong to the specified club.
    */
   async deleteOverride(clubId: string, overrideId: string) {
+    // Tenant-safe: the unscoped lookup loads the override's member relation, and
+    // the member.clubId check below rejects any override outside this club
+    // before the delete runs.
     const override = await this.prisma.memberFeeOverride.findFirst({
       where: { id: overrideId },
       include: { member: true },

--- a/apps/api/src/fees/payments.controller.ts
+++ b/apps/api/src/fees/payments.controller.ts
@@ -1,0 +1,52 @@
+import { Controller, Get, Post, Delete, Param, Body, HttpCode } from '@nestjs/common';
+import { ApiTags, ApiBearerAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { RequireClubContext, GetClubContext } from '../common/decorators/club-context.decorator.js';
+import { RequirePermissions } from '../common/decorators/permissions.decorator.js';
+import { Permission } from '../common/permissions/permissions.enum.js';
+import { CurrentUser } from '../auth/decorators/current-user.decorator.js';
+import { PaymentsService } from './payments.service.js';
+import { RecordPaymentDto } from './dto/record-payment.dto.js';
+import type { ClubContext } from '../common/decorators/club-context.decorator.js';
+
+@ApiTags('Payments')
+@ApiBearerAuth()
+@Controller('clubs/:slug/fees/payments')
+@RequireClubContext()
+export class PaymentsController {
+  constructor(private paymentsService: PaymentsService) {}
+
+  @Post()
+  @RequirePermissions([Permission.FINANCE_CREATE])
+  @ApiOperation({ summary: 'Record a manual payment against a fee charge' })
+  @ApiResponse({ status: 201, description: 'Payment recorded, updated charge status returned' })
+  @ApiResponse({ status: 404, description: 'Fee charge not found' })
+  async recordPayment(
+    @GetClubContext() ctx: ClubContext,
+    @Body() dto: RecordPaymentDto,
+    @CurrentUser('id') userId: string
+  ) {
+    return this.paymentsService.recordPayment(ctx.clubId, dto, userId);
+  }
+
+  @Get('charge/:chargeId')
+  @RequirePermissions([Permission.FINANCE_READ])
+  @ApiOperation({ summary: 'List all payments for a fee charge' })
+  @ApiResponse({ status: 200, description: 'List of payments' })
+  async findPaymentsForCharge(@Param('chargeId') chargeId: string) {
+    return this.paymentsService.findPaymentsForCharge(chargeId);
+  }
+
+  @Delete(':id')
+  @HttpCode(200)
+  @RequirePermissions([Permission.FINANCE_DELETE])
+  @ApiOperation({ summary: 'Soft-delete a payment and recalculate charge status' })
+  @ApiResponse({ status: 200, description: 'Payment deleted, updated charge status returned' })
+  @ApiResponse({ status: 404, description: 'Payment not found' })
+  async softDeletePayment(
+    @GetClubContext() ctx: ClubContext,
+    @Param('id') id: string,
+    @CurrentUser('id') userId: string
+  ) {
+    return this.paymentsService.softDeletePayment(ctx.clubId, id, userId);
+  }
+}

--- a/apps/api/src/fees/payments.controller.ts
+++ b/apps/api/src/fees/payments.controller.ts
@@ -32,8 +32,11 @@ export class PaymentsController {
   @RequirePermissions([Permission.FINANCE_READ])
   @ApiOperation({ summary: 'List all payments for a fee charge' })
   @ApiResponse({ status: 200, description: 'List of payments' })
-  async findPaymentsForCharge(@Param('chargeId') chargeId: string) {
-    return this.paymentsService.findPaymentsForCharge(chargeId);
+  async findPaymentsForCharge(
+    @GetClubContext() ctx: ClubContext,
+    @Param('chargeId') chargeId: string
+  ) {
+    return this.paymentsService.findPaymentsForCharge(ctx.clubId, chargeId);
   }
 
   @Delete(':id')

--- a/apps/api/src/fees/payments.service.spec.ts
+++ b/apps/api/src/fees/payments.service.spec.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PaymentsService } from './payments.service.js';
+import type { PrismaService } from '../prisma/prisma.service.js';
+import { NotFoundException } from '@nestjs/common';
+import { Prisma } from '../../../../prisma/generated/client/index.js';
+
+const { Decimal } = Prisma;
+
+// ─── Mock Data ──────────────────────────────────────────────────────────────
+
+const CLUB_ID = 'club-1';
+const USER_ID = 'user-1';
+const CHARGE_ID = 'fc-1';
+
+function makeFeeCharge(overrides: Record<string, unknown> = {}) {
+  return {
+    id: CHARGE_ID,
+    clubId: CLUB_ID,
+    memberId: 'member-1',
+    amount: new Decimal('120.00'),
+    dueDate: new Date('2026-02-15'),
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+function makePayment(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'pay-1',
+    feeChargeId: CHARGE_ID,
+    amount: new Decimal('50.00'),
+    paidAt: new Date('2026-01-20'),
+    source: 'MANUAL',
+    reference: null,
+    notes: null,
+    recordedBy: USER_ID,
+    deletedAt: null,
+    deletedBy: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+// ─── Mock Prisma ────────────────────────────────────────────────────────────
+
+const mockPrisma = {
+  feeCharge: {
+    findFirst: vi.fn(),
+  },
+  payment: {
+    create: vi.fn(),
+    findMany: vi.fn(),
+    findFirst: vi.fn(),
+    update: vi.fn(),
+    aggregate: vi.fn(),
+  },
+} as unknown as PrismaService;
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('PaymentsService', () => {
+  let service: PaymentsService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new PaymentsService(mockPrisma);
+  });
+
+  // ─── recordPayment ──────────────────────────────────────────────────
+
+  describe('recordPayment()', () => {
+    it('should create Payment record with amount, date, source=MANUAL, recordedBy', async () => {
+      const charge = makeFeeCharge();
+      const payment = makePayment();
+
+      (mockPrisma.feeCharge.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(charge);
+      (mockPrisma.payment.create as ReturnType<typeof vi.fn>).mockResolvedValue(payment);
+      (mockPrisma.payment.aggregate as ReturnType<typeof vi.fn>).mockResolvedValue({
+        _sum: { amount: new Decimal('50.00') },
+      });
+
+      const result = await service.recordPayment(CLUB_ID, {
+        feeChargeId: CHARGE_ID,
+        amount: '50.00',
+        paidAt: '2026-01-20',
+      }, USER_ID);
+
+      expect(mockPrisma.payment.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          feeChargeId: CHARGE_ID,
+          amount: expect.any(Decimal),
+          source: 'MANUAL',
+          recordedBy: USER_ID,
+        }),
+      });
+      expect(result.payment).toBeDefined();
+    });
+
+    it('should return PARTIAL status after partial payment (OPEN -> PARTIAL)', async () => {
+      const charge = makeFeeCharge();
+      const payment = makePayment({ amount: new Decimal('50.00') });
+
+      (mockPrisma.feeCharge.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(charge);
+      (mockPrisma.payment.create as ReturnType<typeof vi.fn>).mockResolvedValue(payment);
+      (mockPrisma.payment.aggregate as ReturnType<typeof vi.fn>).mockResolvedValue({
+        _sum: { amount: new Decimal('50.00') },
+      });
+
+      const result = await service.recordPayment(CLUB_ID, {
+        feeChargeId: CHARGE_ID,
+        amount: '50.00',
+        paidAt: '2026-01-20',
+      }, USER_ID);
+
+      expect(result.chargeStatus.status).toBe('PARTIAL');
+      expect(result.chargeStatus.paidAmount).toBe('50.00');
+      expect(result.chargeStatus.remainingAmount).toBe('70.00');
+    });
+
+    it('should return PAID status after full payment', async () => {
+      const charge = makeFeeCharge();
+      const payment = makePayment({ amount: new Decimal('120.00') });
+
+      (mockPrisma.feeCharge.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(charge);
+      (mockPrisma.payment.create as ReturnType<typeof vi.fn>).mockResolvedValue(payment);
+      (mockPrisma.payment.aggregate as ReturnType<typeof vi.fn>).mockResolvedValue({
+        _sum: { amount: new Decimal('120.00') },
+      });
+
+      const result = await service.recordPayment(CLUB_ID, {
+        feeChargeId: CHARGE_ID,
+        amount: '120.00',
+        paidAt: '2026-01-20',
+      }, USER_ID);
+
+      expect(result.chargeStatus.status).toBe('PAID');
+      expect(result.chargeStatus.paidAmount).toBe('120.00');
+      expect(result.chargeStatus.remainingAmount).toBe('0.00');
+    });
+
+    it('should return PAID status with overpayment (sum >= amount)', async () => {
+      const charge = makeFeeCharge();
+      const payment = makePayment({ amount: new Decimal('150.00') });
+
+      (mockPrisma.feeCharge.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(charge);
+      (mockPrisma.payment.create as ReturnType<typeof vi.fn>).mockResolvedValue(payment);
+      (mockPrisma.payment.aggregate as ReturnType<typeof vi.fn>).mockResolvedValue({
+        _sum: { amount: new Decimal('150.00') },
+      });
+
+      const result = await service.recordPayment(CLUB_ID, {
+        feeChargeId: CHARGE_ID,
+        amount: '150.00',
+        paidAt: '2026-01-20',
+      }, USER_ID);
+
+      expect(result.chargeStatus.status).toBe('PAID');
+      expect(result.chargeStatus.remainingAmount).toBe('0.00');
+    });
+
+    it('should validate feeCharge belongs to the correct club', async () => {
+      // Charge not found (wrong club)
+      (mockPrisma.feeCharge.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+      await expect(
+        service.recordPayment(CLUB_ID, {
+          feeChargeId: 'nonexistent',
+          amount: '50.00',
+          paidAt: '2026-01-20',
+        }, USER_ID)
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ─── findPaymentsForCharge ──────────────────────────────────────────
+
+  describe('findPaymentsForCharge()', () => {
+    it('should return all non-deleted payments for a fee charge', async () => {
+      const payments = [
+        makePayment({ id: 'pay-1', amount: new Decimal('50.00') }),
+        makePayment({ id: 'pay-2', amount: new Decimal('30.00'), paidAt: new Date('2026-02-10') }),
+      ];
+      (mockPrisma.payment.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(payments);
+
+      const result = await service.findPaymentsForCharge(CHARGE_ID);
+
+      expect(result).toHaveLength(2);
+      expect(mockPrisma.payment.findMany).toHaveBeenCalledWith({
+        where: { feeChargeId: CHARGE_ID, deletedAt: null },
+        orderBy: { paidAt: 'desc' },
+      });
+    });
+  });
+
+  // ─── softDeletePayment ──────────────────────────────────────────────
+
+  describe('softDeletePayment()', () => {
+    it('should set deletedAt and recalculate charge status', async () => {
+      const payment = makePayment({
+        feeCharge: makeFeeCharge(),
+      });
+
+      (mockPrisma.payment.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(payment);
+      (mockPrisma.payment.update as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ...payment,
+        deletedAt: new Date(),
+        deletedBy: USER_ID,
+      });
+      // After soft-delete, no remaining payments -> status OPEN
+      (mockPrisma.payment.aggregate as ReturnType<typeof vi.fn>).mockResolvedValue({
+        _sum: { amount: null },
+      });
+
+      const result = await service.softDeletePayment(CLUB_ID, 'pay-1', USER_ID);
+
+      expect(mockPrisma.payment.update).toHaveBeenCalledWith({
+        where: { id: 'pay-1' },
+        data: {
+          deletedAt: expect.any(Date),
+          deletedBy: USER_ID,
+        },
+      });
+      expect(result.status).toBe('OPEN');
+    });
+  });
+});

--- a/apps/api/src/fees/payments.service.spec.ts
+++ b/apps/api/src/fees/payments.service.spec.ts
@@ -197,19 +197,32 @@ describe('PaymentsService', () => {
 
   describe('findPaymentsForCharge()', () => {
     it('should return all non-deleted payments for a fee charge', async () => {
+      const charge = makeFeeCharge();
       const payments = [
         makePayment({ id: 'pay-1', amount: new Decimal('50.00') }),
         makePayment({ id: 'pay-2', amount: new Decimal('30.00'), paidAt: new Date('2026-02-10') }),
       ];
+      (mockPrisma.feeCharge.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(charge);
       (mockPrisma.payment.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(payments);
 
-      const result = await service.findPaymentsForCharge(CHARGE_ID);
+      const result = await service.findPaymentsForCharge(CLUB_ID, CHARGE_ID);
 
       expect(result).toHaveLength(2);
+      expect(mockPrisma.feeCharge.findFirst).toHaveBeenCalledWith({
+        where: { id: CHARGE_ID, clubId: CLUB_ID, deletedAt: null },
+      });
       expect(mockPrisma.payment.findMany).toHaveBeenCalledWith({
         where: { feeChargeId: CHARGE_ID, deletedAt: null },
         orderBy: { paidAt: 'desc' },
       });
+    });
+
+    it('should reject cross-tenant access (charge from another club)', async () => {
+      (mockPrisma.feeCharge.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+      await expect(service.findPaymentsForCharge('other-club', CHARGE_ID)).rejects.toThrow(
+        NotFoundException
+      );
     });
   });
 

--- a/apps/api/src/fees/payments.service.spec.ts
+++ b/apps/api/src/fees/payments.service.spec.ts
@@ -80,11 +80,15 @@ describe('PaymentsService', () => {
         _sum: { amount: new Decimal('50.00') },
       });
 
-      const result = await service.recordPayment(CLUB_ID, {
-        feeChargeId: CHARGE_ID,
-        amount: '50.00',
-        paidAt: '2026-01-20',
-      }, USER_ID);
+      const result = await service.recordPayment(
+        CLUB_ID,
+        {
+          feeChargeId: CHARGE_ID,
+          amount: '50.00',
+          paidAt: '2026-01-20',
+        },
+        USER_ID
+      );
 
       expect(mockPrisma.payment.create).toHaveBeenCalledWith({
         data: expect.objectContaining({
@@ -107,11 +111,15 @@ describe('PaymentsService', () => {
         _sum: { amount: new Decimal('50.00') },
       });
 
-      const result = await service.recordPayment(CLUB_ID, {
-        feeChargeId: CHARGE_ID,
-        amount: '50.00',
-        paidAt: '2026-01-20',
-      }, USER_ID);
+      const result = await service.recordPayment(
+        CLUB_ID,
+        {
+          feeChargeId: CHARGE_ID,
+          amount: '50.00',
+          paidAt: '2026-01-20',
+        },
+        USER_ID
+      );
 
       expect(result.chargeStatus.status).toBe('PARTIAL');
       expect(result.chargeStatus.paidAmount).toBe('50.00');
@@ -128,11 +136,15 @@ describe('PaymentsService', () => {
         _sum: { amount: new Decimal('120.00') },
       });
 
-      const result = await service.recordPayment(CLUB_ID, {
-        feeChargeId: CHARGE_ID,
-        amount: '120.00',
-        paidAt: '2026-01-20',
-      }, USER_ID);
+      const result = await service.recordPayment(
+        CLUB_ID,
+        {
+          feeChargeId: CHARGE_ID,
+          amount: '120.00',
+          paidAt: '2026-01-20',
+        },
+        USER_ID
+      );
 
       expect(result.chargeStatus.status).toBe('PAID');
       expect(result.chargeStatus.paidAmount).toBe('120.00');
@@ -149,11 +161,15 @@ describe('PaymentsService', () => {
         _sum: { amount: new Decimal('150.00') },
       });
 
-      const result = await service.recordPayment(CLUB_ID, {
-        feeChargeId: CHARGE_ID,
-        amount: '150.00',
-        paidAt: '2026-01-20',
-      }, USER_ID);
+      const result = await service.recordPayment(
+        CLUB_ID,
+        {
+          feeChargeId: CHARGE_ID,
+          amount: '150.00',
+          paidAt: '2026-01-20',
+        },
+        USER_ID
+      );
 
       expect(result.chargeStatus.status).toBe('PAID');
       expect(result.chargeStatus.remainingAmount).toBe('0.00');
@@ -164,11 +180,15 @@ describe('PaymentsService', () => {
       (mockPrisma.feeCharge.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
 
       await expect(
-        service.recordPayment(CLUB_ID, {
-          feeChargeId: 'nonexistent',
-          amount: '50.00',
-          paidAt: '2026-01-20',
-        }, USER_ID)
+        service.recordPayment(
+          CLUB_ID,
+          {
+            feeChargeId: 'nonexistent',
+            amount: '50.00',
+            paidAt: '2026-01-20',
+          },
+          USER_ID
+        )
       ).rejects.toThrow(NotFoundException);
     });
   });

--- a/apps/api/src/fees/payments.service.ts
+++ b/apps/api/src/fees/payments.service.ts
@@ -1,0 +1,157 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { Prisma } from '../../../../prisma/generated/client/index.js';
+import type { RecordPaymentDto } from './dto/record-payment.dto.js';
+
+const ZERO = new Prisma.Decimal(0);
+const DECIMAL_PLACES = 2;
+
+/**
+ * Compute charge status from paid vs. charged amounts.
+ * Pure function using Prisma.Decimal comparison methods.
+ */
+export function computeChargeStatus(
+  chargeAmount: Prisma.Decimal,
+  paidAmount: Prisma.Decimal
+): { status: 'OPEN' | 'PARTIAL' | 'PAID'; paidAmount: string; remainingAmount: string } {
+  const status = paidAmount.gte(chargeAmount)
+    ? ('PAID' as const)
+    : paidAmount.gt(ZERO)
+      ? ('PARTIAL' as const)
+      : ('OPEN' as const);
+
+  const remaining = chargeAmount.minus(paidAmount);
+  const remainingAmount = remaining.lt(ZERO) ? ZERO : remaining;
+
+  return {
+    status,
+    paidAmount: paidAmount.toFixed(DECIMAL_PLACES),
+    remainingAmount: remainingAmount.toFixed(DECIMAL_PLACES),
+  };
+}
+
+@Injectable()
+export class PaymentsService {
+  constructor(private prisma: PrismaService) {}
+
+  // ─── Record Payment ─────────────────────────────────────────────────
+
+  /**
+   * Record a manual payment against a fee charge.
+   * Validates club ownership, creates Payment, and returns updated status.
+   */
+  async recordPayment(clubId: string, dto: RecordPaymentDto, userId: string) {
+    // 1. Validate feeCharge exists and belongs to this club
+    const charge = await this.prisma.feeCharge.findFirst({
+      where: { id: dto.feeChargeId, clubId, deletedAt: null },
+    });
+
+    if (!charge) {
+      throw new NotFoundException('Forderung nicht gefunden');
+    }
+
+    // 2. Create payment
+    const payment = await this.prisma.payment.create({
+      data: {
+        feeChargeId: dto.feeChargeId,
+        amount: new Prisma.Decimal(dto.amount),
+        paidAt: new Date(dto.paidAt),
+        source: 'MANUAL',
+        notes: dto.notes ?? null,
+        recordedBy: userId,
+      },
+    });
+
+    // 3. Recompute charge status using SQL aggregate
+    const aggregate = await this.prisma.payment.aggregate({
+      where: { feeChargeId: dto.feeChargeId, deletedAt: null },
+      _sum: { amount: true },
+    });
+    const paidAmount = aggregate._sum.amount ?? ZERO;
+
+    const chargeStatus = computeChargeStatus(charge.amount as Prisma.Decimal, paidAmount);
+
+    return {
+      payment: this.serializePayment(payment),
+      chargeStatus,
+    };
+  }
+
+  // ─── Find Payments for Charge ───────────────────────────────────────
+
+  /**
+   * Return all non-deleted payments for a charge, ordered by paidAt desc.
+   */
+  async findPaymentsForCharge(feeChargeId: string) {
+    const payments = await this.prisma.payment.findMany({
+      where: { feeChargeId, deletedAt: null },
+      orderBy: { paidAt: 'desc' },
+    });
+
+    return payments.map((p) => this.serializePayment(p));
+  }
+
+  // ─── Soft Delete Payment ────────────────────────────────────────────
+
+  /**
+   * Soft-delete a payment and recalculate charge status.
+   * Validates club ownership via the fee charge relation.
+   */
+  async softDeletePayment(clubId: string, paymentId: string, userId: string) {
+    // 1. Find payment with feeCharge for club validation
+    const payment = await this.prisma.payment.findFirst({
+      where: { id: paymentId, deletedAt: null },
+      include: { feeCharge: true },
+    });
+
+    if (!payment || payment.feeCharge.clubId !== clubId) {
+      throw new NotFoundException('Zahlung nicht gefunden');
+    }
+
+    // 2. Soft-delete
+    await this.prisma.payment.update({
+      where: { id: paymentId },
+      data: {
+        deletedAt: new Date(),
+        deletedBy: userId,
+      },
+    });
+
+    // 3. Recalculate status after deletion
+    const aggregate = await this.prisma.payment.aggregate({
+      where: { feeChargeId: payment.feeChargeId, deletedAt: null },
+      _sum: { amount: true },
+    });
+    const paidAmount = aggregate._sum.amount ?? ZERO;
+
+    return computeChargeStatus(payment.feeCharge.amount as Prisma.Decimal, paidAmount);
+  }
+
+  // ─── Private Helpers ────────────────────────────────────────────────
+
+  /**
+   * Serialize payment, converting Decimal fields to strings.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private serializePayment(payment: any) {
+    return {
+      ...payment,
+      amount:
+        payment.amount instanceof Prisma.Decimal
+          ? payment.amount.toFixed(DECIMAL_PLACES)
+          : String(payment.amount),
+      paidAt:
+        payment.paidAt instanceof Date
+          ? payment.paidAt.toISOString().split('T')[0]
+          : payment.paidAt,
+      createdAt:
+        payment.createdAt instanceof Date
+          ? payment.createdAt.toISOString()
+          : payment.createdAt,
+      updatedAt:
+        payment.updatedAt instanceof Date
+          ? payment.updatedAt.toISOString()
+          : payment.updatedAt,
+    };
+  }
+}

--- a/apps/api/src/fees/payments.service.ts
+++ b/apps/api/src/fees/payments.service.ts
@@ -82,7 +82,16 @@ export class PaymentsService {
   /**
    * Return all non-deleted payments for a charge, ordered by paidAt desc.
    */
-  async findPaymentsForCharge(feeChargeId: string) {
+  async findPaymentsForCharge(clubId: string, feeChargeId: string) {
+    // Verify charge belongs to this club before returning payments
+    const charge = await this.prisma.feeCharge.findFirst({
+      where: { id: feeChargeId, clubId, deletedAt: null },
+    });
+
+    if (!charge) {
+      throw new NotFoundException('Forderung nicht gefunden');
+    }
+
     const payments = await this.prisma.payment.findMany({
       where: { feeChargeId, deletedAt: null },
       orderBy: { paidAt: 'desc' },

--- a/apps/api/src/fees/payments.service.ts
+++ b/apps/api/src/fees/payments.service.ts
@@ -145,13 +145,9 @@ export class PaymentsService {
           ? payment.paidAt.toISOString().split('T')[0]
           : payment.paidAt,
       createdAt:
-        payment.createdAt instanceof Date
-          ? payment.createdAt.toISOString()
-          : payment.createdAt,
+        payment.createdAt instanceof Date ? payment.createdAt.toISOString() : payment.createdAt,
       updatedAt:
-        payment.updatedAt instanceof Date
-          ? payment.updatedAt.toISOString()
-          : payment.updatedAt,
+        payment.updatedAt instanceof Date ? payment.updatedAt.toISOString() : payment.updatedAt,
     };
   }
 }

--- a/apps/api/src/fees/payments.service.ts
+++ b/apps/api/src/fees/payments.service.ts
@@ -50,7 +50,9 @@ export class PaymentsService {
       throw new NotFoundException('Forderung nicht gefunden');
     }
 
-    // 2. Create payment
+    // 2. Create payment.
+    // Tenant-safe: Payment has no clubId and is excluded from TENANT_SCOPED_MODELS; the parent
+    // feeCharge was validated against clubId in step 1, so this write stays in-tenant.
     const payment = await this.prisma.payment.create({
       data: {
         feeChargeId: dto.feeChargeId,
@@ -62,7 +64,8 @@ export class PaymentsService {
       },
     });
 
-    // 3. Recompute charge status using SQL aggregate
+    // 3. Recompute charge status using SQL aggregate.
+    // Tenant-safe: filtered by the club-validated feeChargeId from step 1.
     const aggregate = await this.prisma.payment.aggregate({
       where: { feeChargeId: dto.feeChargeId, deletedAt: null },
       _sum: { amount: true },
@@ -92,6 +95,7 @@ export class PaymentsService {
       throw new NotFoundException('Forderung nicht gefunden');
     }
 
+    // Tenant-safe: feeChargeId was validated to belong to clubId above before this unscoped read.
     const payments = await this.prisma.payment.findMany({
       where: { feeChargeId, deletedAt: null },
       orderBy: { paidAt: 'desc' },
@@ -107,7 +111,9 @@ export class PaymentsService {
    * Validates club ownership via the fee charge relation.
    */
   async softDeletePayment(clubId: string, paymentId: string, userId: string) {
-    // 1. Find payment with feeCharge for club validation
+    // 1. Find payment with feeCharge for club validation.
+    // Tenant-safe: the row is unscoped here, but the club is enforced immediately below via
+    // payment.feeCharge.clubId !== clubId before any further use.
     const payment = await this.prisma.payment.findFirst({
       where: { id: paymentId, deletedAt: null },
       include: { feeCharge: true },
@@ -117,7 +123,8 @@ export class PaymentsService {
       throw new NotFoundException('Zahlung nicht gefunden');
     }
 
-    // 2. Soft-delete
+    // 2. Soft-delete.
+    // Tenant-safe: reached only after the feeCharge.clubId ownership check above.
     await this.prisma.payment.update({
       where: { id: paymentId },
       data: {
@@ -126,7 +133,8 @@ export class PaymentsService {
       },
     });
 
-    // 3. Recalculate status after deletion
+    // 3. Recalculate status after deletion.
+    // Tenant-safe: filtered by the club-validated payment.feeChargeId.
     const aggregate = await this.prisma.payment.aggregate({
       where: { feeChargeId: payment.feeChargeId, deletedAt: null },
       _sum: { amount: true },

--- a/apps/api/src/files/files.service.ts
+++ b/apps/api/src/files/files.service.ts
@@ -34,7 +34,7 @@ export class FilesService {
     const allowedTypes = ALLOWED_CONTENT_TYPES[dto.purpose];
     if (!allowedTypes?.includes(dto.contentType)) {
       throw new BadRequestException(
-        `Dateityp "${dto.contentType}" ist nicht erlaubt fuer ${dto.purpose}. ` +
+        `Dateityp "${dto.contentType}" ist nicht erlaubt für ${dto.purpose}. ` +
           `Erlaubt: ${allowedTypes?.join(', ') ?? 'keine'}`
       );
     }
@@ -327,7 +327,7 @@ export class FilesService {
     const file = clubFile.file;
 
     if (file.deletedAt) {
-      throw new BadRequestException('Datei wurde bereits geloescht');
+      throw new BadRequestException('Datei wurde bereits gelöscht');
     }
 
     const updated = await this.prisma.file.update({

--- a/apps/api/src/me/me.service.spec.ts
+++ b/apps/api/src/me/me.service.spec.ts
@@ -472,14 +472,14 @@ describe('MeService', () => {
 
       const result = await service.deleteAccount('user-1');
 
-      expect(result.message).toBe('Konto wurde geloescht');
+      expect(result.message).toBe('Konto wurde gelöscht');
 
       // Verify anonymization
       expect(mockPrisma.user.update).toHaveBeenCalledWith(
         expect.objectContaining({
           where: { id: 'user-1' },
           data: expect.objectContaining({
-            name: 'Geloeschter Benutzer',
+            name: 'Gelöschter Benutzer',
             email: 'deleted_user-1@anonymized.local',
             image: null,
             emailVerified: false,
@@ -537,7 +537,7 @@ describe('MeService', () => {
 
       const result = await service.deleteAccount('user-1');
 
-      expect(result.message).toBe('Konto wurde geloescht');
+      expect(result.message).toBe('Konto wurde gelöscht');
       expect(mockPrisma.file.updateMany).not.toHaveBeenCalled();
     });
   });

--- a/apps/api/src/me/me.service.ts
+++ b/apps/api/src/me/me.service.ts
@@ -39,7 +39,7 @@ export class MeService {
     const allowedTypes = ALLOWED_CONTENT_TYPES['user-avatar'];
     if (!allowedTypes?.includes(dto.contentType)) {
       throw new BadRequestException(
-        `Dateityp "${dto.contentType}" ist nicht erlaubt fuer user-avatar. ` +
+        `Dateityp "${dto.contentType}" ist nicht erlaubt für user-avatar. ` +
           `Erlaubt: ${allowedTypes?.join(', ') ?? 'keine'}`
       );
     }
@@ -349,7 +349,7 @@ export class MeService {
     if (!check.canDelete) {
       throw new BadRequestException({
         message:
-          'Konto kann nicht geloescht werden. Du bist der einzige Verantwortliche in folgenden Vereinen.',
+          'Konto kann nicht gelöscht werden. Du bist der einzige Verantwortliche in folgenden Vereinen.',
         blockedClubs: check.blockedClubs,
       });
     }
@@ -359,7 +359,7 @@ export class MeService {
       await tx.user.update({
         where: { id: userId },
         data: {
-          name: 'Geloeschter Benutzer',
+          name: 'Gelöschter Benutzer',
           email: `deleted_${userId}@anonymized.local`,
           image: null,
           emailVerified: false,
@@ -400,7 +400,7 @@ export class MeService {
 
     this.logger.log(`User ${userId} account anonymized`);
 
-    return { message: 'Konto wurde geloescht' };
+    return { message: 'Konto wurde gelöscht' };
   }
 
   /**

--- a/apps/api/src/members/dto/create-member.dto.ts
+++ b/apps/api/src/members/dto/create-member.dto.ts
@@ -248,4 +248,12 @@ export class CreateMemberDto {
   @IsString()
   @IsOptional()
   userId?: string;
+
+  @ApiPropertyOptional({
+    description: 'Fee type ID (FK to FeeType entity) for billing',
+    example: 'clxyz...',
+  })
+  @IsString()
+  @IsOptional()
+  feeTypeId?: string;
 }

--- a/apps/api/src/members/member-status.service.ts
+++ b/apps/api/src/members/member-status.service.ts
@@ -816,7 +816,7 @@ export class MemberStatusService {
       });
 
       if (!transition) {
-        throw new NotFoundException('Statusuebergang nicht gefunden');
+        throw new NotFoundException('Statusübergang nicht gefunden');
       }
 
       // One-entry-per-day validation when effectiveDate changes
@@ -901,7 +901,7 @@ export class MemberStatusService {
       });
 
       if (!transition) {
-        throw new NotFoundException('Statusuebergang nicht gefunden');
+        throw new NotFoundException('Statusübergang nicht gefunden');
       }
 
       // Guard: block deletion of LEFT transitions when a formal cancellation exists.

--- a/apps/api/src/members/members.service.spec.ts
+++ b/apps/api/src/members/members.service.spec.ts
@@ -30,6 +30,9 @@ const mockPrisma = {
   membershipType: {
     findFirst: vi.fn(),
   },
+  feeType: {
+    findFirst: vi.fn(),
+  },
 } as unknown as PrismaService;
 
 const mockNumberRanges = {
@@ -181,6 +184,40 @@ describe('MembersService', () => {
       await expect(
         service.create('club-1', { firstName: 'Max', lastName: 'Mustermann' } as never, 'user-1')
       ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should reject feeTypeId belonging to a different club (CR-02 tenant isolation)', async () => {
+      (mockNumberRanges.generateNext as ReturnType<typeof vi.fn>).mockResolvedValue('M-0001');
+      // FeeType lookup scoped to this club finds nothing -> foreign club
+      (
+        mockPrisma as unknown as { feeType: { findFirst: ReturnType<typeof vi.fn> } }
+      ).feeType.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.create(
+          'club-1',
+          { firstName: 'Max', lastName: 'Mustermann', feeTypeId: 'ft-other-club' } as never,
+          'user-1'
+        )
+      ).rejects.toThrow(BadRequestException);
+      expect(mockDb.member.create).not.toHaveBeenCalled();
+    });
+
+    it('should accept feeTypeId that belongs to the club', async () => {
+      (mockNumberRanges.generateNext as ReturnType<typeof vi.fn>).mockResolvedValue('M-0001');
+      (
+        mockPrisma as unknown as { feeType: { findFirst: ReturnType<typeof vi.fn> } }
+      ).feeType.findFirst.mockResolvedValue({ id: 'ft-1', clubId: 'club-1' });
+      mockDb.member.create.mockResolvedValue(makeMember({ feeTypeId: 'ft-1' }));
+
+      const result = await service.create(
+        'club-1',
+        { firstName: 'Max', lastName: 'Mustermann', feeTypeId: 'ft-1' } as never,
+        'user-1'
+      );
+
+      expect(result.memberNumber).toBe('M-0001');
+      expect(mockDb.member.create).toHaveBeenCalled();
     });
   });
 
@@ -399,6 +436,42 @@ describe('MembersService', () => {
       await expect(
         service.update('club-1', 'member-1', { lastName: 'Test', version: 0 } as never, 'user-1')
       ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should reject feeTypeId belonging to a different club (CR-02 tenant isolation)', async () => {
+      mockDb.member.findFirst.mockResolvedValue(makeMember());
+      // FeeType lookup scoped to this club finds nothing -> foreign club
+      (
+        mockPrisma as unknown as { feeType: { findFirst: ReturnType<typeof vi.fn> } }
+      ).feeType.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.update(
+          'club-1',
+          'member-1',
+          { feeTypeId: 'ft-other-club', version: 0 } as never,
+          'user-1'
+        )
+      ).rejects.toThrow(BadRequestException);
+      expect(mockDb.member.update).not.toHaveBeenCalled();
+    });
+
+    it('should accept feeTypeId that belongs to the club', async () => {
+      mockDb.member.findFirst.mockResolvedValue(makeMember());
+      (
+        mockPrisma as unknown as { feeType: { findFirst: ReturnType<typeof vi.fn> } }
+      ).feeType.findFirst.mockResolvedValue({ id: 'ft-1', clubId: 'club-1' });
+      mockDb.member.update.mockResolvedValue(makeMember({ feeTypeId: 'ft-1', version: 1 }));
+
+      const result = await service.update(
+        'club-1',
+        'member-1',
+        { feeTypeId: 'ft-1', version: 0 } as never,
+        'user-1'
+      );
+
+      expect(result.feeTypeId).toBe('ft-1');
+      expect(mockDb.member.update).toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/members/members.service.ts
+++ b/apps/api/src/members/members.service.ts
@@ -170,6 +170,7 @@ export class MembersService {
           orderBy: { createdAt: 'desc' },
           take: 20,
         },
+        feeType: { select: { id: true, name: true } },
         user: { select: { image: true } },
       },
     });
@@ -235,6 +236,7 @@ export class MembersService {
       phone: dto.phone,
       mobile: dto.mobile,
       notes: dto.notes,
+      feeTypeId: dto.feeTypeId,
       status: dto.status ?? 'PENDING',
       statusChangedAt: new Date(),
       statusChangedBy: userId,
@@ -359,6 +361,7 @@ export class MembersService {
       'mobile',
       'notes',
       'memberNumber',
+      'feeTypeId',
     ] as const;
 
     for (const field of fields) {
@@ -506,7 +509,7 @@ export class MembersService {
 
     if (member.status !== 'LEFT' && !member.deletedAt) {
       throw new BadRequestException(
-        'Anonymisierung ist nur moeglich, wenn der Status "Ausgetreten" oder das Mitglied geloescht ist'
+        'Anonymisierung ist nur möglich, wenn der Status "Ausgetreten" oder das Mitglied gelöscht ist'
       );
     }
 
@@ -753,6 +756,8 @@ export class MembersService {
       dsgvoRequestDate: toDateString(member.dsgvoRequestDate),
       anonymizedAt: toISOStringOrNull(member.anonymizedAt),
       anonymizedBy: member.anonymizedBy ?? null,
+      feeTypeId: member.feeTypeId ?? null,
+      feeType: member.feeType ?? null,
       userId: member.userId ?? null,
       userImage: member.user?.image ?? null,
       householdId: member.householdId ?? null,

--- a/apps/api/src/members/members.service.ts
+++ b/apps/api/src/members/members.service.ts
@@ -209,6 +209,17 @@ export class MembersService {
       }
     }
 
+    // Validate feeTypeId belongs to this club before persisting the FK
+    // (mirrors the membershipType validation below).
+    if (dto.feeTypeId) {
+      const feeType = await this.prisma.feeType.findFirst({
+        where: { id: dto.feeTypeId, clubId, deletedAt: null },
+      });
+      if (!feeType) {
+        throw new BadRequestException('Die gewählte Beitragsart gehört nicht zu diesem Verein');
+      }
+    }
+
     // Build create data with explicit clubId for TypeScript
     // (tenant extension also injects clubId at runtime)
     const createData: Prisma.MemberUncheckedCreateInput = {
@@ -332,6 +343,17 @@ export class MembersService {
         throw new ConflictException(
           `Mitgliedsnummer "${dtoFields.memberNumber}" ist bereits vergeben`
         );
+      }
+    }
+
+    // Validate feeTypeId belongs to this club before persisting the FK
+    // (mirrors the membershipType validation in create()).
+    if (dtoFields.feeTypeId) {
+      const feeType = await this.prisma.feeType.findFirst({
+        where: { id: dtoFields.feeTypeId, clubId, deletedAt: null },
+      });
+      if (!feeType) {
+        throw new BadRequestException('Die gewählte Beitragsart gehört nicht zu diesem Verein');
       }
     }
 

--- a/apps/api/src/members/membership-periods/membership-periods.service.ts
+++ b/apps/api/src/members/membership-periods/membership-periods.service.ts
@@ -239,7 +239,7 @@ export class MembershipPeriodsService {
 
       if (newStart <= existingEndOrMax && existingStart <= newEndOrMax) {
         throw new BadRequestException(
-          `Mitgliedschaftszeitraum ueberschneidet sich mit bestehendem Zeitraum ` +
+          `Mitgliedschaftszeitraum überschneidet sich mit bestehendem Zeitraum ` +
             `(${toDateString(existingStart)} - ${existingEnd ? toDateString(existingEnd) : 'offen'})`
         );
       }

--- a/apps/api/src/membership-types/dto/create-membership-type.dto.ts
+++ b/apps/api/src/membership-types/dto/create-membership-type.dto.ts
@@ -5,12 +5,14 @@ import {
   IsBoolean,
   IsInt,
   IsIn,
+  IsEnum,
   Min,
   MinLength,
   MaxLength,
   Matches,
 } from 'class-validator';
 import { MEMBER_TYPE_COLORS } from '@ktb/shared';
+import { BillingInterval } from '../../../../../prisma/generated/client/index.js';
 
 export class CreateMembershipTypeDto {
   @ApiProperty({
@@ -100,4 +102,23 @@ export class CreateMembershipTypeDto {
   @IsOptional()
   @IsIn([...MEMBER_TYPE_COLORS], { message: 'Ungueltige Farbe' })
   color?: string;
+
+  @ApiPropertyOptional({
+    description: 'Base fee amount as decimal string (e.g., "120.00")',
+    example: '120.00',
+  })
+  @IsString()
+  @IsOptional()
+  @Matches(/^\d+(\.\d{1,2})?$/, {
+    message: 'Betrag muss ein gueltiges Dezimalformat haben (z.B. "120.00")',
+  })
+  feeAmount?: string;
+
+  @ApiPropertyOptional({
+    description: 'Billing frequency for base fee',
+    enum: BillingInterval,
+  })
+  @IsEnum(BillingInterval, { message: 'Ungueltiger Abrechnungszeitraum' })
+  @IsOptional()
+  billingInterval?: BillingInterval;
 }

--- a/apps/api/src/membership-types/dto/create-membership-type.dto.ts
+++ b/apps/api/src/membership-types/dto/create-membership-type.dto.ts
@@ -5,14 +5,12 @@ import {
   IsBoolean,
   IsInt,
   IsIn,
-  IsEnum,
   Min,
   MinLength,
   MaxLength,
   Matches,
 } from 'class-validator';
 import { MEMBER_TYPE_COLORS } from '@ktb/shared';
-import { BillingInterval } from '../../../../../prisma/generated/client/index.js';
 
 export class CreateMembershipTypeDto {
   @ApiProperty({
@@ -100,25 +98,7 @@ export class CreateMembershipTypeDto {
   })
   @IsString()
   @IsOptional()
-  @IsIn([...MEMBER_TYPE_COLORS], { message: 'Ungueltige Farbe' })
+  @IsIn([...MEMBER_TYPE_COLORS], { message: 'Ungültige Farbe' })
   color?: string;
 
-  @ApiPropertyOptional({
-    description: 'Base fee amount as decimal string (e.g., "120.00")',
-    example: '120.00',
-  })
-  @IsString()
-  @IsOptional()
-  @Matches(/^\d+(\.\d{1,2})?$/, {
-    message: 'Betrag muss ein gueltiges Dezimalformat haben (z.B. "120.00")',
-  })
-  feeAmount?: string;
-
-  @ApiPropertyOptional({
-    description: 'Billing frequency for base fee',
-    enum: BillingInterval,
-  })
-  @IsEnum(BillingInterval, { message: 'Ungueltiger Abrechnungszeitraum' })
-  @IsOptional()
-  billingInterval?: BillingInterval;
 }

--- a/apps/api/src/membership-types/dto/create-membership-type.dto.ts
+++ b/apps/api/src/membership-types/dto/create-membership-type.dto.ts
@@ -100,5 +100,4 @@ export class CreateMembershipTypeDto {
   @IsOptional()
   @IsIn([...MEMBER_TYPE_COLORS], { message: 'Ungültige Farbe' })
   color?: string;
-
 }

--- a/apps/api/src/membership-types/dto/update-membership-type.dto.ts
+++ b/apps/api/src/membership-types/dto/update-membership-type.dto.ts
@@ -5,12 +5,14 @@ import {
   IsBoolean,
   IsInt,
   IsIn,
+  IsEnum,
   Min,
   MinLength,
   MaxLength,
   Matches,
 } from 'class-validator';
 import { MEMBER_TYPE_COLORS } from '@ktb/shared';
+import { BillingInterval } from '../../../../../prisma/generated/client/index.js';
 
 export class UpdateMembershipTypeDto {
   @ApiPropertyOptional({
@@ -95,4 +97,23 @@ export class UpdateMembershipTypeDto {
   @IsOptional()
   @IsIn([...MEMBER_TYPE_COLORS], { message: 'Ungueltige Farbe' })
   color?: string;
+
+  @ApiPropertyOptional({
+    description: 'Base fee amount as decimal string (e.g., "120.00")',
+    example: '120.00',
+  })
+  @IsString()
+  @IsOptional()
+  @Matches(/^\d+(\.\d{1,2})?$/, {
+    message: 'Betrag muss ein gueltiges Dezimalformat haben (z.B. "120.00")',
+  })
+  feeAmount?: string;
+
+  @ApiPropertyOptional({
+    description: 'Billing frequency for base fee',
+    enum: BillingInterval,
+  })
+  @IsEnum(BillingInterval, { message: 'Ungueltiger Abrechnungszeitraum' })
+  @IsOptional()
+  billingInterval?: BillingInterval;
 }

--- a/apps/api/src/membership-types/dto/update-membership-type.dto.ts
+++ b/apps/api/src/membership-types/dto/update-membership-type.dto.ts
@@ -95,5 +95,4 @@ export class UpdateMembershipTypeDto {
   @IsOptional()
   @IsIn([...MEMBER_TYPE_COLORS], { message: 'Ungültige Farbe' })
   color?: string;
-
 }

--- a/apps/api/src/membership-types/dto/update-membership-type.dto.ts
+++ b/apps/api/src/membership-types/dto/update-membership-type.dto.ts
@@ -5,14 +5,12 @@ import {
   IsBoolean,
   IsInt,
   IsIn,
-  IsEnum,
   Min,
   MinLength,
   MaxLength,
   Matches,
 } from 'class-validator';
 import { MEMBER_TYPE_COLORS } from '@ktb/shared';
-import { BillingInterval } from '../../../../../prisma/generated/client/index.js';
 
 export class UpdateMembershipTypeDto {
   @ApiPropertyOptional({
@@ -95,25 +93,7 @@ export class UpdateMembershipTypeDto {
   })
   @IsString()
   @IsOptional()
-  @IsIn([...MEMBER_TYPE_COLORS], { message: 'Ungueltige Farbe' })
+  @IsIn([...MEMBER_TYPE_COLORS], { message: 'Ungültige Farbe' })
   color?: string;
 
-  @ApiPropertyOptional({
-    description: 'Base fee amount as decimal string (e.g., "120.00")',
-    example: '120.00',
-  })
-  @IsString()
-  @IsOptional()
-  @Matches(/^\d+(\.\d{1,2})?$/, {
-    message: 'Betrag muss ein gueltiges Dezimalformat haben (z.B. "120.00")',
-  })
-  feeAmount?: string;
-
-  @ApiPropertyOptional({
-    description: 'Billing frequency for base fee',
-    enum: BillingInterval,
-  })
-  @IsEnum(BillingInterval, { message: 'Ungueltiger Abrechnungszeitraum' })
-  @IsOptional()
-  billingInterval?: BillingInterval;
 }

--- a/apps/api/src/membership-types/membership-types.service.ts
+++ b/apps/api/src/membership-types/membership-types.service.ts
@@ -168,7 +168,7 @@ export class MembershipTypesService {
 
     if (periodCount > 0) {
       throw new BadRequestException(
-        'Mitgliedsart kann nicht geloescht werden, da sie von Mitgliedschaften verwendet wird'
+        'Mitgliedsart kann nicht gelöscht werden, da sie von Mitgliedschaften verwendet wird'
       );
     }
 

--- a/apps/api/src/number-ranges/number-ranges.service.ts
+++ b/apps/api/src/number-ranges/number-ranges.service.ts
@@ -60,7 +60,7 @@ export class NumberRangesService {
     });
 
     if (existing) {
-      throw new ConflictException(`Nummernkreis fuer Typ "${dto.entityType}" existiert bereits`);
+      throw new ConflictException(`Nummernkreis für Typ "${dto.entityType}" existiert bereits`);
     }
 
     // Use raw prisma with explicit clubId (forClub extension adds clubId
@@ -119,7 +119,7 @@ export class NumberRangesService {
 
     if (existing.currentValue > 0) {
       throw new BadRequestException(
-        'Nummernkreis kann nicht geloescht werden, da bereits Nummern vergeben wurden'
+        'Nummernkreis kann nicht gelöscht werden, da bereits Nummern vergeben wurden'
       );
     }
 
@@ -148,7 +148,7 @@ export class NumberRangesService {
       });
 
       if (!current) {
-        throw new NotFoundException(`Nummernkreis fuer Typ "${entityType}" nicht gefunden`);
+        throw new NotFoundException(`Nummernkreis für Typ "${entityType}" nicht gefunden`);
       }
 
       // Handle year reset: compare lastResetYear with current year

--- a/apps/api/src/prisma/extensions/tenant.extension.ts
+++ b/apps/api/src/prisma/extensions/tenant.extension.ts
@@ -9,8 +9,10 @@ const TENANT_SCOPED_MODELS = [
   'Household',
   'NumberRange',
   'LedgerAccount',
-  // Future models: Transaction, TransactionLine, FeeCategory, etc.
+  'FeeCategory',
+  'FeeCharge',
   // Note: MembershipPeriod is scoped via Member relation (no clubId column)
+  // Note: Payment is scoped via FeeCharge relation (no clubId column)
 ] as const;
 
 type TenantScopedModel = (typeof TENANT_SCOPED_MODELS)[number];

--- a/apps/api/src/prisma/extensions/tenant.extension.ts
+++ b/apps/api/src/prisma/extensions/tenant.extension.ts
@@ -11,8 +11,11 @@ const TENANT_SCOPED_MODELS = [
   'LedgerAccount',
   'FeeCategory',
   'FeeCharge',
+  'FeeType',
   // Note: MembershipPeriod is scoped via Member relation (no clubId column)
   // Note: Payment is scoped via FeeCharge relation (no clubId column)
+  // Note: MembershipTypeFeeType is scoped via FeeType relation (no clubId column)
+  // Note: FeeCategoryMembershipType is scoped via FeeCategory relation (no clubId column)
 ] as const;
 
 type TenantScopedModel = (typeof TENANT_SCOPED_MODELS)[number];

--- a/apps/web/app/clubs/[slug]/(club)/fees/_client.tsx
+++ b/apps/web/app/clubs/[slug]/(club)/fees/_client.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { useQueryStates, parseAsStringLiteral } from 'nuqs';
+import { PageHeader } from '@/components/layout/page-header';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Card, CardContent } from '@/components/ui/card';
+import { FeeCategoryList } from '@/components/fees/fee-category-list';
+
+const TAB_VALUES = ['kategorien', 'erhebung', 'forderungen'] as const;
+
+/**
+ * Client component orchestrating the fees management page.
+ * Tab state is persisted in the URL via nuqs (?tab=kategorien|erhebung|forderungen).
+ */
+export function FeesClient() {
+  const [{ tab }, setParams] = useQueryStates(
+    {
+      tab: parseAsStringLiteral(TAB_VALUES).withDefault('kategorien'),
+    },
+    { shallow: true }
+  );
+
+  return (
+    <div>
+      <PageHeader
+        title="Beitraege"
+        description="Beitragskategorien, Erhebungslaeufe und Forderungen verwalten"
+      />
+
+      <div className="container mx-auto px-4 pb-6">
+        <Tabs value={tab} onValueChange={(value) => setParams({ tab: value as (typeof TAB_VALUES)[number] })}>
+          <TabsList>
+            <TabsTrigger value="kategorien">Kategorien</TabsTrigger>
+            <TabsTrigger value="erhebung">Erhebung</TabsTrigger>
+            <TabsTrigger value="forderungen">Forderungen</TabsTrigger>
+          </TabsList>
+
+          <div className="pt-8">
+            <TabsContent value="kategorien" className="mt-0">
+              <FeeCategoryList />
+            </TabsContent>
+
+            <TabsContent value="erhebung" className="mt-0">
+              <Card>
+                <CardContent className="flex items-center justify-center py-12">
+                  <p className="text-muted-foreground">Wird in Kuerze verfuegbar</p>
+                </CardContent>
+              </Card>
+            </TabsContent>
+
+            <TabsContent value="forderungen" className="mt-0">
+              <Card>
+                <CardContent className="flex items-center justify-center py-12">
+                  <p className="text-muted-foreground">Wird in Kuerze verfuegbar</p>
+                </CardContent>
+              </Card>
+            </TabsContent>
+          </div>
+        </Tabs>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/clubs/[slug]/(club)/fees/_client.tsx
+++ b/apps/web/app/clubs/[slug]/(club)/fees/_client.tsx
@@ -30,8 +30,8 @@ export function FeesClient() {
   return (
     <div>
       <PageHeader
-        title="Beitraege"
-        description="Beitragskategorien, Erhebungslaeufe und Forderungen verwalten"
+        title="Beiträge"
+        description="Beitragskategorien, Erhebungsläufe und Forderungen verwalten"
       />
 
       <div className="container mx-auto px-4 pb-6">

--- a/apps/web/app/clubs/[slug]/(club)/fees/_client.tsx
+++ b/apps/web/app/clubs/[slug]/(club)/fees/_client.tsx
@@ -1,21 +1,28 @@
 'use client';
 
-import { useQueryStates, parseAsStringLiteral } from 'nuqs';
+import { useParams } from 'next/navigation';
+import { useQueryStates, parseAsStringLiteral, parseAsString } from 'nuqs';
 import { PageHeader } from '@/components/layout/page-header';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Card, CardContent } from '@/components/ui/card';
 import { FeeCategoryList } from '@/components/fees/fee-category-list';
+import { BillingRunPanel } from '@/components/fees/billing-run-panel';
+import { FeeChargeList } from '@/components/fees/fee-charge-list';
 
 const TAB_VALUES = ['kategorien', 'erhebung', 'forderungen'] as const;
 
 /**
  * Client component orchestrating the fees management page.
  * Tab state is persisted in the URL via nuqs (?tab=kategorien|erhebung|forderungen).
+ * Supports memberId URL parameter for pre-filtering the Forderungen tab.
  */
 export function FeesClient() {
-  const [{ tab }, setParams] = useQueryStates(
+  const params = useParams<{ slug: string }>();
+  const slug = params.slug;
+
+  const [{ tab, memberId }, setParams] = useQueryStates(
     {
       tab: parseAsStringLiteral(TAB_VALUES).withDefault('kategorien'),
+      memberId: parseAsString.withDefault(''),
     },
     { shallow: true }
   );
@@ -44,19 +51,15 @@ export function FeesClient() {
             </TabsContent>
 
             <TabsContent value="erhebung" className="mt-0">
-              <Card>
-                <CardContent className="flex items-center justify-center py-12">
-                  <p className="text-muted-foreground">Wird in Kuerze verfuegbar</p>
-                </CardContent>
-              </Card>
+              <BillingRunPanel slug={slug} onComplete={() => setParams({ tab: 'forderungen' })} />
             </TabsContent>
 
             <TabsContent value="forderungen" className="mt-0">
-              <Card>
-                <CardContent className="flex items-center justify-center py-12">
-                  <p className="text-muted-foreground">Wird in Kuerze verfuegbar</p>
-                </CardContent>
-              </Card>
+              <FeeChargeList
+                slug={slug}
+                memberId={memberId || undefined}
+                onSwitchToErhebung={() => setParams({ tab: 'erhebung' })}
+              />
             </TabsContent>
           </div>
         </Tabs>

--- a/apps/web/app/clubs/[slug]/(club)/fees/_client.tsx
+++ b/apps/web/app/clubs/[slug]/(club)/fees/_client.tsx
@@ -28,7 +28,10 @@ export function FeesClient() {
       />
 
       <div className="container mx-auto px-4 pb-6">
-        <Tabs value={tab} onValueChange={(value) => setParams({ tab: value as (typeof TAB_VALUES)[number] })}>
+        <Tabs
+          value={tab}
+          onValueChange={(value) => setParams({ tab: value as (typeof TAB_VALUES)[number] })}
+        >
           <TabsList>
             <TabsTrigger value="kategorien">Kategorien</TabsTrigger>
             <TabsTrigger value="erhebung">Erhebung</TabsTrigger>

--- a/apps/web/app/clubs/[slug]/(club)/fees/error.tsx
+++ b/apps/web/app/clubs/[slug]/(club)/fees/error.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="container mx-auto py-12 text-center">
+      <h2 className="text-xl font-semibold">Fehler aufgetreten</h2>
+      <p className="text-muted-foreground mt-2">
+        {error.message || 'Ein unbekannter Fehler ist aufgetreten'}
+      </p>
+      <button onClick={reset} className="mt-4 text-primary hover:underline">
+        Erneut versuchen
+      </button>
+    </div>
+  );
+}

--- a/apps/web/app/clubs/[slug]/(club)/fees/page.tsx
+++ b/apps/web/app/clubs/[slug]/(club)/fees/page.tsx
@@ -1,0 +1,19 @@
+import { checkClubAccess } from '@/lib/check-club-access';
+import { FeesClient } from './_client';
+
+interface FeesPageProps {
+  params: Promise<{ slug: string }>;
+}
+
+/**
+ * Fee management page with server-side access check.
+ * Returns proper 404 status if user doesn't have access.
+ */
+export default async function FeesPage({ params }: FeesPageProps) {
+  const { slug } = await params;
+
+  // Server-side access check - throws notFound() with proper 404 status
+  await checkClubAccess(slug);
+
+  return <FeesClient />;
+}

--- a/apps/web/app/clubs/[slug]/(settings)/settings/fee-model/_client.tsx
+++ b/apps/web/app/clubs/[slug]/(settings)/settings/fee-model/_client.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { useParams } from 'next/navigation';
+import { Loader2 } from 'lucide-react';
+import { useClubSettings, useUpdateClubSettings } from '@/hooks/use-club-settings';
+import { useToast } from '@/hooks/use-toast';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { FeeTypeList } from '@/components/fees/fee-type-list';
+import { CrossTableMatrix } from '@/components/fees/cross-table-matrix';
+
+const HOUSEHOLD_BILLING_OPTIONS = [
+  {
+    value: 'NONE',
+    label: 'Kein Rabatt',
+    description: 'Alle Mitglieder zahlen den Einzelbeitrag.',
+  },
+  {
+    value: 'REDUCED_MEMBERS',
+    label: 'Weitere Mitglieder reduziert',
+    description:
+      'Das Hauptmitglied zahlt voll, weitere Mitglieder zahlen einen reduzierten Beitrag.',
+  },
+  {
+    value: 'FAMILY_PAYER',
+    label: 'Einer zahlt für alle',
+    description:
+      'Das Hauptmitglied zahlt einen Familien-Pauschalbeitrag, alle weiteren Mitglieder sind beitragsfrei.',
+  },
+  {
+    value: 'ALL_REDUCED',
+    label: 'Alle im Haushalt reduziert',
+    description:
+      'Alle Haushaltsmitglieder (auch das Hauptmitglied) zahlen einen reduzierten Beitrag.',
+  },
+] as const;
+
+/**
+ * Fee model settings page client component.
+ * Manages household billing model, fee types (Beitragsarten), and the cross-table matrix.
+ */
+export function FeeModelSettingsClient() {
+  const params = useParams<{ slug: string }>();
+  const slug = params.slug;
+  const { data: club, isLoading } = useClubSettings(slug);
+  const updateSettings = useUpdateClubSettings(slug);
+  const { toast } = useToast();
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (!club) {
+    return (
+      <div className="py-12 text-center text-muted-foreground">
+        Einstellungen konnten nicht geladen werden.
+      </div>
+    );
+  }
+
+  async function handleBillingModelChange(value: string) {
+    try {
+      await updateSettings.mutateAsync({ householdBillingModel: value });
+      toast({ title: 'Haushaltsbeitragsmodell gespeichert' });
+    } catch {
+      toast({
+        title: 'Fehler beim Speichern',
+        description: 'Das Haushaltsbeitragsmodell konnte nicht gespeichert werden.',
+        variant: 'destructive',
+      });
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Household billing model */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Haushaltsbeitragsmodell</CardTitle>
+          <CardDescription>Wie werden Beiträge für Haushaltsmitglieder berechnet?</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <RadioGroup
+            value={club.householdBillingModel ?? 'NONE'}
+            onValueChange={handleBillingModelChange}
+            disabled={updateSettings.isPending}
+            className="space-y-3"
+          >
+            {HOUSEHOLD_BILLING_OPTIONS.map((option) => (
+              <div key={option.value} className="flex items-start space-x-3">
+                <RadioGroupItem value={option.value} id={`hbm-${option.value}`} className="mt-1" />
+                <div className="flex-1">
+                  <Label htmlFor={`hbm-${option.value}`} className="text-sm font-medium">
+                    {option.label}
+                  </Label>
+                  <p className="text-sm text-muted-foreground">{option.description}</p>
+                </div>
+              </div>
+            ))}
+          </RadioGroup>
+          <p className="mt-4 text-sm text-muted-foreground">
+            Änderung beeinflusst die automatische Beitragsart-Zuweisung für neue Mitglieder und
+            Haushaltswechsel. Bestehende Zuweisungen bleiben unverändert.
+          </p>
+        </CardContent>
+      </Card>
+
+      {/* Fee types CRUD list */}
+      <FeeTypeList slug={slug} />
+
+      {/* Cross-table matrix */}
+      <CrossTableMatrix slug={slug} />
+    </div>
+  );
+}

--- a/apps/web/app/clubs/[slug]/(settings)/settings/fee-model/_client.tsx
+++ b/apps/web/app/clubs/[slug]/(settings)/settings/fee-model/_client.tsx
@@ -2,6 +2,7 @@
 
 import { useParams } from 'next/navigation';
 import { Loader2 } from 'lucide-react';
+import type { HouseholdBillingModel } from '@ktb/shared';
 import { useClubSettings, useUpdateClubSettings } from '@/hooks/use-club-settings';
 import { useToast } from '@/hooks/use-toast';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -65,7 +66,8 @@ export function FeeModelSettingsClient() {
 
   async function handleBillingModelChange(value: string) {
     try {
-      await updateSettings.mutateAsync({ householdBillingModel: value });
+      // RadioGroup yields a string; the items are exactly the HouseholdBillingModel values.
+      await updateSettings.mutateAsync({ householdBillingModel: value as HouseholdBillingModel });
       toast({ title: 'Haushaltsbeitragsmodell gespeichert' });
     } catch {
       toast({

--- a/apps/web/app/clubs/[slug]/(settings)/settings/fee-model/page.tsx
+++ b/apps/web/app/clubs/[slug]/(settings)/settings/fee-model/page.tsx
@@ -1,0 +1,16 @@
+import { checkClubAccess } from '@/lib/check-club-access';
+import { FeeModelSettingsClient } from './_client';
+
+interface FeeModelPageProps {
+  params: Promise<{ slug: string }>;
+}
+
+/**
+ * Fee model settings page with server-side access check.
+ * Manages Beitragsarten, cross-table, and household billing model.
+ */
+export default async function FeeModelSettingsPage({ params }: FeeModelPageProps) {
+  const { slug } = await params;
+  await checkClubAccess(slug);
+  return <FeeModelSettingsClient />;
+}

--- a/apps/web/app/clubs/[slug]/(settings)/settings/membership-types/_client.tsx
+++ b/apps/web/app/clubs/[slug]/(settings)/settings/membership-types/_client.tsx
@@ -45,6 +45,14 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Separator } from '@/components/ui/separator';
 import { Plus, Pencil, Trash2, Loader2, IdCard, Check, Minus } from 'lucide-react';
 
 interface MembershipTypeFormState {
@@ -57,6 +65,8 @@ interface MembershipTypeFormState {
   vote: boolean;
   assemblyAttendance: boolean;
   eligibleForOffice: boolean;
+  feeAmount: string;
+  billingInterval: 'MONTHLY' | 'QUARTERLY' | 'ANNUALLY';
 }
 
 const DEFAULT_FORM_STATE: MembershipTypeFormState = {
@@ -69,6 +79,8 @@ const DEFAULT_FORM_STATE: MembershipTypeFormState = {
   vote: true,
   assemblyAttendance: true,
   eligibleForOffice: true,
+  feeAmount: '',
+  billingInterval: 'ANNUALLY',
 };
 
 /** Render a boolean value as check or minus icon */
@@ -119,6 +131,9 @@ export function MembershipTypesSettingsClient() {
       vote: type.vote,
       assemblyAttendance: type.assemblyAttendance,
       eligibleForOffice: type.eligibleForOffice,
+      feeAmount: type.feeAmount ?? '',
+      billingInterval:
+        (type.billingInterval as MembershipTypeFormState['billingInterval']) ?? 'ANNUALLY',
     });
     setDialogOpen(true);
   }
@@ -135,6 +150,8 @@ export function MembershipTypesSettingsClient() {
       vote: formState.vote,
       assemblyAttendance: formState.assemblyAttendance,
       eligibleForOffice: formState.eligibleForOffice,
+      feeAmount: formState.feeAmount || null,
+      billingInterval: formState.feeAmount ? formState.billingInterval : undefined,
     };
 
     if (editingType) {
@@ -514,6 +531,48 @@ export function MembershipTypesSettingsClient() {
                   setFormState((prev) => ({ ...prev, eligibleForOffice: checked }))
                 }
               />
+            </div>
+
+            {/* Beitragseinstellungen */}
+            <Separator />
+            <h4 className="text-sm font-semibold">Beitragseinstellungen</h4>
+
+            {/* Grundbeitrag (EUR) */}
+            <div className="space-y-2">
+              <Label htmlFor="feeAmount">Grundbeitrag (EUR)</Label>
+              <Input
+                id="feeAmount"
+                placeholder="z.B. 120.00"
+                inputMode="decimal"
+                value={formState.feeAmount}
+                onChange={(e) => setFormState((prev) => ({ ...prev, feeAmount: e.target.value }))}
+              />
+              <p className="text-xs text-muted-foreground">
+                Optional — nicht jede Mitgliedsart muss einen Beitrag haben.
+              </p>
+            </div>
+
+            {/* Abrechnungszeitraum */}
+            <div className="space-y-2">
+              <Label htmlFor="billingInterval">Abrechnungszeitraum</Label>
+              <Select
+                value={formState.billingInterval}
+                onValueChange={(val) =>
+                  setFormState((prev) => ({
+                    ...prev,
+                    billingInterval: val as MembershipTypeFormState['billingInterval'],
+                  }))
+                }
+              >
+                <SelectTrigger id="billingInterval" className="w-full">
+                  <SelectValue placeholder="Zeitraum waehlen" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="MONTHLY">Monatlich</SelectItem>
+                  <SelectItem value="QUARTERLY">Quartalsweise</SelectItem>
+                  <SelectItem value="ANNUALLY">Jaehrlich</SelectItem>
+                </SelectContent>
+              </Select>
             </div>
           </div>
 

--- a/apps/web/app/clubs/[slug]/(settings)/settings/membership-types/_client.tsx
+++ b/apps/web/app/clubs/[slug]/(settings)/settings/membership-types/_client.tsx
@@ -565,12 +565,12 @@ export function MembershipTypesSettingsClient() {
                 }
               >
                 <SelectTrigger id="billingInterval" className="w-full">
-                  <SelectValue placeholder="Zeitraum waehlen" />
+                  <SelectValue placeholder="Zeitraum wählen" />
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="MONTHLY">Monatlich</SelectItem>
-                  <SelectItem value="QUARTERLY">Quartalsweise</SelectItem>
-                  <SelectItem value="ANNUALLY">Jaehrlich</SelectItem>
+                  <SelectItem value="QUARTERLY">Vierteljährlich</SelectItem>
+                  <SelectItem value="ANNUALLY">Jährlich</SelectItem>
                 </SelectContent>
               </Select>
             </div>

--- a/apps/web/app/clubs/[slug]/(settings)/settings/membership-types/_client.tsx
+++ b/apps/web/app/clubs/[slug]/(settings)/settings/membership-types/_client.tsx
@@ -45,14 +45,6 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import { Separator } from '@/components/ui/separator';
 import { Plus, Pencil, Trash2, Loader2, IdCard, Check, Minus } from 'lucide-react';
 
 interface MembershipTypeFormState {

--- a/apps/web/app/clubs/[slug]/(settings)/settings/membership-types/_client.tsx
+++ b/apps/web/app/clubs/[slug]/(settings)/settings/membership-types/_client.tsx
@@ -65,8 +65,6 @@ interface MembershipTypeFormState {
   vote: boolean;
   assemblyAttendance: boolean;
   eligibleForOffice: boolean;
-  feeAmount: string;
-  billingInterval: 'MONTHLY' | 'QUARTERLY' | 'ANNUALLY';
 }
 
 const DEFAULT_FORM_STATE: MembershipTypeFormState = {
@@ -79,8 +77,6 @@ const DEFAULT_FORM_STATE: MembershipTypeFormState = {
   vote: true,
   assemblyAttendance: true,
   eligibleForOffice: true,
-  feeAmount: '',
-  billingInterval: 'ANNUALLY',
 };
 
 /** Render a boolean value as check or minus icon */
@@ -131,9 +127,6 @@ export function MembershipTypesSettingsClient() {
       vote: type.vote,
       assemblyAttendance: type.assemblyAttendance,
       eligibleForOffice: type.eligibleForOffice,
-      feeAmount: type.feeAmount ?? '',
-      billingInterval:
-        (type.billingInterval as MembershipTypeFormState['billingInterval']) ?? 'ANNUALLY',
     });
     setDialogOpen(true);
   }
@@ -150,8 +143,6 @@ export function MembershipTypesSettingsClient() {
       vote: formState.vote,
       assemblyAttendance: formState.assemblyAttendance,
       eligibleForOffice: formState.eligibleForOffice,
-      feeAmount: formState.feeAmount || null,
-      billingInterval: formState.feeAmount ? formState.billingInterval : undefined,
     };
 
     if (editingType) {
@@ -533,47 +524,7 @@ export function MembershipTypesSettingsClient() {
               />
             </div>
 
-            {/* Beitragseinstellungen */}
-            <Separator />
-            <h4 className="text-sm font-semibold">Beitragseinstellungen</h4>
-
-            {/* Grundbeitrag (EUR) */}
-            <div className="space-y-2">
-              <Label htmlFor="feeAmount">Grundbeitrag (EUR)</Label>
-              <Input
-                id="feeAmount"
-                placeholder="z.B. 120.00"
-                inputMode="decimal"
-                value={formState.feeAmount}
-                onChange={(e) => setFormState((prev) => ({ ...prev, feeAmount: e.target.value }))}
-              />
-              <p className="text-xs text-muted-foreground">
-                Optional — nicht jede Mitgliedsart muss einen Beitrag haben.
-              </p>
-            </div>
-
-            {/* Abrechnungszeitraum */}
-            <div className="space-y-2">
-              <Label htmlFor="billingInterval">Abrechnungszeitraum</Label>
-              <Select
-                value={formState.billingInterval}
-                onValueChange={(val) =>
-                  setFormState((prev) => ({
-                    ...prev,
-                    billingInterval: val as MembershipTypeFormState['billingInterval'],
-                  }))
-                }
-              >
-                <SelectTrigger id="billingInterval" className="w-full">
-                  <SelectValue placeholder="Zeitraum wählen" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="MONTHLY">Monatlich</SelectItem>
-                  <SelectItem value="QUARTERLY">Vierteljährlich</SelectItem>
-                  <SelectItem value="ANNUALLY">Jährlich</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
+            {/* Note: Fee amounts are now configured in the Beitragsmodell section (FeeType x MembershipType cross-table) */}
           </div>
 
           <DialogFooter>

--- a/apps/web/components/fees/billing-run-panel.tsx
+++ b/apps/web/components/fees/billing-run-panel.tsx
@@ -1,0 +1,263 @@
+'use client';
+
+import { useState } from 'react';
+import { Loader2, AlertTriangle } from 'lucide-react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Skeleton } from '@/components/ui/skeleton';
+import { BillingRunPreview } from '@/components/fees/billing-run-preview';
+import { useBillingRunPreview, useBillingRunConfirm } from '@/hooks/use-billing-run';
+import type { BillingRunPreviewResponse, BillingInterval } from '@ktb/shared';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface BillingRunPanelProps {
+  slug: string;
+  /** Callback when billing run completes (e.g., switch to Forderungen tab) */
+  onComplete?: () => void;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const moneyFormatter = new Intl.NumberFormat('de-DE', {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+function formatMoney(value: string): string {
+  return `${moneyFormatter.format(parseFloat(value))} EUR`;
+}
+
+const INTERVAL_OPTIONS: { value: BillingInterval; label: string }[] = [
+  { value: 'MONTHLY', label: 'Monatlich' },
+  { value: 'QUARTERLY', label: 'Quartalsweise' },
+  { value: 'ANNUALLY', label: 'Jaehrlich' },
+];
+
+// ============================================================================
+// Component
+// ============================================================================
+
+/**
+ * Billing run orchestration panel.
+ *
+ * Two-step flow:
+ * 1. Configuration: Select period, interval, load preview
+ * 2. Preview: Review summary, set due date, confirm
+ */
+export function BillingRunPanel({ slug, onComplete }: BillingRunPanelProps) {
+  // Form state
+  const [periodStart, setPeriodStart] = useState('');
+  const [periodEnd, setPeriodEnd] = useState('');
+  const [billingInterval, setBillingInterval] = useState<BillingInterval>('ANNUALLY');
+  const [dueDate, setDueDate] = useState('');
+  const [showConfirmDialog, setShowConfirmDialog] = useState(false);
+
+  // Preview state
+  const [previewData, setPreviewData] = useState<BillingRunPreviewResponse | null>(null);
+
+  // Mutations
+  const previewMutation = useBillingRunPreview(slug);
+  const confirmMutation = useBillingRunConfirm(slug);
+
+  // Handlers
+  function handleLoadPreview() {
+    if (!periodStart || !periodEnd) return;
+
+    previewMutation.mutate(
+      { periodStart, periodEnd, billingInterval },
+      {
+        onSuccess: (data) => {
+          setPreviewData(data);
+        },
+      }
+    );
+  }
+
+  function handleConfirm() {
+    if (!periodStart || !periodEnd || !dueDate) return;
+
+    confirmMutation.mutate(
+      { periodStart, periodEnd, billingInterval, dueDate },
+      {
+        onSuccess: () => {
+          setShowConfirmDialog(false);
+          setPreviewData(null);
+          setPeriodStart('');
+          setPeriodEnd('');
+          setDueDate('');
+          onComplete?.();
+        },
+      }
+    );
+  }
+
+  function handleBack() {
+    setPreviewData(null);
+    setDueDate('');
+  }
+
+  const canLoadPreview = periodStart && periodEnd && !previewMutation.isPending;
+  const canConfirm = previewData && dueDate && !confirmMutation.isPending;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Beitragserhebung</CardTitle>
+        <CardDescription>Forderungen fuer einen Abrechnungszeitraum erstellen</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {/* Step 1: Configuration */}
+        {!previewData && (
+          <div className="space-y-4">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+              <div className="space-y-2">
+                <Label htmlFor="periodStart">Von</Label>
+                <Input
+                  id="periodStart"
+                  type="date"
+                  value={periodStart}
+                  onChange={(e) => setPeriodStart(e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="periodEnd">Bis</Label>
+                <Input
+                  id="periodEnd"
+                  type="date"
+                  value={periodEnd}
+                  onChange={(e) => setPeriodEnd(e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="billingInterval">Rhythmus</Label>
+                <Select
+                  value={billingInterval}
+                  onValueChange={(value) => setBillingInterval(value as BillingInterval)}
+                >
+                  <SelectTrigger id="billingInterval" className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {INTERVAL_OPTIONS.map((opt) => (
+                      <SelectItem key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            <Button onClick={handleLoadPreview} disabled={!canLoadPreview}>
+              {previewMutation.isPending && <Loader2 className="h-4 w-4 animate-spin" />}
+              Vorschau laden
+            </Button>
+          </div>
+        )}
+
+        {/* Loading skeleton for preview */}
+        {previewMutation.isPending && !previewData && (
+          <div className="space-y-4">
+            <Skeleton className="h-6 w-40" />
+            <div className="flex gap-6">
+              <Skeleton className="h-5 w-32" />
+              <Skeleton className="h-5 w-40" />
+              <Skeleton className="h-5 w-24" />
+            </div>
+            <Skeleton className="h-6 w-56" />
+            <div className="space-y-2">
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+          </div>
+        )}
+
+        {/* Step 2: Preview + Confirm */}
+        {previewData && (
+          <div className="space-y-6">
+            <BillingRunPreview data={previewData} />
+
+            {/* Duplicate period warning */}
+            {previewData.existingCharges > 0 && (
+              <div className="flex items-start gap-3 rounded-md border bg-warning/15 border-warning/25 p-4">
+                <AlertTriangle className="h-5 w-5 shrink-0 text-warning-foreground" />
+                <p className="text-sm text-warning-foreground">
+                  Fuer diesen Zeitraum existieren bereits {previewData.existingCharges} Forderungen.
+                  Doppelte werden uebersprungen.
+                </p>
+              </div>
+            )}
+
+            {/* Due date field */}
+            <div className="space-y-2">
+              <Label htmlFor="dueDate">Faelligkeitsdatum</Label>
+              <Input
+                id="dueDate"
+                type="date"
+                value={dueDate}
+                onChange={(e) => setDueDate(e.target.value)}
+                className="max-w-xs"
+              />
+            </div>
+
+            {/* Action buttons */}
+            <div className="flex gap-4">
+              <Button variant="outline" onClick={handleBack}>
+                Zurueck
+              </Button>
+              <Button onClick={() => setShowConfirmDialog(true)} disabled={!canConfirm}>
+                Erhebung durchfuehren
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* Confirmation AlertDialog */}
+        <AlertDialog open={showConfirmDialog} onOpenChange={setShowConfirmDialog}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Beitragserhebung durchfuehren</AlertDialogTitle>
+              <AlertDialogDescription>
+                Es werden {previewData?.memberCount ?? 0} Forderungen ueber insgesamt{' '}
+                {previewData ? formatMoney(previewData.totalAmount) : '0,00 EUR'} erstellt. Dieser
+                Vorgang kann nicht rueckgaengig gemacht werden.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Abbrechen</AlertDialogCancel>
+              <AlertDialogAction onClick={handleConfirm} disabled={confirmMutation.isPending}>
+                {confirmMutation.isPending && <Loader2 className="h-4 w-4 animate-spin" />}
+                Erhebung starten
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/components/fees/billing-run-panel.tsx
+++ b/apps/web/components/fees/billing-run-panel.tsx
@@ -42,14 +42,7 @@ interface BillingRunPanelProps {
 // Helpers
 // ============================================================================
 
-const moneyFormatter = new Intl.NumberFormat('de-DE', {
-  minimumFractionDigits: 2,
-  maximumFractionDigits: 2,
-});
-
-function formatMoney(value: string): string {
-  return `${moneyFormatter.format(parseFloat(value))} EUR`;
-}
+import { formatMoney } from '@/lib/format-money';
 
 const INTERVAL_OPTIONS: { value: BillingInterval; label: string }[] = [
   { value: 'MONTHLY', label: 'Monatlich' },

--- a/apps/web/components/fees/billing-run-panel.tsx
+++ b/apps/web/components/fees/billing-run-panel.tsx
@@ -46,8 +46,8 @@ import { formatMoney } from '@/lib/format-money';
 
 const INTERVAL_OPTIONS: { value: BillingInterval; label: string }[] = [
   { value: 'MONTHLY', label: 'Monatlich' },
-  { value: 'QUARTERLY', label: 'Quartalsweise' },
-  { value: 'ANNUALLY', label: 'Jaehrlich' },
+  { value: 'QUARTERLY', label: 'Vierteljährlich' },
+  { value: 'ANNUALLY', label: 'Jährlich' },
 ];
 
 // ============================================================================
@@ -120,7 +120,7 @@ export function BillingRunPanel({ slug, onComplete }: BillingRunPanelProps) {
     <Card>
       <CardHeader>
         <CardTitle>Beitragserhebung</CardTitle>
-        <CardDescription>Forderungen fuer einen Abrechnungszeitraum erstellen</CardDescription>
+        <CardDescription>Forderungen für einen Abrechnungszeitraum erstellen</CardDescription>
       </CardHeader>
       <CardContent className="space-y-6">
         {/* Step 1: Configuration */}
@@ -200,15 +200,15 @@ export function BillingRunPanel({ slug, onComplete }: BillingRunPanelProps) {
               <div className="flex items-start gap-3 rounded-md border bg-warning/15 border-warning/25 p-4">
                 <AlertTriangle className="h-5 w-5 shrink-0 text-warning-foreground" />
                 <p className="text-sm text-warning-foreground">
-                  Fuer diesen Zeitraum existieren bereits {previewData.existingCharges} Forderungen.
-                  Doppelte werden uebersprungen.
+                  Für diesen Zeitraum existieren bereits {previewData.existingCharges} Forderungen.
+                  Doppelte werden übersprungen.
                 </p>
               </div>
             )}
 
             {/* Due date field */}
             <div className="space-y-2">
-              <Label htmlFor="dueDate">Faelligkeitsdatum</Label>
+              <Label htmlFor="dueDate">Fälligkeitsdatum</Label>
               <Input
                 id="dueDate"
                 type="date"
@@ -221,10 +221,10 @@ export function BillingRunPanel({ slug, onComplete }: BillingRunPanelProps) {
             {/* Action buttons */}
             <div className="flex gap-4">
               <Button variant="outline" onClick={handleBack}>
-                Zurueck
+                Zurück
               </Button>
               <Button onClick={() => setShowConfirmDialog(true)} disabled={!canConfirm}>
-                Erhebung durchfuehren
+                Erhebung durchführen
               </Button>
             </div>
           </div>
@@ -234,11 +234,11 @@ export function BillingRunPanel({ slug, onComplete }: BillingRunPanelProps) {
         <AlertDialog open={showConfirmDialog} onOpenChange={setShowConfirmDialog}>
           <AlertDialogContent>
             <AlertDialogHeader>
-              <AlertDialogTitle>Beitragserhebung durchfuehren</AlertDialogTitle>
+              <AlertDialogTitle>Beitragserhebung durchführen</AlertDialogTitle>
               <AlertDialogDescription>
-                Es werden {previewData?.memberCount ?? 0} Forderungen ueber insgesamt{' '}
+                Es werden {previewData?.memberCount ?? 0} Forderungen über insgesamt{' '}
                 {previewData ? formatMoney(previewData.totalAmount) : '0,00 EUR'} erstellt. Dieser
-                Vorgang kann nicht rueckgaengig gemacht werden.
+                Vorgang kann nicht rückgängig gemacht werden.
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>

--- a/apps/web/components/fees/billing-run-panel.tsx
+++ b/apps/web/components/fees/billing-run-panel.tsx
@@ -236,7 +236,8 @@ export function BillingRunPanel({ slug, onComplete }: BillingRunPanelProps) {
             <AlertDialogHeader>
               <AlertDialogTitle>Beitragserhebung durchführen</AlertDialogTitle>
               <AlertDialogDescription>
-                Es werden {previewData?.memberCount ?? 0} Forderungen über insgesamt{' '}
+                Es werden {previewData?.chargeCount ?? 0} Forderungen für{' '}
+                {previewData?.memberCount ?? 0} Mitglieder über insgesamt{' '}
                 {previewData ? formatMoney(previewData.totalAmount) : '0,00 EUR'} erstellt. Dieser
                 Vorgang kann nicht rückgängig gemacht werden.
               </AlertDialogDescription>

--- a/apps/web/components/fees/billing-run-preview.test.tsx
+++ b/apps/web/components/fees/billing-run-preview.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import type { BillingRunPreviewResponse } from '@ktb/shared';
+
+import { BillingRunPreview } from './billing-run-preview';
+
+// A breakdown row may carry a `kind` discriminator added by the backend
+// (WR-04). The shared type does not yet declare it, so the tests construct
+// rows with the field and cast to the prop type.
+type BreakdownRow = {
+  membershipType: string;
+  count: number;
+  subtotal: string;
+  kind?: 'membershipType' | 'category';
+};
+
+function makeData(overrides: Partial<BillingRunPreviewResponse> = {}): BillingRunPreviewResponse {
+  return {
+    memberCount: 3,
+    chargeCount: 3,
+    totalAmount: '195.00',
+    exemptions: 0,
+    existingCharges: 0,
+    breakdown: [],
+    warnings: [],
+    ...overrides,
+  } as BillingRunPreviewResponse;
+}
+
+describe('BillingRunPreview', () => {
+  it('renders summary stats', () => {
+    render(<BillingRunPreview data={makeData()} />);
+
+    expect(screen.getByText('Zusammenfassung')).toBeInTheDocument();
+    expect(screen.getByText('Mitglieder:')).toBeInTheDocument();
+  });
+
+  /**
+   * Regression WR-05: the breakdown previously rendered a "Keine Beitragsart"
+   * badge whenever a warning's `memberName` equalled a breakdown row's
+   * `membershipType`. Member full names never equal breakdown type/category
+   * names, so the branch was dead. Even when a warning name happens to collide
+   * with a breakdown row name, no "Keine Beitragsart" badge must render —
+   * members without a Beitragsart are excluded from the breakdown entirely.
+   */
+  it('never renders a "Keine Beitragsart" badge inside breakdown rows', () => {
+    const breakdown: BreakdownRow[] = [
+      { membershipType: 'Max Mustermann', count: 1, subtotal: '65.00', kind: 'membershipType' },
+    ];
+    const data = makeData({
+      breakdown: breakdown as BillingRunPreviewResponse['breakdown'],
+      // Deliberately collide warning name with the breakdown row name.
+      warnings: [{ memberId: 'm1', memberName: 'Max Mustermann', reason: 'Keine Beitragsart' }],
+    });
+
+    render(<BillingRunPreview data={data} />);
+
+    expect(screen.queryByText('Keine Beitragsart')).not.toBeInTheDocument();
+  });
+
+  /**
+   * WR-04: breakdown rows must be labeled by their kind so a membership type
+   * and a fee category that share a display name are not conflated.
+   */
+  it('labels membership-type rows with "Mitgliedsart"', () => {
+    const breakdown: BreakdownRow[] = [
+      {
+        membershipType: 'Ordentliches Mitglied',
+        count: 2,
+        subtotal: '130.00',
+        kind: 'membershipType',
+      },
+    ];
+    render(
+      <BillingRunPreview
+        data={makeData({ breakdown: breakdown as BillingRunPreviewResponse['breakdown'] })}
+      />
+    );
+
+    expect(screen.getByText('Ordentliches Mitglied')).toBeInTheDocument();
+    expect(screen.getByText('Mitgliedsart')).toBeInTheDocument();
+  });
+
+  it('labels category rows with "Kategorie"', () => {
+    const breakdown: BreakdownRow[] = [
+      { membershipType: 'Spendenbeitrag', count: 5, subtotal: '250.00', kind: 'category' },
+    ];
+    render(
+      <BillingRunPreview
+        data={makeData({ breakdown: breakdown as BillingRunPreviewResponse['breakdown'] })}
+      />
+    );
+
+    expect(screen.getByText('Spendenbeitrag')).toBeInTheDocument();
+    expect(screen.getByText('Kategorie')).toBeInTheDocument();
+  });
+
+  it('distinguishes a category and a membership type that share a name', () => {
+    const breakdown: BreakdownRow[] = [
+      { membershipType: 'Förderung', count: 2, subtotal: '100.00', kind: 'membershipType' },
+      { membershipType: 'Förderung', count: 3, subtotal: '90.00', kind: 'category' },
+    ];
+    render(
+      <BillingRunPreview
+        data={makeData({ breakdown: breakdown as BillingRunPreviewResponse['breakdown'] })}
+      />
+    );
+
+    expect(screen.getByText('Mitgliedsart')).toBeInTheDocument();
+    expect(screen.getByText('Kategorie')).toBeInTheDocument();
+    expect(screen.getAllByText('Förderung')).toHaveLength(2);
+  });
+
+  it('falls back to "Mitgliedsart" when kind is absent', () => {
+    const breakdown: BreakdownRow[] = [
+      { membershipType: 'Ehrenmitglied', count: 1, subtotal: '0.00' },
+    ];
+    render(
+      <BillingRunPreview
+        data={makeData({ breakdown: breakdown as BillingRunPreviewResponse['breakdown'] })}
+      />
+    );
+
+    expect(screen.getByText('Mitgliedsart')).toBeInTheDocument();
+  });
+
+  it('shows the warnings banner for members without Beitragsart', () => {
+    const data = makeData({
+      warnings: [{ memberId: 'm1', memberName: 'Erika Beispiel', reason: 'Keine Beitragsart' }],
+    });
+    render(<BillingRunPreview data={data} />);
+
+    // The banner lists the excluded member; this is separate from the breakdown.
+    expect(screen.getByText(/werden nicht berücksichtigt/i)).toBeInTheDocument();
+    expect(screen.getByText(/Erika Beispiel/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/fees/billing-run-preview.tsx
+++ b/apps/web/components/fees/billing-run-preview.tsx
@@ -23,14 +23,7 @@ interface BillingRunPreviewProps {
 // Helpers
 // ============================================================================
 
-const moneyFormatter = new Intl.NumberFormat('de-DE', {
-  minimumFractionDigits: 2,
-  maximumFractionDigits: 2,
-});
-
-function formatMoney(value: string): string {
-  return `${moneyFormatter.format(parseFloat(value))} EUR`;
-}
+import { formatMoney } from '@/lib/format-money';
 
 // ============================================================================
 // Component

--- a/apps/web/components/fees/billing-run-preview.tsx
+++ b/apps/web/components/fees/billing-run-preview.tsx
@@ -63,7 +63,7 @@ export function BillingRunPreview({ data }: BillingRunPreviewProps) {
         {/* Breakdown */}
         {data.breakdown.length > 0 && (
           <div>
-            <h3 className="text-sm font-medium mb-3">Aufschluesselung nach Mitgliedsart:</h3>
+            <h3 className="text-sm font-medium mb-3">Aufschlüsselung nach Mitgliedsart:</h3>
             <Table>
               <TableHeader>
                 <TableRow>

--- a/apps/web/components/fees/billing-run-preview.tsx
+++ b/apps/web/components/fees/billing-run-preview.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { Card, CardContent } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import type { BillingRunPreviewResponse } from '@ktb/shared';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface BillingRunPreviewProps {
+  data: BillingRunPreviewResponse;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const moneyFormatter = new Intl.NumberFormat('de-DE', {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+function formatMoney(value: string): string {
+  return `${moneyFormatter.format(parseFloat(value))} EUR`;
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+/**
+ * Displays billing run preview data: summary stats and breakdown by membership type.
+ */
+export function BillingRunPreview({ data }: BillingRunPreviewProps) {
+  return (
+    <Card>
+      <CardContent className="space-y-6">
+        {/* Summary */}
+        <div>
+          <h3 className="text-sm font-medium mb-3">Zusammenfassung</h3>
+          <div className="flex flex-wrap gap-6">
+            <div>
+              <span className="text-sm text-muted-foreground">Mitglieder: </span>
+              <span className="text-sm font-medium tabular-nums">{data.memberCount}</span>
+            </div>
+            <div>
+              <span className="text-sm text-muted-foreground">Gesamtbetrag: </span>
+              <span
+                className="text-sm font-medium tabular-nums"
+                aria-label={`Gesamtbetrag: ${formatMoney(data.totalAmount)}`}
+              >
+                {formatMoney(data.totalAmount)}
+              </span>
+            </div>
+            <div>
+              <span className="text-sm text-muted-foreground">Befreit: </span>
+              <span className="text-sm font-medium tabular-nums">{data.exemptions}</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Breakdown */}
+        {data.breakdown.length > 0 && (
+          <div>
+            <h3 className="text-sm font-medium mb-3">Aufschluesselung nach Mitgliedsart:</h3>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Mitgliedsart</TableHead>
+                  <TableHead className="text-right tabular-nums">Anzahl</TableHead>
+                  <TableHead className="text-right tabular-nums">Zwischensumme</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {data.breakdown.map((item) => (
+                  <TableRow key={item.membershipType}>
+                    <TableCell>{item.membershipType}</TableCell>
+                    <TableCell className="text-right tabular-nums">{item.count}</TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {formatMoney(item.subtotal)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/components/fees/billing-run-preview.tsx
+++ b/apps/web/components/fees/billing-run-preview.tsx
@@ -1,6 +1,8 @@
 'use client';
 
+import { AlertTriangle } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
 import {
   Table,
   TableBody,
@@ -9,6 +11,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import type { BillingRunPreviewResponse } from '@ktb/shared';
 
 // ============================================================================
@@ -30,12 +33,40 @@ import { formatMoney } from '@/lib/format-money';
 // ============================================================================
 
 /**
- * Displays billing run preview data: summary stats and breakdown by membership type.
+ * Displays billing run preview data: summary stats, warnings for members
+ * without Beitragsart, and breakdown by membership type.
  */
 export function BillingRunPreview({ data }: BillingRunPreviewProps) {
+  const warnings = data.warnings ?? [];
+
   return (
     <Card>
       <CardContent className="space-y-6">
+        {/* Warnings summary for members without Beitragsart */}
+        {warnings.length > 0 && (
+          <div className="rounded-md border border-warning/50 bg-warning/10 p-3">
+            <div className="flex items-start gap-2">
+              <AlertTriangle className="h-4 w-4 text-warning shrink-0 mt-0.5" />
+              <div>
+                <p className="text-sm font-medium text-warning">
+                  {warnings.length} Mitglied{warnings.length !== 1 ? 'er' : ''} ohne Beitragsart —
+                  werden nicht berücksichtigt
+                </p>
+                <ul className="mt-1 text-xs text-muted-foreground space-y-0.5">
+                  {warnings.slice(0, 5).map((w) => (
+                    <li key={w.memberId}>
+                      {w.memberName}: {w.reason}
+                    </li>
+                  ))}
+                  {warnings.length > 5 && (
+                    <li className="text-muted-foreground">... und {warnings.length - 5} weitere</li>
+                  )}
+                </ul>
+              </div>
+            </div>
+          </div>
+        )}
+
         {/* Summary */}
         <div>
           <h3 className="text-sm font-medium mb-3">Zusammenfassung</h3>
@@ -43,6 +74,10 @@ export function BillingRunPreview({ data }: BillingRunPreviewProps) {
             <div>
               <span className="text-sm text-muted-foreground">Mitglieder: </span>
               <span className="text-sm font-medium tabular-nums">{data.memberCount}</span>
+            </div>
+            <div>
+              <span className="text-sm text-muted-foreground">Forderungen: </span>
+              <span className="text-sm font-medium tabular-nums">{data.chargeCount}</span>
             </div>
             <div>
               <span className="text-sm text-muted-foreground">Gesamtbetrag: </span>
@@ -57,31 +92,64 @@ export function BillingRunPreview({ data }: BillingRunPreviewProps) {
               <span className="text-sm text-muted-foreground">Befreit: </span>
               <span className="text-sm font-medium tabular-nums">{data.exemptions}</span>
             </div>
+            {warnings.length > 0 && (
+              <div>
+                <span className="text-sm text-muted-foreground">Ohne Beitragsart: </span>
+                <span className="text-sm font-medium tabular-nums text-warning">
+                  {warnings.length}
+                </span>
+              </div>
+            )}
           </div>
         </div>
 
         {/* Breakdown */}
         {data.breakdown.length > 0 && (
           <div>
-            <h3 className="text-sm font-medium mb-3">Aufschlüsselung nach Mitgliedsart:</h3>
+            <h3 className="text-sm font-medium mb-3">Aufschlüsselung:</h3>
             <Table>
               <TableHeader>
                 <TableRow>
-                  <TableHead>Mitgliedsart</TableHead>
+                  <TableHead>Position</TableHead>
+                  <TableHead>Beitragsart</TableHead>
                   <TableHead className="text-right tabular-nums">Anzahl</TableHead>
                   <TableHead className="text-right tabular-nums">Zwischensumme</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {data.breakdown.map((item) => (
-                  <TableRow key={item.membershipType}>
-                    <TableCell>{item.membershipType}</TableCell>
-                    <TableCell className="text-right tabular-nums">{item.count}</TableCell>
-                    <TableCell className="text-right tabular-nums">
-                      {formatMoney(item.subtotal)}
-                    </TableCell>
-                  </TableRow>
-                ))}
+                {data.breakdown.map((item) => {
+                  const memberWarning = warnings.find((w) => w.memberName === item.membershipType);
+                  return (
+                    <TableRow key={item.membershipType}>
+                      <TableCell>
+                        <span>{item.membershipType}</span>
+                        {memberWarning && (
+                          <TooltipProvider>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <Badge
+                                  variant="outline"
+                                  className="ml-2 bg-warning/15 text-warning"
+                                  role="status"
+                                >
+                                  Keine Beitragsart
+                                </Badge>
+                              </TooltipTrigger>
+                              <TooltipContent>
+                                <p>{memberWarning.reason}</p>
+                              </TooltipContent>
+                            </Tooltip>
+                          </TooltipProvider>
+                        )}
+                      </TableCell>
+                      <TableCell className="text-muted-foreground">{'\u2014'}</TableCell>
+                      <TableCell className="text-right tabular-nums">{item.count}</TableCell>
+                      <TableCell className="text-right tabular-nums">
+                        {formatMoney(item.subtotal)}
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
               </TableBody>
             </Table>
           </div>

--- a/apps/web/components/fees/billing-run-preview.tsx
+++ b/apps/web/components/fees/billing-run-preview.tsx
@@ -142,7 +142,7 @@ export function BillingRunPreview({ data }: BillingRunPreviewProps) {
                           </TooltipProvider>
                         )}
                       </TableCell>
-                      <TableCell className="text-muted-foreground">{'\u2014'}</TableCell>
+                      <TableCell className="text-muted-foreground">{'—'}</TableCell>
                       <TableCell className="text-right tabular-nums">{item.count}</TableCell>
                       <TableCell className="text-right tabular-nums">
                         {formatMoney(item.subtotal)}

--- a/apps/web/components/fees/billing-run-preview.tsx
+++ b/apps/web/components/fees/billing-run-preview.tsx
@@ -11,7 +11,6 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import type { BillingRunPreviewResponse } from '@ktb/shared';
 
 // ============================================================================
@@ -21,6 +20,23 @@ import type { BillingRunPreviewResponse } from '@ktb/shared';
 interface BillingRunPreviewProps {
   data: BillingRunPreviewResponse;
 }
+
+/**
+ * A single breakdown row. Each entry carries a `kind` distinguishing
+ * membership-type base-fee rows from fee-category rows, so rows that share a
+ * display name are not conflated in the UI (see WR-04).
+ *
+ * `kind` is optional here for forward-compatibility: older preview responses
+ * without the field fall back to "membershipType".
+ */
+type BreakdownItem = BillingRunPreviewResponse['breakdown'][number] & {
+  kind?: 'membershipType' | 'category';
+};
+
+const KIND_LABELS: Record<'membershipType' | 'category', string> = {
+  membershipType: 'Mitgliedsart',
+  category: 'Kategorie',
+};
 
 // ============================================================================
 // Helpers
@@ -117,30 +133,15 @@ export function BillingRunPreview({ data }: BillingRunPreviewProps) {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {data.breakdown.map((item) => {
-                  const memberWarning = warnings.find((w) => w.memberName === item.membershipType);
+                {(data.breakdown as BreakdownItem[]).map((item) => {
+                  const kind = item.kind ?? 'membershipType';
                   return (
-                    <TableRow key={item.membershipType}>
+                    <TableRow key={`${kind}-${item.membershipType}`}>
                       <TableCell>
                         <span>{item.membershipType}</span>
-                        {memberWarning && (
-                          <TooltipProvider>
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <Badge
-                                  variant="outline"
-                                  className="ml-2 bg-warning/15 text-warning"
-                                  role="status"
-                                >
-                                  Keine Beitragsart
-                                </Badge>
-                              </TooltipTrigger>
-                              <TooltipContent>
-                                <p>{memberWarning.reason}</p>
-                              </TooltipContent>
-                            </Tooltip>
-                          </TooltipProvider>
-                        )}
+                        <Badge variant="outline" className="ml-2 bg-muted text-muted-foreground">
+                          {KIND_LABELS[kind]}
+                        </Badge>
                       </TableCell>
                       <TableCell className="text-muted-foreground">{'—'}</TableCell>
                       <TableCell className="text-right tabular-nums">{item.count}</TableCell>

--- a/apps/web/components/fees/cross-table-matrix.test.tsx
+++ b/apps/web/components/fees/cross-table-matrix.test.tsx
@@ -1,0 +1,125 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { CrossTableEntryResponse } from '@ktb/shared';
+
+// ----------------------------------------------------------------------------
+// Hook mocks
+// ----------------------------------------------------------------------------
+
+const feeType = { id: 'ft-1', name: 'Einzelbeitrag', isActive: true };
+const membershipType = { id: 'mt-1', name: 'Ordentliches Mitglied' };
+
+let crossTableEntries: CrossTableEntryResponse[] = [];
+
+vi.mock('@/hooks/use-fee-types', () => ({
+  useFeeTypes: () => ({ data: [feeType], isLoading: false }),
+}));
+
+vi.mock('@/hooks/use-membership-types', () => ({
+  useMembershipTypes: () => ({ data: [membershipType], isLoading: false }),
+}));
+
+const mockUpsertMutateAsync = vi.fn();
+const mockDeleteMutateAsync = vi.fn();
+
+vi.mock('@/hooks/use-cross-table', () => ({
+  useCrossTable: () => ({ data: crossTableEntries, isLoading: false }),
+  useUpsertCrossTableEntry: () => ({
+    mutateAsync: mockUpsertMutateAsync,
+    isError: false,
+  }),
+  useDeleteCrossTableEntry: () => ({
+    mutateAsync: mockDeleteMutateAsync,
+    isError: false,
+  }),
+}));
+
+const mockToast = vi.fn();
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+import { CrossTableMatrix } from './cross-table-matrix';
+
+function makeEntry(): CrossTableEntryResponse {
+  return {
+    id: 'entry-1',
+    membershipTypeId: membershipType.id,
+    feeTypeId: feeType.id,
+    amount: '65.00',
+    billingInterval: 'ANNUALLY',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+const cellLabel = `${membershipType.name} ${feeType.name} Betrag`;
+
+describe('CrossTableMatrix', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUpsertMutateAsync.mockResolvedValue({});
+    mockDeleteMutateAsync.mockResolvedValue(undefined);
+    crossTableEntries = [];
+  });
+
+  /**
+   * Regression WR-06: clearing an existing entry's amount and saving must call
+   * the delete mutation with the entry id. Previously this branch only called
+   * cancelEditing() and the row stayed billable.
+   */
+  it('deletes an existing entry when its amount is cleared and saved', async () => {
+    crossTableEntries = [makeEntry()];
+    const user = userEvent.setup();
+    render(<CrossTableMatrix slug="tsv" />);
+
+    // Enter edit mode on the populated cell.
+    await user.click(screen.getByLabelText(cellLabel));
+    const input = screen.getByLabelText(cellLabel) as HTMLInputElement;
+
+    // Clear the amount and save via Enter.
+    await user.clear(input);
+    await user.keyboard('{Enter}');
+
+    expect(mockDeleteMutateAsync).toHaveBeenCalledWith('entry-1');
+    expect(mockUpsertMutateAsync).not.toHaveBeenCalled();
+  });
+
+  /**
+   * WR-06: when no entry exists, clearing/saving an empty value is a no-op —
+   * nothing to delete, nothing to upsert.
+   */
+  it('does not call delete when an empty cell is saved empty', async () => {
+    crossTableEntries = [];
+    const user = userEvent.setup();
+    render(<CrossTableMatrix slug="tsv" />);
+
+    await user.click(screen.getByLabelText(cellLabel));
+    // Cell is now an empty editing input; saving without typing is a no-op.
+    await user.keyboard('{Enter}');
+
+    expect(mockDeleteMutateAsync).not.toHaveBeenCalled();
+    expect(mockUpsertMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('upserts when a valid amount is entered into an empty cell', async () => {
+    crossTableEntries = [];
+    const user = userEvent.setup();
+    render(<CrossTableMatrix slug="tsv" />);
+
+    await user.click(screen.getByLabelText(cellLabel));
+    const input = screen.getByLabelText(cellLabel) as HTMLInputElement;
+
+    await user.type(input, '50,00');
+    await user.keyboard('{Enter}');
+
+    expect(mockUpsertMutateAsync).toHaveBeenCalledWith({
+      membershipTypeId: membershipType.id,
+      feeTypeId: feeType.id,
+      amount: '50.00',
+      billingInterval: 'ANNUALLY',
+    });
+    expect(mockDeleteMutateAsync).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/components/fees/cross-table-matrix.tsx
+++ b/apps/web/components/fees/cross-table-matrix.tsx
@@ -67,13 +67,13 @@ export function CrossTableMatrix({ slug }: CrossTableMatrixProps) {
       <Card>
         <CardHeader>
           <CardTitle>Beitragstabelle</CardTitle>
-          <CardDescription>Betr\u00e4ge pro Mitgliedsart und Beitragsart</CardDescription>
+          <CardDescription>Beträge pro Mitgliedsart und Beitragsart</CardDescription>
         </CardHeader>
         <CardContent>
           <div className="flex flex-col items-center justify-center py-12 text-center">
-            <h3 className="text-lg font-semibold mb-2">Beitragstabelle nicht verf\u00fcgbar</h3>
+            <h3 className="text-lg font-semibold mb-2">Beitragstabelle nicht verfügbar</h3>
             <p className="text-muted-foreground max-w-md">
-              Erstelle zuerst Beitragsarten (siehe oben), um die Beitragstabelle zu bef\u00fcllen.
+              Erstelle zuerst Beitragsarten (siehe oben), um die Beitragstabelle zu befüllen.
             </p>
           </div>
         </CardContent>
@@ -87,7 +87,7 @@ export function CrossTableMatrix({ slug }: CrossTableMatrixProps) {
       <Card>
         <CardHeader>
           <CardTitle>Beitragstabelle</CardTitle>
-          <CardDescription>Betr\u00e4ge pro Mitgliedsart und Beitragsart</CardDescription>
+          <CardDescription>Beträge pro Mitgliedsart und Beitragsart</CardDescription>
         </CardHeader>
         <CardContent>
           <div className="flex flex-col items-center justify-center py-12 text-center">
@@ -105,7 +105,7 @@ export function CrossTableMatrix({ slug }: CrossTableMatrixProps) {
     <Card>
       <CardHeader>
         <CardTitle>Beitragstabelle</CardTitle>
-        <CardDescription>Betr\u00e4ge pro Mitgliedsart und Beitragsart</CardDescription>
+        <CardDescription>Beträge pro Mitgliedsart und Beitragsart</CardDescription>
       </CardHeader>
       <CardContent>
         <div className="overflow-x-auto">
@@ -146,8 +146,8 @@ export function CrossTableMatrix({ slug }: CrossTableMatrixProps) {
           </Table>
         </div>
         <p className="mt-4 text-sm text-muted-foreground">
-          Leere Zellen bedeuten, dass die Kombination nicht verf\u00fcgbar ist. Trage einen Betrag
-          ein, um die Zuordnung zu aktivieren.
+          Leere Zellen bedeuten, dass die Kombination nicht verfügbar ist. Trage einen Betrag ein,
+          um die Zuordnung zu aktivieren.
         </p>
       </CardContent>
     </Card>
@@ -208,7 +208,7 @@ function MatrixCell({ slug, membershipType, feeType, entry }: MatrixCellProps) {
     if (isNaN(num) || num < 0) {
       toast({
         title: 'Fehler',
-        description: 'Bitte gib einen g\u00fcltigen Betrag ein (z.B. 65,00).',
+        description: 'Bitte gib einen gültigen Betrag ein (z.B. 65,00).',
         variant: 'destructive',
       });
       return;

--- a/apps/web/components/fees/cross-table-matrix.tsx
+++ b/apps/web/components/fees/cross-table-matrix.tsx
@@ -71,12 +71,9 @@ export function CrossTableMatrix({ slug }: CrossTableMatrixProps) {
         </CardHeader>
         <CardContent>
           <div className="flex flex-col items-center justify-center py-12 text-center">
-            <h3 className="text-lg font-semibold mb-2">
-              Beitragstabelle nicht verf\u00fcgbar
-            </h3>
+            <h3 className="text-lg font-semibold mb-2">Beitragstabelle nicht verf\u00fcgbar</h3>
             <p className="text-muted-foreground max-w-md">
-              Erstelle zuerst Beitragsarten (siehe oben), um die Beitragstabelle zu
-              bef\u00fcllen.
+              Erstelle zuerst Beitragsarten (siehe oben), um die Beitragstabelle zu bef\u00fcllen.
             </p>
           </div>
         </CardContent>
@@ -149,8 +146,8 @@ export function CrossTableMatrix({ slug }: CrossTableMatrixProps) {
           </Table>
         </div>
         <p className="mt-4 text-sm text-muted-foreground">
-          Leere Zellen bedeuten, dass die Kombination nicht verf\u00fcgbar ist. Trage einen
-          Betrag ein, um die Zuordnung zu aktivieren.
+          Leere Zellen bedeuten, dass die Kombination nicht verf\u00fcgbar ist. Trage einen Betrag
+          ein, um die Zuordnung zu aktivieren.
         </p>
       </CardContent>
     </Card>

--- a/apps/web/components/fees/cross-table-matrix.tsx
+++ b/apps/web/components/fees/cross-table-matrix.tsx
@@ -226,6 +226,7 @@ function MatrixCell({ slug, membershipType, feeType, entry }: MatrixCellProps) {
         membershipTypeId: membershipType.id,
         feeTypeId: feeType.id,
         amount: normalized,
+        billingInterval: entry?.billingInterval ?? 'ANNUALLY',
       });
       setIsEditing(false);
     } catch {

--- a/apps/web/components/fees/cross-table-matrix.tsx
+++ b/apps/web/components/fees/cross-table-matrix.tsx
@@ -271,20 +271,22 @@ function MatrixCell({ slug, membershipType, feeType, entry }: MatrixCellProps) {
   if (!entry) {
     return (
       <TableCell
-        className="text-center text-muted-foreground cursor-pointer hover:bg-muted/50"
+        className="text-right text-muted-foreground cursor-pointer hover:bg-muted/50 hover:ring-1 hover:ring-border hover:rounded-sm transition-shadow"
         onClick={startEditing}
         aria-label={ariaLabel}
+        title="Klicke, um einen Betrag einzutragen"
       >
-        <span className="text-sm">&mdash;</span>
+        <span className="text-sm">—</span>
       </TableCell>
     );
   }
 
   return (
     <TableCell
-      className={`text-right tabular-nums text-sm cursor-pointer hover:bg-muted/50 ${isSaving ? 'opacity-50' : ''}`}
+      className={`text-right tabular-nums text-sm cursor-pointer hover:bg-muted/50 hover:ring-1 hover:ring-border hover:rounded-sm transition-shadow ${isSaving ? 'opacity-50' : ''}`}
       onClick={startEditing}
       aria-label={ariaLabel}
+      title="Klicke, um den Betrag zu ändern"
     >
       {displayValue} EUR
     </TableCell>

--- a/apps/web/components/fees/cross-table-matrix.tsx
+++ b/apps/web/components/fees/cross-table-matrix.tsx
@@ -1,0 +1,307 @@
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Input } from '@/components/ui/input';
+import { useFeeTypes } from '@/hooks/use-fee-types';
+import { useCrossTable, useUpsertCrossTableEntry } from '@/hooks/use-cross-table';
+import { useMembershipTypes } from '@/hooks/use-membership-types';
+import { useToast } from '@/hooks/use-toast';
+import type { CrossTableEntryResponse, FeeTypeResponse } from '@ktb/shared';
+import type { MembershipType } from '@/hooks/use-membership-types';
+
+interface CrossTableMatrixProps {
+  slug: string;
+}
+
+/**
+ * Editable matrix table for MembershipType x FeeType = amount.
+ * Rows: MembershipTypes, Columns: Active FeeTypes, Cells: editable amounts.
+ */
+export function CrossTableMatrix({ slug }: CrossTableMatrixProps) {
+  const { data: feeTypes, isLoading: feeTypesLoading } = useFeeTypes(slug);
+  const { data: crossTableEntries, isLoading: crossTableLoading } = useCrossTable(slug);
+  const { data: membershipTypes, isLoading: membershipTypesLoading } = useMembershipTypes(slug);
+
+  const isLoading = feeTypesLoading || crossTableLoading || membershipTypesLoading;
+
+  const activeFeeTypes = (feeTypes ?? []).filter((ft) => ft.isActive);
+  const mtList = membershipTypes ?? [];
+  const entries = crossTableEntries ?? [];
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-5 w-48" />
+          <Skeleton className="h-4 w-80 mt-2" />
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-3">
+            {[...Array(3)].map((_, i) => (
+              <div key={i} className="flex items-center gap-4 py-2">
+                <Skeleton className="h-4 w-24" />
+                <Skeleton className="h-8 w-24" />
+                <Skeleton className="h-8 w-24" />
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Empty state: no FeeTypes
+  if (activeFeeTypes.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Beitragstabelle</CardTitle>
+          <CardDescription>Betr\u00e4ge pro Mitgliedsart und Beitragsart</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-col items-center justify-center py-12 text-center">
+            <h3 className="text-lg font-semibold mb-2">
+              Beitragstabelle nicht verf\u00fcgbar
+            </h3>
+            <p className="text-muted-foreground max-w-md">
+              Erstelle zuerst Beitragsarten (siehe oben), um die Beitragstabelle zu
+              bef\u00fcllen.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Empty state: no MembershipTypes
+  if (mtList.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Beitragstabelle</CardTitle>
+          <CardDescription>Betr\u00e4ge pro Mitgliedsart und Beitragsart</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-col items-center justify-center py-12 text-center">
+            <h3 className="text-lg font-semibold mb-2">Keine Mitgliedsarten vorhanden</h3>
+            <p className="text-muted-foreground max-w-md">
+              Erstelle zuerst Mitgliedsarten in den Vereinseinstellungen.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Beitragstabelle</CardTitle>
+        <CardDescription>Betr\u00e4ge pro Mitgliedsart und Beitragsart</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-x-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="min-w-[150px]">Mitgliedsart</TableHead>
+                {activeFeeTypes.map((ft) => (
+                  <TableHead key={ft.id} scope="col" className="text-right min-w-[120px]">
+                    {ft.name}
+                  </TableHead>
+                ))}
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {mtList.map((mt) => (
+                <TableRow key={mt.id}>
+                  <TableCell className="font-medium" scope="row">
+                    {mt.name}
+                  </TableCell>
+                  {activeFeeTypes.map((ft) => {
+                    const entry = entries.find(
+                      (e) => e.membershipTypeId === mt.id && e.feeTypeId === ft.id
+                    );
+                    return (
+                      <MatrixCell
+                        key={`${mt.id}-${ft.id}`}
+                        slug={slug}
+                        membershipType={mt}
+                        feeType={ft}
+                        entry={entry}
+                      />
+                    );
+                  })}
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+        <p className="mt-4 text-sm text-muted-foreground">
+          Leere Zellen bedeuten, dass die Kombination nicht verf\u00fcgbar ist. Trage einen
+          Betrag ein, um die Zuordnung zu aktivieren.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ============================================================================
+// MatrixCell — inline editable amount cell
+// ============================================================================
+
+interface MatrixCellProps {
+  slug: string;
+  membershipType: MembershipType;
+  feeType: FeeTypeResponse;
+  entry: CrossTableEntryResponse | undefined;
+}
+
+function MatrixCell({ slug, membershipType, feeType, entry }: MatrixCellProps) {
+  const upsertMutation = useUpsertCrossTableEntry(slug);
+  const { toast } = useToast();
+
+  const [isEditing, setIsEditing] = useState(false);
+  const [localValue, setLocalValue] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Format amount for display (German decimal format)
+  const displayValue = entry ? formatGermanDecimal(entry.amount) : '';
+
+  const startEditing = useCallback(() => {
+    setLocalValue(entry ? formatGermanDecimal(entry.amount) : '');
+    setIsEditing(true);
+    // Focus input on next tick
+    setTimeout(() => {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }, 0);
+  }, [entry]);
+
+  const cancelEditing = useCallback(() => {
+    setIsEditing(false);
+    setLocalValue('');
+  }, []);
+
+  const saveValue = useCallback(async () => {
+    const trimmed = localValue.trim();
+
+    // Empty value means remove the entry — just cancel
+    if (!trimmed) {
+      cancelEditing();
+      return;
+    }
+
+    // Normalize: replace comma with dot for validation
+    const normalized = trimmed.replace(',', '.');
+    const num = parseFloat(normalized);
+
+    if (isNaN(num) || num < 0) {
+      toast({
+        title: 'Fehler',
+        description: 'Bitte gib einen g\u00fcltigen Betrag ein (z.B. 65,00).',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    // Check if the value actually changed
+    if (entry && parseFloat(entry.amount) === num) {
+      cancelEditing();
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      await upsertMutation.mutateAsync({
+        membershipTypeId: membershipType.id,
+        feeTypeId: feeType.id,
+        amount: normalized,
+      });
+      setIsEditing(false);
+    } catch {
+      // Error toast is handled by the mutation hook
+    } finally {
+      setIsSaving(false);
+    }
+  }, [localValue, entry, membershipType.id, feeType.id, upsertMutation, cancelEditing, toast]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        saveValue();
+      } else if (e.key === 'Escape') {
+        cancelEditing();
+      }
+    },
+    [saveValue, cancelEditing]
+  );
+
+  const ariaLabel = `${membershipType.name} ${feeType.name} Betrag`;
+
+  if (isEditing) {
+    return (
+      <TableCell className="text-right p-1">
+        <Input
+          ref={inputRef}
+          className={`w-[100px] text-right text-sm tabular-nums ml-auto ${isSaving ? 'opacity-50' : ''} ${upsertMutation.isError ? 'border-destructive' : ''}`}
+          value={localValue}
+          onChange={(e) => setLocalValue(e.target.value)}
+          onBlur={saveValue}
+          onKeyDown={handleKeyDown}
+          aria-label={ariaLabel}
+          inputMode="decimal"
+          disabled={isSaving}
+        />
+      </TableCell>
+    );
+  }
+
+  if (!entry) {
+    return (
+      <TableCell
+        className="text-center text-muted-foreground cursor-pointer hover:bg-muted/50"
+        onClick={startEditing}
+        aria-label={ariaLabel}
+      >
+        <span className="text-sm">&mdash;</span>
+      </TableCell>
+    );
+  }
+
+  return (
+    <TableCell
+      className={`text-right tabular-nums text-sm cursor-pointer hover:bg-muted/50 ${isSaving ? 'opacity-50' : ''}`}
+      onClick={startEditing}
+      aria-label={ariaLabel}
+    >
+      {displayValue} EUR
+    </TableCell>
+  );
+}
+
+// ============================================================================
+// Helper
+// ============================================================================
+
+/**
+ * Format a decimal string to German locale (dot -> comma).
+ */
+function formatGermanDecimal(value: string): string {
+  const num = parseFloat(value);
+  if (isNaN(num)) return value;
+  return num.toFixed(2).replace('.', ',');
+}

--- a/apps/web/components/fees/cross-table-matrix.tsx
+++ b/apps/web/components/fees/cross-table-matrix.tsx
@@ -13,7 +13,11 @@ import {
 import { Skeleton } from '@/components/ui/skeleton';
 import { Input } from '@/components/ui/input';
 import { useFeeTypes } from '@/hooks/use-fee-types';
-import { useCrossTable, useUpsertCrossTableEntry } from '@/hooks/use-cross-table';
+import {
+  useCrossTable,
+  useUpsertCrossTableEntry,
+  useDeleteCrossTableEntry,
+} from '@/hooks/use-cross-table';
 import { useMembershipTypes } from '@/hooks/use-membership-types';
 import { useToast } from '@/hooks/use-toast';
 import type { CrossTableEntryResponse, FeeTypeResponse } from '@ktb/shared';
@@ -147,7 +151,7 @@ export function CrossTableMatrix({ slug }: CrossTableMatrixProps) {
         </div>
         <p className="mt-4 text-sm text-muted-foreground">
           Leere Zellen bedeuten, dass die Kombination nicht verfügbar ist. Trage einen Betrag ein,
-          um die Zuordnung zu aktivieren.
+          um die Zuordnung zu aktivieren, oder lösche den Betrag, um sie wieder zu entfernen.
         </p>
       </CardContent>
     </Card>
@@ -167,6 +171,7 @@ interface MatrixCellProps {
 
 function MatrixCell({ slug, membershipType, feeType, entry }: MatrixCellProps) {
   const upsertMutation = useUpsertCrossTableEntry(slug);
+  const deleteMutation = useDeleteCrossTableEntry(slug);
   const { toast } = useToast();
 
   const [isEditing, setIsEditing] = useState(false);
@@ -195,9 +200,22 @@ function MatrixCell({ slug, membershipType, feeType, entry }: MatrixCellProps) {
   const saveValue = useCallback(async () => {
     const trimmed = localValue.trim();
 
-    // Empty value means remove the entry — just cancel
+    // Empty value: remove an existing entry so the combination is no longer
+    // billable. If there is no entry yet, there is nothing to delete — cancel.
     if (!trimmed) {
-      cancelEditing();
+      if (!entry) {
+        cancelEditing();
+        return;
+      }
+      setIsSaving(true);
+      try {
+        await deleteMutation.mutateAsync(entry.id);
+        setIsEditing(false);
+      } catch {
+        // Error toast is handled by the mutation hook
+      } finally {
+        setIsSaving(false);
+      }
       return;
     }
 
@@ -234,7 +252,16 @@ function MatrixCell({ slug, membershipType, feeType, entry }: MatrixCellProps) {
     } finally {
       setIsSaving(false);
     }
-  }, [localValue, entry, membershipType.id, feeType.id, upsertMutation, cancelEditing, toast]);
+  }, [
+    localValue,
+    entry,
+    membershipType.id,
+    feeType.id,
+    upsertMutation,
+    deleteMutation,
+    cancelEditing,
+    toast,
+  ]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -255,7 +282,7 @@ function MatrixCell({ slug, membershipType, feeType, entry }: MatrixCellProps) {
       <TableCell className="text-right p-1">
         <Input
           ref={inputRef}
-          className={`w-[100px] text-right text-sm tabular-nums ml-auto ${isSaving ? 'opacity-50' : ''} ${upsertMutation.isError ? 'border-destructive' : ''}`}
+          className={`w-[100px] text-right text-sm tabular-nums ml-auto ${isSaving ? 'opacity-50' : ''} ${upsertMutation.isError || deleteMutation.isError ? 'border-destructive' : ''}`}
           value={localValue}
           onChange={(e) => setLocalValue(e.target.value)}
           onBlur={saveValue}

--- a/apps/web/components/fees/expandable-description.tsx
+++ b/apps/web/components/fees/expandable-description.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { ChevronDown, ChevronUp } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface ExpandableDescriptionProps {
+  children: React.ReactNode;
+}
+
+/**
+ * Renders text with 2-line clamp and an expand/collapse toggle.
+ * Overrides TableCell's whitespace-nowrap with whitespace-normal.
+ * The toggle only appears when text actually overflows 2 lines.
+ */
+export function ExpandableDescription({ children }: ExpandableDescriptionProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [isClamped, setIsClamped] = useState(false);
+  const textRef = useRef<HTMLParagraphElement>(null);
+
+  const checkClamped = useCallback(() => {
+    const el = textRef.current;
+    if (el) {
+      setIsClamped(el.scrollHeight > el.clientHeight + 1);
+    }
+  }, []);
+
+  useEffect(() => {
+    setExpanded(false);
+    checkClamped();
+  }, [checkClamped, children]);
+
+  return (
+    <div className="max-w-xs">
+      <p
+        ref={textRef}
+        className={cn(
+          'whitespace-normal text-muted-foreground',
+          expanded ? 'line-clamp-none' : 'line-clamp-2'
+        )}
+      >
+        {children}
+      </p>
+      {(isClamped || expanded) && (
+        <button
+          type="button"
+          onClick={() => setExpanded((prev) => !prev)}
+          className="text-xs text-primary hover:underline mt-0.5 inline-flex items-center gap-0.5"
+        >
+          {expanded ? (
+            <>
+              weniger <ChevronUp className="h-3 w-3" />
+            </>
+          ) : (
+            <>
+              mehr <ChevronDown className="h-3 w-3" />
+            </>
+          )}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/fees/fee-category-form.tsx
+++ b/apps/web/components/fees/fee-category-form.tsx
@@ -128,7 +128,7 @@ export function FeeCategoryForm({ open, onOpenChange, editingCategory }: FeeCate
           </DialogTitle>
           <DialogDescription>
             {isEditing
-              ? 'Aendere die Konfiguration der Beitragskategorie.'
+              ? 'Ändere die Konfiguration der Beitragskategorie.'
               : 'Erstelle eine neue Beitragskategorie mit Betrag und Abrechnungszeitraum.'}
           </DialogDescription>
         </DialogHeader>
@@ -202,11 +202,11 @@ export function FeeCategoryForm({ open, onOpenChange, editingCategory }: FeeCate
               )}
             </div>
 
-            {/* Einmalige Gebuehr */}
+            {/* Einmalige Gebühr */}
             <div className="flex items-center justify-between rounded-lg border p-4">
               <div className="space-y-0.5">
                 <Label htmlFor="fc-isOneTime" className="text-sm font-medium">
-                  Einmalige Gebuehr (z.B. Aufnahmegebuehr)
+                  Einmalige Gebühr (z.B. Aufnahmegebühr)
                 </Label>
               </div>
               <Switch

--- a/apps/web/components/fees/fee-category-form.tsx
+++ b/apps/web/components/fees/fee-category-form.tsx
@@ -1,0 +1,252 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useParams } from 'next/navigation';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Loader2 } from 'lucide-react';
+import {
+  CreateFeeCategorySchema,
+  type CreateFeeCategory,
+  type FeeCategoryResponse,
+} from '@ktb/shared';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Switch } from '@/components/ui/switch';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useCreateFeeCategory, useUpdateFeeCategory } from '@/hooks/use-fee-categories';
+
+/**
+ * Form values type uses the schema _input for zodResolver compatibility.
+ */
+type FeeCategoryFormValues = (typeof CreateFeeCategorySchema)['_input'];
+
+const DEFAULT_VALUES: FeeCategoryFormValues = {
+  name: '',
+  description: '',
+  amount: '',
+  billingInterval: 'ANNUALLY',
+  isOneTime: false,
+  sortOrder: 0,
+};
+
+interface FeeCategoryFormProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  editingCategory: FeeCategoryResponse | null;
+}
+
+/**
+ * Dialog for creating or editing a fee category.
+ * Uses react-hook-form with zodResolver for validation.
+ */
+export function FeeCategoryForm({ open, onOpenChange, editingCategory }: FeeCategoryFormProps) {
+  const params = useParams<{ slug: string }>();
+  const slug = params.slug;
+  const isEditing = !!editingCategory;
+
+  const createMutation = useCreateFeeCategory(slug);
+  const updateMutation = useUpdateFeeCategory(slug);
+  const isPending = createMutation.isPending || updateMutation.isPending;
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    setValue,
+    watch,
+    formState: { errors },
+  } = useForm<FeeCategoryFormValues>({
+    resolver: zodResolver(CreateFeeCategorySchema),
+    defaultValues: DEFAULT_VALUES,
+  });
+
+  // Reset form when dialog opens/closes or editing target changes
+  useEffect(() => {
+    if (open) {
+      if (editingCategory) {
+        reset({
+          name: editingCategory.name,
+          description: editingCategory.description ?? '',
+          amount: editingCategory.amount,
+          billingInterval: editingCategory.billingInterval,
+          isOneTime: editingCategory.isOneTime,
+          sortOrder: editingCategory.sortOrder,
+        });
+      } else {
+        reset(DEFAULT_VALUES);
+      }
+    }
+  }, [open, editingCategory, reset]);
+
+  async function onSubmit(data: FeeCategoryFormValues) {
+    const payload: CreateFeeCategory = {
+      name: data.name,
+      description: data.description || undefined,
+      amount: data.amount,
+      billingInterval: data.billingInterval ?? 'ANNUALLY',
+      isOneTime: data.isOneTime ?? false,
+      sortOrder: data.sortOrder ?? 0,
+    };
+
+    if (isEditing) {
+      await updateMutation.mutateAsync({
+        id: editingCategory.id,
+        data: payload,
+      });
+    } else {
+      await createMutation.mutateAsync(payload);
+    }
+    onOpenChange(false);
+  }
+
+  const isOneTime = watch('isOneTime');
+  const billingInterval = watch('billingInterval');
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg max-h-[85vh] flex flex-col">
+        <DialogHeader>
+          <DialogTitle>
+            {isEditing ? 'Beitragskategorie bearbeiten' : 'Beitragskategorie erstellen'}
+          </DialogTitle>
+          <DialogDescription>
+            {isEditing
+              ? 'Aendere die Konfiguration der Beitragskategorie.'
+              : 'Erstelle eine neue Beitragskategorie mit Betrag und Abrechnungszeitraum.'}
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col flex-1 min-h-0">
+          <div className="space-y-4 py-4 overflow-y-auto">
+            {/* Name */}
+            <div className="space-y-2">
+              <Label htmlFor="fc-name">Name</Label>
+              <Input
+                id="fc-name"
+                placeholder="z.B. Tennisabteilung"
+                maxLength={100}
+                autoFocus
+                {...register('name')}
+              />
+              {errors.name?.message && (
+                <p className="text-destructive text-sm">{errors.name.message}</p>
+              )}
+            </div>
+
+            {/* Beschreibung */}
+            <div className="space-y-2">
+              <Label htmlFor="fc-description">Beschreibung</Label>
+              <Textarea
+                id="fc-description"
+                placeholder="Optionale Beschreibung"
+                maxLength={500}
+                rows={2}
+                {...register('description')}
+              />
+              {errors.description?.message && (
+                <p className="text-destructive text-sm">{errors.description.message}</p>
+              )}
+            </div>
+
+            {/* Betrag (EUR) */}
+            <div className="space-y-2">
+              <Label htmlFor="fc-amount">Betrag (EUR)</Label>
+              <Input
+                id="fc-amount"
+                placeholder="z.B. 120.00"
+                inputMode="decimal"
+                {...register('amount')}
+              />
+              {errors.amount?.message && (
+                <p className="text-destructive text-sm">{errors.amount.message}</p>
+              )}
+            </div>
+
+            {/* Abrechnungszeitraum */}
+            <div className="space-y-2">
+              <Label htmlFor="fc-interval">Abrechnungszeitraum</Label>
+              <Select
+                value={billingInterval}
+                onValueChange={(val) =>
+                  setValue('billingInterval', val as FeeCategoryFormValues['billingInterval'])
+                }
+              >
+                <SelectTrigger id="fc-interval" className="w-full">
+                  <SelectValue placeholder="Zeitraum waehlen" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="MONTHLY">Monatlich</SelectItem>
+                  <SelectItem value="QUARTERLY">Quartalsweise</SelectItem>
+                  <SelectItem value="ANNUALLY">Jaehrlich</SelectItem>
+                </SelectContent>
+              </Select>
+              {errors.billingInterval?.message && (
+                <p className="text-destructive text-sm">{errors.billingInterval.message}</p>
+              )}
+            </div>
+
+            {/* Einmalige Gebuehr */}
+            <div className="flex items-center justify-between rounded-lg border p-4">
+              <div className="space-y-0.5">
+                <Label htmlFor="fc-isOneTime" className="text-sm font-medium">
+                  Einmalige Gebuehr (z.B. Aufnahmegebuehr)
+                </Label>
+              </div>
+              <Switch
+                id="fc-isOneTime"
+                checked={isOneTime}
+                onCheckedChange={(checked) => setValue('isOneTime', checked)}
+              />
+            </div>
+
+            {/* Sortierung */}
+            <div className="space-y-2">
+              <Label htmlFor="fc-sortOrder">Sortierung</Label>
+              <Input
+                id="fc-sortOrder"
+                type="number"
+                min={0}
+                {...register('sortOrder', { valueAsNumber: true })}
+              />
+              {errors.sortOrder?.message && (
+                <p className="text-destructive text-sm">{errors.sortOrder.message}</p>
+              )}
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isPending}
+            >
+              Abbrechen
+            </Button>
+            <Button type="submit" disabled={isPending}>
+              {isPending && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+              {isEditing ? 'Speichern' : 'Erstellen'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/components/fees/fee-category-form.tsx
+++ b/apps/web/components/fees/fee-category-form.tsx
@@ -189,12 +189,12 @@ export function FeeCategoryForm({ open, onOpenChange, editingCategory }: FeeCate
                 }
               >
                 <SelectTrigger id="fc-interval" className="w-full">
-                  <SelectValue placeholder="Zeitraum waehlen" />
+                  <SelectValue placeholder="Zeitraum wählen" />
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="MONTHLY">Monatlich</SelectItem>
-                  <SelectItem value="QUARTERLY">Quartalsweise</SelectItem>
-                  <SelectItem value="ANNUALLY">Jaehrlich</SelectItem>
+                  <SelectItem value="QUARTERLY">Vierteljährlich</SelectItem>
+                  <SelectItem value="ANNUALLY">Jährlich</SelectItem>
                 </SelectContent>
               </Select>
               {errors.billingInterval?.message && (

--- a/apps/web/components/fees/fee-category-form.tsx
+++ b/apps/web/components/fees/fee-category-form.tsx
@@ -103,6 +103,7 @@ export function FeeCategoryForm({ open, onOpenChange, editingCategory }: FeeCate
       billingInterval: data.billingInterval ?? 'ANNUALLY',
       isOneTime: data.isOneTime ?? false,
       sortOrder: data.sortOrder ?? 0,
+      scope: 'ALL_MEMBERS',
     };
 
     if (isEditing) {
@@ -116,6 +117,8 @@ export function FeeCategoryForm({ open, onOpenChange, editingCategory }: FeeCate
     onOpenChange(false);
   }
 
+  const name = watch('name');
+  const amount = watch('amount');
   const isOneTime = watch('isOneTime');
   const billingInterval = watch('billingInterval');
 
@@ -240,7 +243,7 @@ export function FeeCategoryForm({ open, onOpenChange, editingCategory }: FeeCate
             >
               Abbrechen
             </Button>
-            <Button type="submit" disabled={isPending}>
+            <Button type="submit" disabled={isPending || !name || !amount}>
               {isPending && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
               {isEditing ? 'Speichern' : 'Erstellen'}
             </Button>

--- a/apps/web/components/fees/fee-category-form.tsx
+++ b/apps/web/components/fees/fee-category-form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -9,8 +9,10 @@ import {
   CreateFeeCategorySchema,
   type CreateFeeCategory,
   type FeeCategoryResponse,
+  type FeeCategoryScope,
 } from '@ktb/shared';
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import {
   Dialog,
   DialogContent,
@@ -31,6 +33,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { useCreateFeeCategory, useUpdateFeeCategory } from '@/hooks/use-fee-categories';
+import { useMembershipTypes } from '@/hooks/use-membership-types';
 
 /**
  * Form values type uses the schema _input for zodResolver compatibility.
@@ -44,6 +47,8 @@ const DEFAULT_VALUES: FeeCategoryFormValues = {
   billingInterval: 'ANNUALLY',
   isOneTime: false,
   sortOrder: 0,
+  scope: 'ALL_MEMBERS',
+  membershipTypeIds: [],
 };
 
 interface FeeCategoryFormProps {
@@ -65,6 +70,11 @@ export function FeeCategoryForm({ open, onOpenChange, editingCategory }: FeeCate
   const updateMutation = useUpdateFeeCategory(slug);
   const isPending = createMutation.isPending || updateMutation.isPending;
 
+  const { data: membershipTypes } = useMembershipTypes(slug);
+
+  // Track selected membership type IDs for BY_MEMBERSHIP_TYPE scope
+  const [selectedMembershipTypeIds, setSelectedMembershipTypeIds] = useState<string[]>([]);
+
   const {
     register,
     handleSubmit,
@@ -81,6 +91,8 @@ export function FeeCategoryForm({ open, onOpenChange, editingCategory }: FeeCate
   useEffect(() => {
     if (open) {
       if (editingCategory) {
+        const existingMtIds =
+          editingCategory.membershipTypes?.map((mt) => mt.membershipTypeId) ?? [];
         reset({
           name: editingCategory.name,
           description: editingCategory.description ?? '',
@@ -88,14 +100,19 @@ export function FeeCategoryForm({ open, onOpenChange, editingCategory }: FeeCate
           billingInterval: editingCategory.billingInterval,
           isOneTime: editingCategory.isOneTime,
           sortOrder: editingCategory.sortOrder,
+          scope: editingCategory.scope,
+          membershipTypeIds: existingMtIds,
         });
+        setSelectedMembershipTypeIds(existingMtIds);
       } else {
         reset(DEFAULT_VALUES);
+        setSelectedMembershipTypeIds([]);
       }
     }
   }, [open, editingCategory, reset]);
 
   async function onSubmit(data: FeeCategoryFormValues) {
+    const scope = (data.scope ?? 'ALL_MEMBERS') as FeeCategoryScope;
     const payload: CreateFeeCategory = {
       name: data.name,
       description: data.description || undefined,
@@ -103,7 +120,8 @@ export function FeeCategoryForm({ open, onOpenChange, editingCategory }: FeeCate
       billingInterval: data.billingInterval ?? 'ANNUALLY',
       isOneTime: data.isOneTime ?? false,
       sortOrder: data.sortOrder ?? 0,
-      scope: 'ALL_MEMBERS',
+      scope,
+      membershipTypeIds: scope === 'BY_MEMBERSHIP_TYPE' ? selectedMembershipTypeIds : undefined,
     };
 
     if (isEditing) {
@@ -121,6 +139,13 @@ export function FeeCategoryForm({ open, onOpenChange, editingCategory }: FeeCate
   const amount = watch('amount');
   const isOneTime = watch('isOneTime');
   const billingInterval = watch('billingInterval');
+  const watchedScope = watch('scope') as FeeCategoryScope | undefined;
+
+  function handleMembershipTypeToggle(mtId: string, checked: boolean) {
+    setSelectedMembershipTypeIds((prev) =>
+      checked ? [...prev, mtId] : prev.filter((id) => id !== mtId)
+    );
+  }
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -232,6 +257,58 @@ export function FeeCategoryForm({ open, onOpenChange, editingCategory }: FeeCate
                 <p className="text-destructive text-sm">{errors.sortOrder.message}</p>
               )}
             </div>
+
+            {/* Zuordnung (Scope) */}
+            <div className="space-y-2">
+              <Label htmlFor="fc-scope">Zuordnung</Label>
+              <Select
+                value={watchedScope ?? 'ALL_MEMBERS'}
+                onValueChange={(val) => setValue('scope', val as FeeCategoryScope)}
+              >
+                <SelectTrigger id="fc-scope" className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="ALL_MEMBERS">Alle Mitglieder</SelectItem>
+                  <SelectItem value="BY_MEMBERSHIP_TYPE">Nach Mitgliedsart</SelectItem>
+                  <SelectItem value="INDIVIDUAL">Individuell</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            {/* Conditional MembershipType checkboxes */}
+            {watchedScope === 'BY_MEMBERSHIP_TYPE' && (
+              <div className="space-y-2">
+                <Label>Mitgliedsarten</Label>
+                {membershipTypes && membershipTypes.length > 0 ? (
+                  <div className="space-y-2">
+                    {membershipTypes.map((mt) => (
+                      <div key={mt.id} className="flex items-center space-x-2">
+                        <Checkbox
+                          id={`mt-${mt.id}`}
+                          checked={selectedMembershipTypeIds.includes(mt.id)}
+                          onCheckedChange={(checked) =>
+                            handleMembershipTypeToggle(mt.id, !!checked)
+                          }
+                        />
+                        <Label htmlFor={`mt-${mt.id}`} className="font-normal">
+                          {mt.name}
+                        </Label>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-sm text-muted-foreground">Keine Mitgliedsarten vorhanden.</p>
+                )}
+                {selectedMembershipTypeIds.length === 0 &&
+                  membershipTypes &&
+                  membershipTypes.length > 0 && (
+                    <p className="text-sm text-destructive">
+                      Wähle mindestens eine Mitgliedsart aus.
+                    </p>
+                  )}
+              </div>
+            )}
           </div>
 
           <DialogFooter>

--- a/apps/web/components/fees/fee-category-list.tsx
+++ b/apps/web/components/fees/fee-category-list.tsx
@@ -1,9 +1,224 @@
 'use client';
 
+import { useState } from 'react';
+import { useParams } from 'next/navigation';
+import { Pencil, Plus, Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardDescription, CardHeader } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Skeleton } from '@/components/ui/skeleton';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+import { useFeeCategories, useDeleteFeeCategory } from '@/hooks/use-fee-categories';
+import { FeeCategoryForm } from './fee-category-form';
+import type { FeeCategoryResponse } from '@ktb/shared';
+
+const INTERVAL_LABELS: Record<string, string> = {
+  MONTHLY: 'Monatlich',
+  QUARTERLY: 'Quartalsweise',
+  ANNUALLY: 'Jaehrlich',
+};
+
+function formatAmount(amount: string): string {
+  return (
+    new Intl.NumberFormat('de-DE', {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(parseFloat(amount)) + ' EUR'
+  );
+}
+
 /**
- * Fee category list component - placeholder.
- * Full implementation in Task 2.
+ * Fee category list with CRUD actions.
+ * Displays a table of fee categories with create, edit, and delete functionality.
  */
 export function FeeCategoryList() {
-  return <div>Loading fee categories...</div>;
+  const params = useParams<{ slug: string }>();
+  const slug = params.slug;
+
+  const { data: categories, isLoading } = useFeeCategories(slug);
+  const deleteMutation = useDeleteFeeCategory(slug);
+
+  // Dialog state
+  const [formOpen, setFormOpen] = useState(false);
+  const [editingCategory, setEditingCategory] = useState<FeeCategoryResponse | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<FeeCategoryResponse | null>(null);
+
+  function openCreate() {
+    setEditingCategory(null);
+    setFormOpen(true);
+  }
+
+  function openEdit(category: FeeCategoryResponse) {
+    setEditingCategory(category);
+    setFormOpen(true);
+  }
+
+  async function handleDelete() {
+    if (!deleteTarget) return;
+    await deleteMutation.mutateAsync(deleteTarget.id);
+    setDeleteTarget(null);
+  }
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-5 w-48" />
+          <Skeleton className="h-4 w-96 mt-2" />
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-3">
+            {[...Array(3)].map((_, i) => (
+              <div key={i} className="flex items-center gap-4 py-2">
+                <Skeleton className="h-4 w-32" />
+                <Skeleton className="h-4 w-48 hidden lg:block" />
+                <Skeleton className="h-4 w-20" />
+                <Skeleton className="h-4 w-24" />
+                <Skeleton className="h-5 w-12 rounded-md" />
+                <Skeleton className="h-5 w-12 rounded-md" />
+                <Skeleton className="h-8 w-16" />
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const items = categories ?? [];
+  const isEmpty = items.length === 0;
+
+  return (
+    <>
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div>
+              <CardDescription>
+                Zusaetzliche Beitragspositionen neben dem Grundbeitrag der Mitgliedsart
+              </CardDescription>
+            </div>
+            {!isEmpty && (
+              <Button onClick={openCreate}>
+                <Plus className="h-4 w-4 mr-2" />
+                Kategorie erstellen
+              </Button>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent className="p-6">
+          {isEmpty ? (
+            <div className="flex flex-col items-center justify-center py-12 text-center">
+              <h3 className="text-lg font-semibold mb-2">Noch keine Beitragskategorien</h3>
+              <p className="text-muted-foreground max-w-md mb-6">
+                Erstelle Beitragskategorien fuer zusaetzliche Positionen neben dem Grundbeitrag der
+                Mitgliedsart.
+              </p>
+              <Button onClick={openCreate}>
+                <Plus className="h-4 w-4 mr-2" />
+                Erste Kategorie erstellen
+              </Button>
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead className="hidden lg:table-cell">Beschreibung</TableHead>
+                  <TableHead className="text-right">Betrag</TableHead>
+                  <TableHead>Rhythmus</TableHead>
+                  <TableHead>Einmalig</TableHead>
+                  <TableHead>Aktiv</TableHead>
+                  <TableHead className="w-24">Aktionen</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {items.map((category) => (
+                  <TableRow key={category.id}>
+                    <TableCell className="font-medium">{category.name}</TableCell>
+                    <TableCell className="hidden lg:table-cell text-muted-foreground">
+                      {category.description || '—'}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {formatAmount(category.amount)}
+                    </TableCell>
+                    <TableCell>
+                      {category.isOneTime
+                        ? 'Einmalig'
+                        : (INTERVAL_LABELS[category.billingInterval] ?? category.billingInterval)}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={category.isOneTime ? 'default' : 'secondary'}>
+                        {category.isOneTime ? 'Ja' : 'Nein'}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <Badge
+                        className={
+                          category.isActive
+                            ? 'bg-success/15 text-success border-success/25'
+                            : 'bg-muted text-muted-foreground'
+                        }
+                      >
+                        {category.isActive ? 'Aktiv' : 'Inaktiv'}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex items-center gap-1 justify-end">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => openEdit(category)}
+                          aria-label={`${category.name} bearbeiten`}
+                        >
+                          <Pencil className="h-4 w-4" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => setDeleteTarget(category)}
+                          aria-label={`${category.name} loeschen`}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Create/Edit Dialog */}
+      <FeeCategoryForm
+        open={formOpen}
+        onOpenChange={setFormOpen}
+        editingCategory={editingCategory}
+      />
+
+      {/* Delete Confirmation */}
+      <ConfirmDialog
+        open={!!deleteTarget}
+        onOpenChange={(open) => !open && setDeleteTarget(null)}
+        title="Beitragskategorie loeschen"
+        description={`Moechtest du die Kategorie "${deleteTarget?.name}" wirklich loeschen? Bestehende Forderungen bleiben erhalten.`}
+        confirmLabel="Loeschen"
+        cancelLabel="Abbrechen"
+        variant="destructive"
+        onConfirm={handleDelete}
+        loading={deleteMutation.isPending}
+      />
+    </>
+  );
 }

--- a/apps/web/components/fees/fee-category-list.tsx
+++ b/apps/web/components/fees/fee-category-list.tsx
@@ -26,14 +26,7 @@ const INTERVAL_LABELS: Record<string, string> = {
   ANNUALLY: 'Jährlich',
 };
 
-function formatAmount(amount: string): string {
-  return (
-    new Intl.NumberFormat('de-DE', {
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    }).format(parseFloat(amount)) + ' EUR'
-  );
-}
+import { formatMoney } from '@/lib/format-money';
 
 /**
  * Fee category list with CRUD actions.
@@ -104,7 +97,7 @@ export function FeeCategoryList() {
           <div className="flex items-center justify-between">
             <div>
               <CardDescription>
-                Zusaetzliche Beitragspositionen neben dem Grundbeitrag der Mitgliedsart
+                Zusätzliche Beitragspositionen neben dem Grundbeitrag der Mitgliedsart
               </CardDescription>
             </div>
             {!isEmpty && (
@@ -149,7 +142,7 @@ export function FeeCategoryList() {
                       {category.description || '—'}
                     </TableCell>
                     <TableCell className="text-right tabular-nums">
-                      {formatAmount(category.amount)}
+                      {formatMoney(category.amount)}
                     </TableCell>
                     <TableCell>
                       {category.isOneTime

--- a/apps/web/components/fees/fee-category-list.tsx
+++ b/apps/web/components/fees/fee-category-list.tsx
@@ -22,8 +22,8 @@ import type { FeeCategoryResponse } from '@ktb/shared';
 
 const INTERVAL_LABELS: Record<string, string> = {
   MONTHLY: 'Monatlich',
-  QUARTERLY: 'Quartalsweise',
-  ANNUALLY: 'Jaehrlich',
+  QUARTERLY: 'Vierteljährlich',
+  ANNUALLY: 'Jährlich',
 };
 
 function formatAmount(amount: string): string {
@@ -120,7 +120,7 @@ export function FeeCategoryList() {
             <div className="flex flex-col items-center justify-center py-12 text-center">
               <h3 className="text-lg font-semibold mb-2">Noch keine Beitragskategorien</h3>
               <p className="text-muted-foreground max-w-md mb-6">
-                Erstelle Beitragskategorien fuer zusaetzliche Positionen neben dem Grundbeitrag der
+                Erstelle Beitragskategorien für zusätzliche Positionen neben dem Grundbeitrag der
                 Mitgliedsart.
               </p>
               <Button onClick={openCreate}>
@@ -186,7 +186,7 @@ export function FeeCategoryList() {
                           variant="ghost"
                           size="icon"
                           onClick={() => setDeleteTarget(category)}
-                          aria-label={`${category.name} loeschen`}
+                          aria-label={`${category.name} löschen`}
                         >
                           <Trash2 className="h-4 w-4" />
                         </Button>
@@ -211,9 +211,9 @@ export function FeeCategoryList() {
       <ConfirmDialog
         open={!!deleteTarget}
         onOpenChange={(open) => !open && setDeleteTarget(null)}
-        title="Beitragskategorie loeschen"
-        description={`Moechtest du die Kategorie "${deleteTarget?.name}" wirklich loeschen? Bestehende Forderungen bleiben erhalten.`}
-        confirmLabel="Loeschen"
+        title="Beitragskategorie löschen"
+        description={`Möchtest du die Kategorie „${deleteTarget?.name}" wirklich löschen? Bestehende Forderungen bleiben erhalten.`}
+        confirmLabel="Löschen"
         cancelLabel="Abbrechen"
         variant="destructive"
         onConfirm={handleDelete}

--- a/apps/web/components/fees/fee-category-list.tsx
+++ b/apps/web/components/fees/fee-category-list.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+/**
+ * Fee category list component - placeholder.
+ * Full implementation in Task 2.
+ */
+export function FeeCategoryList() {
+  return <div>Loading fee categories...</div>;
+}

--- a/apps/web/components/fees/fee-category-list.tsx
+++ b/apps/web/components/fees/fee-category-list.tsx
@@ -26,6 +26,12 @@ const INTERVAL_LABELS: Record<string, string> = {
   ANNUALLY: 'Jährlich',
 };
 
+const SCOPE_LABELS: Record<string, string> = {
+  ALL_MEMBERS: 'Alle',
+  BY_MEMBERSHIP_TYPE: 'Nach Mitgliedsart',
+  INDIVIDUAL: 'Individuell',
+};
+
 import { formatMoney } from '@/lib/format-money';
 
 /**
@@ -129,6 +135,7 @@ export function FeeCategoryList() {
                   <TableHead className="hidden lg:table-cell">Beschreibung</TableHead>
                   <TableHead className="text-right">Betrag</TableHead>
                   <TableHead>Rhythmus</TableHead>
+                  <TableHead>Zuordnung</TableHead>
                   <TableHead>Einmalig</TableHead>
                   <TableHead>Aktiv</TableHead>
                   <TableHead className="w-24">Aktionen</TableHead>
@@ -148,6 +155,11 @@ export function FeeCategoryList() {
                       {category.isOneTime
                         ? 'Einmalig'
                         : (INTERVAL_LABELS[category.billingInterval] ?? category.billingInterval)}
+                    </TableCell>
+                    <TableCell>
+                      <span className="text-xs text-muted-foreground">
+                        {SCOPE_LABELS[category.scope] ?? category.scope}
+                      </span>
                     </TableCell>
                     <TableCell>
                       <Badge variant={category.isOneTime ? 'default' : 'secondary'}>

--- a/apps/web/components/fees/fee-category-list.tsx
+++ b/apps/web/components/fees/fee-category-list.tsx
@@ -18,6 +18,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { useFeeCategories, useDeleteFeeCategory } from '@/hooks/use-fee-categories';
 import { FeeCategoryForm } from './fee-category-form';
+import { ExpandableDescription } from './expandable-description';
 import type { FeeCategoryResponse } from '@ktb/shared';
 
 const INTERVAL_LABELS: Record<string, string> = {
@@ -145,8 +146,12 @@ export function FeeCategoryList() {
                 {items.map((category) => (
                   <TableRow key={category.id}>
                     <TableCell className="font-medium">{category.name}</TableCell>
-                    <TableCell className="hidden lg:table-cell text-muted-foreground">
-                      {category.description || '—'}
+                    <TableCell className="hidden lg:table-cell">
+                      {category.description ? (
+                        <ExpandableDescription>{category.description}</ExpandableDescription>
+                      ) : (
+                        <span className="text-muted-foreground">—</span>
+                      )}
                     </TableCell>
                     <TableCell className="text-right tabular-nums">
                       {formatMoney(category.amount)}

--- a/apps/web/components/fees/fee-charge-list.tsx
+++ b/apps/web/components/fees/fee-charge-list.tsx
@@ -1,0 +1,432 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import { CreditCard, X, ChevronLeft, ChevronRight } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Skeleton } from '@/components/ui/skeleton';
+import { FeeChargeStatusBadge } from '@/components/fees/fee-charge-status-badge';
+import { PaymentRecordDialog } from '@/components/fees/payment-record-dialog';
+import { useFeeCharges, type FeeChargeFilters } from '@/hooks/use-fee-charges';
+import { useDebounce } from '@/hooks/use-debounce';
+import { cn } from '@/lib/utils';
+import type { FeeChargeResponse } from '@ktb/shared';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface FeeChargeListProps {
+  slug: string;
+  /** Pre-filter by member ID (from member detail navigation) */
+  memberId?: string;
+  /** Member name for the pre-filter banner */
+  memberName?: string;
+  /** Callback to switch to the Erhebung tab */
+  onSwitchToErhebung?: () => void;
+}
+
+type StatusFilter = 'ALL' | 'OPEN' | 'PARTIAL' | 'PAID' | 'OVERDUE';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const moneyFormatter = new Intl.NumberFormat('de-DE', {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+function formatMoney(value: string): string {
+  return `${moneyFormatter.format(parseFloat(value))} EUR`;
+}
+
+function formatPeriod(start: string, end: string): string {
+  const startDate = new Date(start);
+  const endDate = new Date(end);
+  const formatDay = (d: Date) =>
+    `${String(d.getDate()).padStart(2, '0')}.${String(d.getMonth() + 1).padStart(2, '0')}.`;
+  return `${formatDay(startDate)}-${formatDay(endDate)}`;
+}
+
+const PAGE_SIZE = 20;
+
+// ============================================================================
+// Component
+// ============================================================================
+
+/**
+ * Filterable table of fee charges with status badges and payment recording.
+ */
+export function FeeChargeList({
+  slug,
+  memberId: initialMemberId,
+  memberName,
+  onSwitchToErhebung,
+}: FeeChargeListProps) {
+  // Filter state
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('ALL');
+  const [memberSearch, setMemberSearch] = useState('');
+  const [periodFilter, setPeriodFilter] = useState('');
+  const [memberId, setMemberId] = useState(initialMemberId);
+  const [page, setPage] = useState(1);
+
+  // Payment dialog state
+  const [selectedCharge, setSelectedCharge] = useState<FeeChargeResponse | null>(null);
+
+  const debouncedMemberSearch = useDebounce(memberSearch, 300);
+
+  // Build filter object
+  const filters = useMemo<FeeChargeFilters>(() => {
+    const f: FeeChargeFilters = {
+      page,
+      limit: PAGE_SIZE,
+    };
+    if (statusFilter !== 'ALL' && statusFilter !== 'OVERDUE') {
+      f.status = statusFilter;
+    }
+    if (memberId) {
+      f.memberId = memberId;
+    }
+    if (periodFilter) {
+      f.periodStart = `${periodFilter}-01-01`;
+      f.periodEnd = `${periodFilter}-12-31`;
+    }
+    return f;
+  }, [statusFilter, memberId, periodFilter, page]);
+
+  const { data, isLoading } = useFeeCharges(slug, filters);
+
+  // Compute filtered data for OVERDUE client-side filter
+  const charges = useMemo(() => {
+    if (!data?.data) return [];
+    if (statusFilter === 'OVERDUE') {
+      return data.data.filter((c) => c.isOverdue);
+    }
+    // Client-side member name search (API filters by memberId; this filters by name text)
+    if (debouncedMemberSearch && !memberId) {
+      const search = debouncedMemberSearch.toLowerCase();
+      return data.data.filter(
+        (c) =>
+          c.member.firstName.toLowerCase().includes(search) ||
+          c.member.lastName.toLowerCase().includes(search) ||
+          c.member.memberNumber.toLowerCase().includes(search)
+      );
+    }
+    return data.data;
+  }, [data?.data, statusFilter, debouncedMemberSearch, memberId]);
+
+  // Summary calculations
+  const summary = useMemo(() => {
+    if (!data?.data) return { total: 0, openAmount: '0', paidAmount: '0' };
+    const total = data.total ?? data.data.length;
+    let openSum = 0;
+    let paidSum = 0;
+    for (const charge of data.data) {
+      if (charge.status !== 'PAID') {
+        openSum += parseFloat(charge.remainingAmount);
+      }
+      paidSum += parseFloat(charge.paidAmount);
+    }
+    return {
+      total,
+      openAmount: moneyFormatter.format(openSum),
+      paidAmount: moneyFormatter.format(paidSum),
+    };
+  }, [data]);
+
+  const hasActiveFilters = statusFilter !== 'ALL' || memberSearch || periodFilter || memberId;
+
+  function resetFilters() {
+    setStatusFilter('ALL');
+    setMemberSearch('');
+    setPeriodFilter('');
+    setMemberId(undefined);
+    setPage(1);
+  }
+
+  function clearMemberFilter() {
+    setMemberId(undefined);
+  }
+
+  // ---- Render ----
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <div className="flex gap-4">
+          <Skeleton className="h-9 w-32" />
+          <Skeleton className="h-9 w-48" />
+          <Skeleton className="h-9 w-28" />
+        </div>
+        <Skeleton className="h-5 w-96" />
+        <div className="space-y-2">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Skeleton key={i} className="h-12 w-full" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  // Empty state: No charges at all
+  if (!isLoading && !hasActiveFilters && charges.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 text-center">
+        <CreditCard className="h-12 w-12 text-muted-foreground mb-4" />
+        <h3 className="text-lg font-semibold">Noch keine Forderungen</h3>
+        <p className="text-sm text-muted-foreground mt-2 max-w-md">
+          Fuehre eine Beitragserhebung durch, um Forderungen fuer deine Mitglieder zu erstellen.
+        </p>
+        {onSwitchToErhebung && (
+          <Button className="mt-4" onClick={onSwitchToErhebung}>
+            Zur Erhebung
+          </Button>
+        )}
+      </div>
+    );
+  }
+
+  // Empty state: No filter results
+  if (!isLoading && hasActiveFilters && charges.length === 0) {
+    return (
+      <div className="space-y-4">
+        <FilterBar
+          statusFilter={statusFilter}
+          onStatusChange={setStatusFilter}
+          memberSearch={memberSearch}
+          onMemberSearchChange={setMemberSearch}
+          periodFilter={periodFilter}
+          onPeriodChange={setPeriodFilter}
+        />
+        {memberId && memberName && (
+          <MemberFilterBanner name={memberName} onClear={clearMemberFilter} />
+        )}
+        <div className="flex flex-col items-center justify-center py-12 text-center">
+          <h3 className="text-lg font-semibold">Keine Forderungen gefunden</h3>
+          <p className="text-sm text-muted-foreground mt-2">Deine Filter ergaben keine Treffer.</p>
+          <Button variant="outline" className="mt-4" onClick={resetFilters}>
+            Filter zuruecksetzen
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Filter bar */}
+      <FilterBar
+        statusFilter={statusFilter}
+        onStatusChange={setStatusFilter}
+        memberSearch={memberSearch}
+        onMemberSearchChange={setMemberSearch}
+        periodFilter={periodFilter}
+        onPeriodChange={setPeriodFilter}
+      />
+
+      {/* Member pre-filter banner */}
+      {memberId && memberName && (
+        <MemberFilterBanner name={memberName} onClear={clearMemberFilter} />
+      )}
+
+      {/* Summary row */}
+      <p className="text-sm text-muted-foreground">
+        Gesamt: {summary.total} Forderungen | Offen: {summary.openAmount} EUR | Bezahlt:{' '}
+        {summary.paidAmount} EUR
+      </p>
+
+      {/* Charges table */}
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Mitglied</TableHead>
+            <TableHead>Beschreibung</TableHead>
+            <TableHead className="hidden lg:table-cell">Zeitraum</TableHead>
+            <TableHead className="text-right tabular-nums">Betrag</TableHead>
+            <TableHead className="text-right tabular-nums">Bezahlt</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead className="w-10">Aktionen</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {charges.map((charge) => (
+            <TableRow
+              key={charge.id}
+              className={cn(charge.isOverdue && 'border-l-4 border-destructive')}
+            >
+              <TableCell>
+                <div>
+                  <span className="font-medium">
+                    {charge.member.lastName}, {charge.member.firstName}
+                  </span>
+                  <span className="ml-2 text-xs text-muted-foreground">
+                    {charge.member.memberNumber}
+                  </span>
+                </div>
+              </TableCell>
+              <TableCell>{charge.description}</TableCell>
+              <TableCell className="hidden lg:table-cell">
+                {formatPeriod(charge.periodStart, charge.periodEnd)}
+              </TableCell>
+              <TableCell className="text-right tabular-nums">
+                {formatMoney(charge.amount)}
+              </TableCell>
+              <TableCell className="text-right tabular-nums">
+                {formatMoney(charge.paidAmount)}
+              </TableCell>
+              <TableCell>
+                <FeeChargeStatusBadge status={charge.status} isOverdue={charge.isOverdue} />
+              </TableCell>
+              <TableCell>
+                <Button
+                  variant="ghost"
+                  size="icon-xs"
+                  onClick={() => setSelectedCharge(charge)}
+                  aria-label="Zahlung erfassen"
+                >
+                  <CreditCard className="h-4 w-4" />
+                </Button>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+
+      {/* Pagination */}
+      {data && data.total > PAGE_SIZE && (
+        <div className="flex items-center justify-end gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            disabled={page <= 1}
+          >
+            <ChevronLeft className="h-4 w-4" />
+            Zurueck
+          </Button>
+          <span className="text-sm text-muted-foreground tabular-nums">Seite {page}</span>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setPage((p) => p + 1)}
+            disabled={page * PAGE_SIZE >= data.total}
+          >
+            Weiter
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+        </div>
+      )}
+
+      {/* Payment recording dialog */}
+      {selectedCharge && (
+        <PaymentRecordDialog
+          charge={selectedCharge}
+          open={!!selectedCharge}
+          onOpenChange={(open) => {
+            if (!open) setSelectedCharge(null);
+          }}
+          slug={slug}
+        />
+      )}
+    </div>
+  );
+}
+
+// ============================================================================
+// Sub-components
+// ============================================================================
+
+interface FilterBarProps {
+  statusFilter: StatusFilter;
+  onStatusChange: (value: StatusFilter) => void;
+  memberSearch: string;
+  onMemberSearchChange: (value: string) => void;
+  periodFilter: string;
+  onPeriodChange: (value: string) => void;
+}
+
+function FilterBar({
+  statusFilter,
+  onStatusChange,
+  memberSearch,
+  onMemberSearchChange,
+  periodFilter,
+  onPeriodChange,
+}: FilterBarProps) {
+  return (
+    <div className="flex flex-wrap items-end gap-4">
+      <div className="space-y-2">
+        <Label htmlFor="statusFilter">Status</Label>
+        <Select value={statusFilter} onValueChange={(v) => onStatusChange(v as StatusFilter)}>
+          <SelectTrigger id="statusFilter" className="w-44">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="ALL">Alle</SelectItem>
+            <SelectItem value="OPEN">Offen</SelectItem>
+            <SelectItem value="PARTIAL">Teilweise bezahlt</SelectItem>
+            <SelectItem value="PAID">Bezahlt</SelectItem>
+            <SelectItem value="OVERDUE">Ueberfaellig</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="memberSearch">Mitglied</Label>
+        <Input
+          id="memberSearch"
+          placeholder="Suchen..."
+          value={memberSearch}
+          onChange={(e) => onMemberSearchChange(e.target.value)}
+          className="w-48"
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="periodFilter">Periode</Label>
+        <Input
+          id="periodFilter"
+          type="number"
+          placeholder="z.B. 2026"
+          value={periodFilter}
+          onChange={(e) => onPeriodChange(e.target.value)}
+          className="w-28"
+          min={2000}
+          max={2100}
+        />
+      </div>
+    </div>
+  );
+}
+
+interface MemberFilterBannerProps {
+  name: string;
+  onClear: () => void;
+}
+
+function MemberFilterBanner({ name, onClear }: MemberFilterBannerProps) {
+  return (
+    <div className="flex items-center gap-2 rounded-md border bg-muted px-3 py-2 text-sm">
+      <span>Gefiltert nach: {name}</span>
+      <Button variant="ghost" size="icon-xs" onClick={onClear} aria-label="Filter entfernen">
+        <X className="h-3 w-3" />
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/components/fees/fee-charge-list.tsx
+++ b/apps/web/components/fees/fee-charge-list.tsx
@@ -91,7 +91,7 @@ export function FeeChargeList({
       page,
       limit: PAGE_SIZE,
     };
-    if (statusFilter !== 'ALL' && statusFilter !== 'OVERDUE') {
+    if (statusFilter !== 'ALL') {
       f.status = statusFilter;
     }
     if (memberId) {
@@ -109,9 +109,6 @@ export function FeeChargeList({
   // Compute filtered data for OVERDUE client-side filter
   const charges = useMemo(() => {
     if (!data?.data) return [];
-    if (statusFilter === 'OVERDUE') {
-      return data.data.filter((c) => c.isOverdue);
-    }
     // Client-side member name search (API filters by memberId; this filters by name text)
     if (debouncedMemberSearch && !memberId) {
       const search = debouncedMemberSearch.toLowerCase();
@@ -216,7 +213,7 @@ export function FeeChargeList({
           <h3 className="text-lg font-semibold">Keine Forderungen gefunden</h3>
           <p className="text-sm text-muted-foreground mt-2">Deine Filter ergaben keine Treffer.</p>
           <Button variant="outline" className="mt-4" onClick={resetFilters}>
-            Filter zuruecksetzen
+            Filter zurücksetzen
           </Button>
         </div>
       </div>
@@ -313,7 +310,7 @@ export function FeeChargeList({
             disabled={page <= 1}
           >
             <ChevronLeft className="h-4 w-4" />
-            Zurueck
+            Zurück
           </Button>
           <span className="text-sm text-muted-foreground tabular-nums">Seite {page}</span>
           <Button

--- a/apps/web/components/fees/fee-charge-list.tsx
+++ b/apps/web/components/fees/fee-charge-list.tsx
@@ -186,7 +186,7 @@ export function FeeChargeList({
         <CreditCard className="h-12 w-12 text-muted-foreground mb-4" />
         <h3 className="text-lg font-semibold">Noch keine Forderungen</h3>
         <p className="text-sm text-muted-foreground mt-2 max-w-md">
-          Fuehre eine Beitragserhebung durch, um Forderungen fuer deine Mitglieder zu erstellen.
+          Führe eine Beitragserhebung durch, um Forderungen für deine Mitglieder zu erstellen.
         </p>
         {onSwitchToErhebung && (
           <Button className="mt-4" onClick={onSwitchToErhebung}>
@@ -377,7 +377,7 @@ function FilterBar({
             <SelectItem value="OPEN">Offen</SelectItem>
             <SelectItem value="PARTIAL">Teilweise bezahlt</SelectItem>
             <SelectItem value="PAID">Bezahlt</SelectItem>
-            <SelectItem value="OVERDUE">Ueberfaellig</SelectItem>
+            <SelectItem value="OVERDUE">Überfällig</SelectItem>
           </SelectContent>
         </Select>
       </div>

--- a/apps/web/components/fees/fee-charge-list.tsx
+++ b/apps/web/components/fees/fee-charge-list.tsx
@@ -48,14 +48,7 @@ type StatusFilter = 'ALL' | 'OPEN' | 'PARTIAL' | 'PAID' | 'OVERDUE';
 // Helpers
 // ============================================================================
 
-const moneyFormatter = new Intl.NumberFormat('de-DE', {
-  minimumFractionDigits: 2,
-  maximumFractionDigits: 2,
-});
-
-function formatMoney(value: string): string {
-  return `${moneyFormatter.format(parseFloat(value))} EUR`;
-}
+import { moneyFormatter, formatMoney } from '@/lib/format-money';
 
 function formatPeriod(start: string, end: string): string {
   const startDate = new Date(start);

--- a/apps/web/components/fees/fee-charge-list.tsx
+++ b/apps/web/components/fees/fee-charge-list.tsx
@@ -21,6 +21,7 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { Skeleton } from '@/components/ui/skeleton';
+import { ExpandableDescription } from '@/components/fees/expandable-description';
 import { FeeChargeStatusBadge } from '@/components/fees/fee-charge-status-badge';
 import { PaymentRecordDialog } from '@/components/fees/payment-record-dialog';
 import { useFeeCharges, type FeeChargeFilters } from '@/hooks/use-fee-charges';
@@ -272,7 +273,9 @@ export function FeeChargeList({
                   </span>
                 </div>
               </TableCell>
-              <TableCell>{charge.description}</TableCell>
+              <TableCell>
+                <ExpandableDescription>{charge.description}</ExpandableDescription>
+              </TableCell>
               <TableCell className="hidden lg:table-cell">
                 {formatPeriod(charge.periodStart, charge.periodEnd)}
               </TableCell>

--- a/apps/web/components/fees/fee-charge-status-badge.tsx
+++ b/apps/web/components/fees/fee-charge-status-badge.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+import type { FeeChargeStatus } from '@ktb/shared';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface FeeChargeStatusBadgeProps {
+  /** Charge payment status */
+  status: FeeChargeStatus;
+  /** Whether the charge is past due date and not fully paid */
+  isOverdue: boolean;
+  className?: string;
+}
+
+// ============================================================================
+// Status Configuration
+// ============================================================================
+
+const STATUS_CONFIG: Record<string, { label: string; className: string }> = {
+  OVERDUE: {
+    label: 'Ueberfaellig',
+    className: 'bg-destructive/15 text-destructive border-destructive/25',
+  },
+  OPEN: {
+    label: 'Offen',
+    className: 'bg-muted text-muted-foreground border-border',
+  },
+  PARTIAL: {
+    label: 'Teilweise bezahlt',
+    className: 'bg-warning/15 text-warning-foreground border-warning/25',
+  },
+  PAID: {
+    label: 'Bezahlt',
+    className: 'bg-success/15 text-success border-success/25',
+  },
+};
+
+// ============================================================================
+// Component
+// ============================================================================
+
+/**
+ * Badge displaying fee charge payment status with semantic colors.
+ *
+ * Status hierarchy:
+ * - OVERDUE takes precedence when isOverdue=true and status is OPEN or PARTIAL
+ * - PAID is always shown as PAID regardless of isOverdue
+ *
+ * Colors follow the UI-SPEC Fee Charge Status Colors table.
+ */
+export function FeeChargeStatusBadge({ status, isOverdue, className }: FeeChargeStatusBadgeProps) {
+  // Determine effective status: OVERDUE overrides OPEN/PARTIAL
+  const effectiveStatus = isOverdue && status !== 'PAID' ? 'OVERDUE' : status;
+
+  const config = STATUS_CONFIG[effectiveStatus] ?? STATUS_CONFIG.OPEN;
+
+  return (
+    <Badge variant="outline" className={cn(config.className, className)}>
+      {config.label}
+    </Badge>
+  );
+}

--- a/apps/web/components/fees/fee-charge-status-badge.tsx
+++ b/apps/web/components/fees/fee-charge-status-badge.tsx
@@ -22,7 +22,7 @@ interface FeeChargeStatusBadgeProps {
 
 const STATUS_CONFIG: Record<string, { label: string; className: string }> = {
   OVERDUE: {
-    label: 'Ueberfaellig',
+    label: 'Überfällig',
     className: 'bg-destructive/15 text-destructive border-destructive/25',
   },
   OPEN: {

--- a/apps/web/components/fees/fee-override-dialog.tsx
+++ b/apps/web/components/fees/fee-override-dialog.tsx
@@ -142,7 +142,7 @@ export function FeeOverrideDialog({
         <DialogContent className="max-w-lg max-h-[80vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle className="text-xl font-semibold">
-              Beitragsanpassungen fuer {memberName}
+              Beitragsanpassungen für {memberName}
             </DialogTitle>
             <DialogDescription>
               Befreiungen, individuelle Betraege und Zusatzbeitraege verwalten
@@ -302,7 +302,7 @@ export function FeeOverrideDialog({
           <AlertDialogHeader>
             <AlertDialogTitle>Anpassung entfernen</AlertDialogTitle>
             <AlertDialogDescription>
-              Moechtest du diese Beitragsanpassung wirklich entfernen?
+              Möchtest du diese Beitragsanpassung wirklich entfernen?
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/apps/web/components/fees/fee-override-dialog.tsx
+++ b/apps/web/components/fees/fee-override-dialog.tsx
@@ -145,7 +145,7 @@ export function FeeOverrideDialog({
               Beitragsanpassungen für {memberName}
             </DialogTitle>
             <DialogDescription>
-              Befreiungen, individuelle Betraege und Zusatzbeitraege verwalten
+              Befreiungen, individuelle Beträge und Zusatzbeiträge verwalten
             </DialogDescription>
           </DialogHeader>
 
@@ -262,7 +262,7 @@ export function FeeOverrideDialog({
                   <Label htmlFor="overrideReason">Grund</Label>
                   <Textarea
                     id="overrideReason"
-                    placeholder="z.B. Ehrenamtliche Taetigkeit"
+                    placeholder="z.B. Ehrenamtliche Tätigkeit"
                     value={formReason}
                     onChange={(e) => setFormReason(e.target.value)}
                     rows={2}
@@ -289,7 +289,7 @@ export function FeeOverrideDialog({
             {!showAddForm && !isLoading && (
               <Button variant="outline" size="sm" onClick={() => setShowAddForm(true)}>
                 <Plus className="h-4 w-4" />
-                Anpassung hinzufuegen
+                Anpassung hinzufügen
               </Button>
             )}
           </div>

--- a/apps/web/components/fees/fee-override-dialog.tsx
+++ b/apps/web/components/fees/fee-override-dialog.tsx
@@ -1,0 +1,337 @@
+'use client';
+
+import { useState } from 'react';
+import { Loader2, Plus, Trash2 } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  useFeeOverrides,
+  useCreateFeeOverride,
+  useDeleteFeeOverride,
+} from '@/hooks/use-fee-overrides';
+import { useFeeCategories } from '@/hooks/use-fee-categories';
+import type { FeeOverrideType, FeeOverrideResponse } from '@/hooks/use-fee-overrides';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface FeeOverrideDialogProps {
+  slug: string;
+  memberId: string;
+  memberName: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const moneyFormatter = new Intl.NumberFormat('de-DE', {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+const OVERRIDE_TYPE_OPTIONS: { value: FeeOverrideType; label: string }[] = [
+  { value: 'EXEMPT', label: 'Befreit' },
+  { value: 'CUSTOM_AMOUNT', label: 'Individueller Betrag' },
+  { value: 'ADDITIONAL', label: 'Zusatzbeitrag' },
+];
+
+const OVERRIDE_TYPE_LABELS: Record<string, string> = {
+  EXEMPT: 'Befreit',
+  CUSTOM_AMOUNT: 'Individueller Betrag',
+  ADDITIONAL: 'Zusatzbeitrag',
+};
+
+// ============================================================================
+// Component
+// ============================================================================
+
+/**
+ * Dialog for managing a member's fee overrides.
+ *
+ * Separates "modify existing fee" (EXEMPT, CUSTOM_AMOUNT on base fee or category)
+ * from "add new fee" (ADDITIONAL with category selection).
+ *
+ * Per CONV-010: Delete uses AlertDialog, not browser confirm().
+ */
+export function FeeOverrideDialog({
+  slug,
+  memberId,
+  memberName,
+  open,
+  onOpenChange,
+}: FeeOverrideDialogProps) {
+  const { data: overrides, isLoading } = useFeeOverrides(slug, memberId);
+  const { data: categories } = useFeeCategories(slug);
+  const createOverride = useCreateFeeOverride(slug);
+  const deleteOverride = useDeleteFeeOverride(slug);
+
+  // Form state for adding new override
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [formType, setFormType] = useState<FeeOverrideType>('EXEMPT');
+  const [formTarget, setFormTarget] = useState<string>('base');
+  const [formAmount, setFormAmount] = useState('');
+  const [formReason, setFormReason] = useState('');
+
+  // Delete confirmation state
+  const [deleteTarget, setDeleteTarget] = useState<FeeOverrideResponse | null>(null);
+
+  function resetForm() {
+    setShowAddForm(false);
+    setFormType('EXEMPT');
+    setFormTarget('base');
+    setFormAmount('');
+    setFormReason('');
+  }
+
+  async function handleCreate() {
+    const isBaseFee = formTarget === 'base';
+    const feeCategoryId = isBaseFee ? undefined : formTarget;
+
+    await createOverride.mutateAsync({
+      memberId,
+      overrideType: formType,
+      isBaseFee,
+      feeCategoryId,
+      customAmount: formType === 'CUSTOM_AMOUNT' || formType === 'ADDITIONAL' ? formAmount : undefined,
+      reason: formReason || undefined,
+    });
+
+    resetForm();
+  }
+
+  async function handleDelete() {
+    if (!deleteTarget) return;
+    await deleteOverride.mutateAsync(deleteTarget.id);
+    setDeleteTarget(null);
+  }
+
+  const showAmountField = formType === 'CUSTOM_AMOUNT' || formType === 'ADDITIONAL';
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="max-w-lg max-h-[80vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle className="text-xl font-semibold">
+              Beitragsanpassungen fuer {memberName}
+            </DialogTitle>
+            <DialogDescription>
+              Befreiungen, individuelle Betraege und Zusatzbeitraege verwalten
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4">
+            {/* Loading */}
+            {isLoading && (
+              <div className="flex items-center justify-center py-6">
+                <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+              </div>
+            )}
+
+            {/* Existing overrides list */}
+            {!isLoading && overrides && overrides.length === 0 && !showAddForm && (
+              <p className="text-sm text-muted-foreground">Keine Anpassungen vorhanden</p>
+            )}
+
+            {!isLoading && overrides && overrides.length > 0 && (
+              <div className="space-y-3">
+                {overrides.map((override) => (
+                  <div
+                    key={override.id}
+                    className="flex items-start justify-between gap-3 rounded-md border p-3"
+                  >
+                    <div className="space-y-1 min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <Badge variant="outline">
+                          {OVERRIDE_TYPE_LABELS[override.overrideType] ?? override.overrideType}
+                        </Badge>
+                        <span className="text-sm text-muted-foreground">
+                          {override.isBaseFee
+                            ? 'Grundbeitrag'
+                            : override.feeCategory?.name ?? 'Kategorie'}
+                        </span>
+                      </div>
+                      {override.customAmount && (
+                        <p className="text-sm tabular-nums">
+                          {moneyFormatter.format(parseFloat(override.customAmount))} EUR
+                        </p>
+                      )}
+                      {override.reason && (
+                        <p className="text-sm text-muted-foreground">{override.reason}</p>
+                      )}
+                    </div>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="shrink-0 h-8 w-8 text-destructive hover:text-destructive"
+                      onClick={() => setDeleteTarget(override)}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                      <span className="sr-only">Entfernen</span>
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {/* Add form */}
+            {showAddForm && (
+              <div className="space-y-4 rounded-md border p-4">
+                {/* Override type */}
+                <div className="space-y-2">
+                  <Label htmlFor="overrideType">Art der Anpassung</Label>
+                  <Select
+                    value={formType}
+                    onValueChange={(v) => setFormType(v as FeeOverrideType)}
+                  >
+                    <SelectTrigger id="overrideType" className="w-full">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {OVERRIDE_TYPE_OPTIONS.map((opt) => (
+                        <SelectItem key={opt.value} value={opt.value}>
+                          {opt.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                {/* Target */}
+                <div className="space-y-2">
+                  <Label htmlFor="overrideTarget">Betrifft</Label>
+                  <Select value={formTarget} onValueChange={setFormTarget}>
+                    <SelectTrigger id="overrideTarget" className="w-full">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="base">Grundbeitrag</SelectItem>
+                      {categories?.map((cat) => (
+                        <SelectItem key={cat.id} value={cat.id}>
+                          {cat.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                {/* Custom amount */}
+                {showAmountField && (
+                  <div className="space-y-2">
+                    <Label htmlFor="overrideAmount">Betrag (EUR)</Label>
+                    <Input
+                      id="overrideAmount"
+                      type="number"
+                      step="0.01"
+                      min="0"
+                      placeholder="0.00"
+                      value={formAmount}
+                      onChange={(e) => setFormAmount(e.target.value)}
+                    />
+                  </div>
+                )}
+
+                {/* Reason */}
+                <div className="space-y-2">
+                  <Label htmlFor="overrideReason">Grund</Label>
+                  <Textarea
+                    id="overrideReason"
+                    placeholder="z.B. Ehrenamtliche Taetigkeit"
+                    value={formReason}
+                    onChange={(e) => setFormReason(e.target.value)}
+                    rows={2}
+                  />
+                </div>
+
+                {/* Form actions */}
+                <div className="flex gap-2">
+                  <Button
+                    onClick={handleCreate}
+                    disabled={
+                      createOverride.isPending ||
+                      (showAmountField && !formAmount)
+                    }
+                  >
+                    {createOverride.isPending && (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    )}
+                    Speichern
+                  </Button>
+                  <Button variant="outline" onClick={resetForm}>
+                    Abbrechen
+                  </Button>
+                </div>
+              </div>
+            )}
+
+            {/* Add button */}
+            {!showAddForm && !isLoading && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setShowAddForm(true)}
+              >
+                <Plus className="h-4 w-4" />
+                Anpassung hinzufuegen
+              </Button>
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete confirmation - per CONV-010 */}
+      <AlertDialog open={!!deleteTarget} onOpenChange={(open) => !open && setDeleteTarget(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Anpassung entfernen</AlertDialogTitle>
+            <AlertDialogDescription>
+              Moechtest du diese Beitragsanpassung wirklich entfernen?
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Abbrechen</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              disabled={deleteOverride.isPending}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {deleteOverride.isPending && <Loader2 className="h-4 w-4 animate-spin" />}
+              Entfernen
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/apps/web/components/fees/fee-override-dialog.tsx
+++ b/apps/web/components/fees/fee-override-dialog.tsx
@@ -55,10 +55,7 @@ interface FeeOverrideDialogProps {
 // Helpers
 // ============================================================================
 
-const moneyFormatter = new Intl.NumberFormat('de-DE', {
-  minimumFractionDigits: 2,
-  maximumFractionDigits: 2,
-});
+import { moneyFormatter } from '@/lib/format-money';
 
 const OVERRIDE_TYPE_OPTIONS: { value: FeeOverrideType; label: string }[] = [
   { value: 'EXEMPT', label: 'Befreit' },

--- a/apps/web/components/fees/fee-override-dialog.tsx
+++ b/apps/web/components/fees/fee-override-dialog.tsx
@@ -123,7 +123,8 @@ export function FeeOverrideDialog({
       overrideType: formType,
       isBaseFee,
       feeCategoryId,
-      customAmount: formType === 'CUSTOM_AMOUNT' || formType === 'ADDITIONAL' ? formAmount : undefined,
+      customAmount:
+        formType === 'CUSTOM_AMOUNT' || formType === 'ADDITIONAL' ? formAmount : undefined,
       reason: formReason || undefined,
     });
 
@@ -179,7 +180,7 @@ export function FeeOverrideDialog({
                         <span className="text-sm text-muted-foreground">
                           {override.isBaseFee
                             ? 'Grundbeitrag'
-                            : override.feeCategory?.name ?? 'Kategorie'}
+                            : (override.feeCategory?.name ?? 'Kategorie')}
                         </span>
                       </div>
                       {override.customAmount && (
@@ -211,10 +212,7 @@ export function FeeOverrideDialog({
                 {/* Override type */}
                 <div className="space-y-2">
                   <Label htmlFor="overrideType">Art der Anpassung</Label>
-                  <Select
-                    value={formType}
-                    onValueChange={(v) => setFormType(v as FeeOverrideType)}
-                  >
+                  <Select value={formType} onValueChange={(v) => setFormType(v as FeeOverrideType)}>
                     <SelectTrigger id="overrideType" className="w-full">
                       <SelectValue />
                     </SelectTrigger>
@@ -278,14 +276,9 @@ export function FeeOverrideDialog({
                 <div className="flex gap-2">
                   <Button
                     onClick={handleCreate}
-                    disabled={
-                      createOverride.isPending ||
-                      (showAmountField && !formAmount)
-                    }
+                    disabled={createOverride.isPending || (showAmountField && !formAmount)}
                   >
-                    {createOverride.isPending && (
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                    )}
+                    {createOverride.isPending && <Loader2 className="h-4 w-4 animate-spin" />}
                     Speichern
                   </Button>
                   <Button variant="outline" onClick={resetForm}>
@@ -297,11 +290,7 @@ export function FeeOverrideDialog({
 
             {/* Add button */}
             {!showAddForm && !isLoading && (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => setShowAddForm(true)}
-              >
+              <Button variant="outline" size="sm" onClick={() => setShowAddForm(true)}>
                 <Plus className="h-4 w-4" />
                 Anpassung hinzufuegen
               </Button>

--- a/apps/web/components/fees/fee-type-form.tsx
+++ b/apps/web/components/fees/fee-type-form.tsx
@@ -1,0 +1,181 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useParams } from 'next/navigation';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Loader2 } from 'lucide-react';
+import { CreateFeeTypeSchema, type CreateFeeType, type FeeTypeResponse } from '@ktb/shared';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Switch } from '@/components/ui/switch';
+import { useCreateFeeType, useUpdateFeeType } from '@/hooks/use-fee-types';
+
+type FeeTypeFormValues = (typeof CreateFeeTypeSchema)['_input'];
+
+const DEFAULT_VALUES: FeeTypeFormValues = {
+  name: '',
+  description: '',
+  isActive: true,
+};
+
+interface FeeTypeFormProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  editingFeeType: FeeTypeResponse | null;
+}
+
+/**
+ * Dialog for creating or editing a fee type.
+ * Uses react-hook-form with zodResolver for validation.
+ */
+export function FeeTypeForm({ open, onOpenChange, editingFeeType }: FeeTypeFormProps) {
+  const params = useParams<{ slug: string }>();
+  const slug = params.slug;
+  const isEditing = !!editingFeeType;
+
+  const createMutation = useCreateFeeType(slug);
+  const updateMutation = useUpdateFeeType(slug);
+  const isPending = createMutation.isPending || updateMutation.isPending;
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    setValue,
+    watch,
+    formState: { errors },
+  } = useForm<FeeTypeFormValues>({
+    resolver: zodResolver(CreateFeeTypeSchema),
+    defaultValues: DEFAULT_VALUES,
+  });
+
+  // Reset form when dialog opens/closes or editing target changes
+  useEffect(() => {
+    if (open) {
+      if (editingFeeType) {
+        reset({
+          name: editingFeeType.name,
+          description: editingFeeType.description ?? '',
+          isActive: editingFeeType.isActive,
+        });
+      } else {
+        reset(DEFAULT_VALUES);
+      }
+    }
+  }, [open, editingFeeType, reset]);
+
+  async function onSubmit(data: FeeTypeFormValues) {
+    const payload: CreateFeeType = {
+      name: data.name,
+      description: data.description || undefined,
+      isActive: data.isActive ?? true,
+    };
+
+    if (isEditing) {
+      await updateMutation.mutateAsync({
+        id: editingFeeType.id,
+        data: payload,
+      });
+    } else {
+      await createMutation.mutateAsync(payload);
+    }
+    onOpenChange(false);
+  }
+
+  const name = watch('name');
+  const isActive = watch('isActive');
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg max-h-[85vh] flex flex-col">
+        <DialogHeader>
+          <DialogTitle>
+            {isEditing ? 'Beitragsart bearbeiten' : 'Beitragsart erstellen'}
+          </DialogTitle>
+          <DialogDescription>
+            {isEditing
+              ? '\u00c4ndere die Konfiguration der Beitragsart.'
+              : 'Erstelle eine neue Beitragsart, die festlegt, wie ein Mitglied zahlt.'}
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col flex-1 min-h-0">
+          <div className="space-y-4 py-4 overflow-y-auto">
+            {/* Name */}
+            <div className="space-y-2">
+              <Label htmlFor="ft-name">Name</Label>
+              <Input
+                id="ft-name"
+                placeholder="z.B. Einzelbeitrag"
+                maxLength={100}
+                autoFocus
+                {...register('name')}
+              />
+              {errors.name?.message && (
+                <p className="text-destructive text-sm">{errors.name.message}</p>
+              )}
+            </div>
+
+            {/* Beschreibung */}
+            <div className="space-y-2">
+              <Label htmlFor="ft-description">Beschreibung</Label>
+              <Textarea
+                id="ft-description"
+                placeholder="Optionale Beschreibung"
+                maxLength={500}
+                rows={2}
+                {...register('description')}
+              />
+              {errors.description?.message && (
+                <p className="text-destructive text-sm">{errors.description.message}</p>
+              )}
+            </div>
+
+            {/* Aktiv */}
+            <div className="flex items-center justify-between rounded-lg border p-4">
+              <div className="space-y-0.5">
+                <Label htmlFor="ft-isActive" className="text-sm font-medium">
+                  Aktiv
+                </Label>
+                <p className="text-xs text-muted-foreground">
+                  Inaktive Beitragsarten k\u00f6nnen nicht mehr zugewiesen werden.
+                </p>
+              </div>
+              <Switch
+                id="ft-isActive"
+                checked={isActive}
+                onCheckedChange={(checked) => setValue('isActive', checked)}
+              />
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isPending}
+            >
+              Abbrechen
+            </Button>
+            <Button type="submit" disabled={isPending || !name}>
+              {isPending && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+              {isEditing ? 'Speichern' : 'Erstellen'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/components/fees/fee-type-form.tsx
+++ b/apps/web/components/fees/fee-type-form.tsx
@@ -105,7 +105,7 @@ export function FeeTypeForm({ open, onOpenChange, editingFeeType }: FeeTypeFormP
           </DialogTitle>
           <DialogDescription>
             {isEditing
-              ? '\u00c4ndere die Konfiguration der Beitragsart.'
+              ? 'Ändere die Konfiguration der Beitragsart.'
               : 'Erstelle eine neue Beitragsart, die festlegt, wie ein Mitglied zahlt.'}
           </DialogDescription>
         </DialogHeader>
@@ -149,7 +149,7 @@ export function FeeTypeForm({ open, onOpenChange, editingFeeType }: FeeTypeFormP
                   Aktiv
                 </Label>
                 <p className="text-xs text-muted-foreground">
-                  Inaktive Beitragsarten k\u00f6nnen nicht mehr zugewiesen werden.
+                  Inaktive Beitragsarten können nicht mehr zugewiesen werden.
                 </p>
               </div>
               <Switch

--- a/apps/web/components/fees/fee-type-list.tsx
+++ b/apps/web/components/fees/fee-type-list.tsx
@@ -127,7 +127,7 @@ export function FeeTypeList({ slug }: FeeTypeListProps) {
                   <TableRow key={ft.id}>
                     <TableCell className="font-medium">{ft.name}</TableCell>
                     <TableCell className="hidden lg:table-cell text-muted-foreground">
-                      {ft.description || '\u2014'}
+                      {ft.description || '—'}
                     </TableCell>
                     <TableCell>
                       <Badge
@@ -154,7 +154,7 @@ export function FeeTypeList({ slug }: FeeTypeListProps) {
                           variant="ghost"
                           size="icon"
                           onClick={() => setDeleteTarget(ft)}
-                          aria-label={`Beitragsart ${ft.name} l\u00f6schen`}
+                          aria-label={`Beitragsart ${ft.name} löschen`}
                         >
                           <Trash2 className="h-4 w-4" />
                         </Button>
@@ -175,9 +175,9 @@ export function FeeTypeList({ slug }: FeeTypeListProps) {
       <ConfirmDialog
         open={!!deleteTarget}
         onOpenChange={(open) => !open && setDeleteTarget(null)}
-        title="Beitragsart l\u00f6schen"
-        description={`M\u00f6chtest du die Beitragsart \u201e${deleteTarget?.name}\u201c wirklich l\u00f6schen? Mitglieder mit dieser Beitragsart behalten ihre aktuelle Zuweisung, die Beitragsart kann aber nicht mehr neu zugewiesen werden.`}
-        confirmLabel="Beitragsart l\u00f6schen"
+        title="Beitragsart löschen"
+        description={`Möchtest du die Beitragsart „${deleteTarget?.name}" wirklich löschen? Mitglieder mit dieser Beitragsart behalten ihre aktuelle Zuweisung, die Beitragsart kann aber nicht mehr neu zugewiesen werden.`}
+        confirmLabel="Beitragsart löschen"
         cancelLabel="Abbrechen"
         variant="destructive"
         onConfirm={handleDelete}

--- a/apps/web/components/fees/fee-type-list.tsx
+++ b/apps/web/components/fees/fee-type-list.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import { useState } from 'react';
+import { Pencil, Plus, Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Skeleton } from '@/components/ui/skeleton';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+import { useFeeTypes, useDeleteFeeType } from '@/hooks/use-fee-types';
+import { FeeTypeForm } from './fee-type-form';
+import type { FeeTypeResponse } from '@ktb/shared';
+
+interface FeeTypeListProps {
+  slug: string;
+}
+
+/**
+ * FeeType CRUD list component.
+ * Displays a table of fee types with create, edit, and delete functionality.
+ * Used in the Beitragsmodell section of Settings.
+ */
+export function FeeTypeList({ slug }: FeeTypeListProps) {
+  const { data: feeTypes, isLoading } = useFeeTypes(slug);
+  const deleteMutation = useDeleteFeeType(slug);
+
+  // Dialog state
+  const [formOpen, setFormOpen] = useState(false);
+  const [editingFeeType, setEditingFeeType] = useState<FeeTypeResponse | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<FeeTypeResponse | null>(null);
+
+  function openCreate() {
+    setEditingFeeType(null);
+    setFormOpen(true);
+  }
+
+  function openEdit(feeType: FeeTypeResponse) {
+    setEditingFeeType(feeType);
+    setFormOpen(true);
+  }
+
+  async function handleDelete() {
+    if (!deleteTarget) return;
+    await deleteMutation.mutateAsync(deleteTarget.id);
+    setDeleteTarget(null);
+  }
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-5 w-48" />
+          <Skeleton className="h-4 w-96 mt-2" />
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-3">
+            {[...Array(3)].map((_, i) => (
+              <div key={i} className="flex items-center gap-4 py-2">
+                <Skeleton className="h-4 w-32" />
+                <Skeleton className="h-4 w-48 hidden lg:block" />
+                <Skeleton className="h-5 w-12 rounded-md" />
+                <Skeleton className="h-8 w-16" />
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const items = feeTypes ?? [];
+  const isEmpty = items.length === 0;
+
+  return (
+    <>
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div>
+              <CardTitle>Beitragsarten</CardTitle>
+              <CardDescription>
+                Definiere, wie deine Mitglieder zahlen (z.B. Einzelbeitrag, Familientarif)
+              </CardDescription>
+            </div>
+            {!isEmpty && (
+              <Button onClick={openCreate}>
+                <Plus className="h-4 w-4 mr-2" />
+                Beitragsart erstellen
+              </Button>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent className="p-6">
+          {isEmpty ? (
+            <div className="flex flex-col items-center justify-center py-12 text-center">
+              <h3 className="text-lg font-semibold mb-2">Noch keine Beitragsarten</h3>
+              <p className="text-muted-foreground max-w-md mb-6">
+                Erstelle Beitragsarten, um festzulegen, wie deine Mitglieder zahlen (z.B.
+                Einzelbeitrag, Familientarif).
+              </p>
+              <Button onClick={openCreate}>
+                <Plus className="h-4 w-4 mr-2" />
+                Erste Beitragsart erstellen
+              </Button>
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead className="hidden lg:table-cell">Beschreibung</TableHead>
+                  <TableHead>Aktiv</TableHead>
+                  <TableHead className="w-24">Aktionen</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {items.map((ft) => (
+                  <TableRow key={ft.id}>
+                    <TableCell className="font-medium">{ft.name}</TableCell>
+                    <TableCell className="hidden lg:table-cell text-muted-foreground">
+                      {ft.description || '\u2014'}
+                    </TableCell>
+                    <TableCell>
+                      <Badge
+                        className={
+                          ft.isActive
+                            ? 'bg-success/15 text-success border-success/25'
+                            : 'bg-muted text-muted-foreground'
+                        }
+                      >
+                        {ft.isActive ? 'Aktiv' : 'Inaktiv'}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex items-center gap-1 justify-end">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => openEdit(ft)}
+                          aria-label={`Beitragsart ${ft.name} bearbeiten`}
+                        >
+                          <Pencil className="h-4 w-4" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => setDeleteTarget(ft)}
+                          aria-label={`Beitragsart ${ft.name} l\u00f6schen`}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Create/Edit Dialog */}
+      <FeeTypeForm
+        open={formOpen}
+        onOpenChange={setFormOpen}
+        editingFeeType={editingFeeType}
+      />
+
+      {/* Delete Confirmation */}
+      <ConfirmDialog
+        open={!!deleteTarget}
+        onOpenChange={(open) => !open && setDeleteTarget(null)}
+        title="Beitragsart l\u00f6schen"
+        description={`M\u00f6chtest du die Beitragsart \u201e${deleteTarget?.name}\u201c wirklich l\u00f6schen? Mitglieder mit dieser Beitragsart behalten ihre aktuelle Zuweisung, die Beitragsart kann aber nicht mehr neu zugewiesen werden.`}
+        confirmLabel="Beitragsart l\u00f6schen"
+        cancelLabel="Abbrechen"
+        variant="destructive"
+        onConfirm={handleDelete}
+        loading={deleteMutation.isPending}
+      />
+    </>
+  );
+}

--- a/apps/web/components/fees/fee-type-list.tsx
+++ b/apps/web/components/fees/fee-type-list.tsx
@@ -169,11 +169,7 @@ export function FeeTypeList({ slug }: FeeTypeListProps) {
       </Card>
 
       {/* Create/Edit Dialog */}
-      <FeeTypeForm
-        open={formOpen}
-        onOpenChange={setFormOpen}
-        editingFeeType={editingFeeType}
-      />
+      <FeeTypeForm open={formOpen} onOpenChange={setFormOpen} editingFeeType={editingFeeType} />
 
       {/* Delete Confirmation */}
       <ConfirmDialog

--- a/apps/web/components/fees/member-fee-badge.tsx
+++ b/apps/web/components/fees/member-fee-badge.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useMemo } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { useMemberFeeCharges } from '@/hooks/use-fee-charges';
+import { cn } from '@/lib/utils';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface MemberFeeBadgeProps {
+  slug: string;
+  memberId: string;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const moneyFormatter = new Intl.NumberFormat('de-DE', {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+// ============================================================================
+// Component
+// ============================================================================
+
+/**
+ * Compact fee status badge for the member detail header.
+ *
+ * Display logic per UI-SPEC IC-05:
+ * - No open/overdue charges: hidden (return null)
+ * - Open charges (not overdue): muted badge with count and total
+ * - Any overdue charge: destructive badge with count and total
+ *
+ * Badge hidden during loading (no skeleton for inline badge per UI-SPEC).
+ * Click scrolls to #member-fee-section and opens the collapsible.
+ */
+export function MemberFeeBadge({ slug, memberId }: MemberFeeBadgeProps) {
+  const { data: charges, isLoading } = useMemberFeeCharges(slug, memberId);
+
+  const badgeInfo = useMemo(() => {
+    if (!charges?.length) return null;
+
+    const openCharges = charges.filter((c) => c.status !== 'PAID');
+    if (openCharges.length === 0) return null;
+
+    const hasOverdue = openCharges.some((c) => c.isOverdue);
+    const totalAmount = openCharges.reduce((sum, c) => sum + parseFloat(c.remainingAmount), 0);
+
+    return {
+      count: openCharges.length,
+      amount: moneyFormatter.format(totalAmount),
+      hasOverdue,
+    };
+  }, [charges]);
+
+  if (isLoading || !badgeInfo) return null;
+
+  const handleClick = () => {
+    const section = document.getElementById('member-fee-section');
+    if (section) {
+      section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      // Dispatch a custom event to open the collapsible
+      section.dispatchEvent(new CustomEvent('expand-fee-section'));
+    }
+  };
+
+  return (
+    <Badge
+      variant="outline"
+      className={cn(
+        'cursor-pointer transition-colors',
+        badgeInfo.hasOverdue
+          ? 'bg-destructive/15 text-destructive border-destructive/25'
+          : 'bg-muted text-muted-foreground border-border'
+      )}
+      onClick={handleClick}
+    >
+      {badgeInfo.count} offen, {badgeInfo.amount} EUR
+    </Badge>
+  );
+}

--- a/apps/web/components/fees/member-fee-badge.tsx
+++ b/apps/web/components/fees/member-fee-badge.tsx
@@ -18,10 +18,7 @@ interface MemberFeeBadgeProps {
 // Helpers
 // ============================================================================
 
-const moneyFormatter = new Intl.NumberFormat('de-DE', {
-  minimumFractionDigits: 2,
-  maximumFractionDigits: 2,
-});
+import { moneyFormatter } from '@/lib/format-money';
 
 // ============================================================================
 // Component

--- a/apps/web/components/fees/member-fee-section.tsx
+++ b/apps/web/components/fees/member-fee-section.tsx
@@ -6,11 +6,7 @@ import { ChevronRight, ChevronsUpDown, Settings2 } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from '@/components/ui/collapsible';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { FeeChargeStatusBadge } from '@/components/fees/fee-charge-status-badge';
 import { FeeOverrideDialog } from '@/components/fees/fee-override-dialog';
 import { useMemberFeeCharges } from '@/hooks/use-fee-charges';
@@ -132,10 +128,7 @@ export function MemberFeeSection({ slug, memberId, memberName }: MemberFeeSectio
             {!chargesLoading && displayCharges.length > 0 && (
               <div className="space-y-2">
                 {displayCharges.map((charge) => (
-                  <div
-                    key={charge.id}
-                    className="flex items-center justify-between gap-2 text-sm"
-                  >
+                  <div key={charge.id} className="flex items-center justify-between gap-2 text-sm">
                     <span className="truncate min-w-0">{charge.description}</span>
                     <div className="flex items-center gap-2 shrink-0">
                       <span className="tabular-nums text-right">
@@ -150,9 +143,7 @@ export function MemberFeeSection({ slug, memberId, memberName }: MemberFeeSectio
                 ))}
 
                 {remainingCount > 0 && (
-                  <p className="text-sm text-muted-foreground">
-                    und {remainingCount} weitere...
-                  </p>
+                  <p className="text-sm text-muted-foreground">und {remainingCount} weitere...</p>
                 )}
               </div>
             )}
@@ -181,11 +172,7 @@ export function MemberFeeSection({ slug, memberId, memberName }: MemberFeeSectio
                 <ChevronRight className="h-3 w-3" />
               </Link>
 
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={() => setOverrideDialogOpen(true)}
-              >
+              <Button variant="secondary" size="sm" onClick={() => setOverrideDialogOpen(true)}>
                 <Settings2 className="h-3.5 w-3.5" />
                 Anpassungen verwalten
               </Button>

--- a/apps/web/components/fees/member-fee-section.tsx
+++ b/apps/web/components/fees/member-fee-section.tsx
@@ -1,0 +1,207 @@
+'use client';
+
+import { useMemo, useState, useEffect, useRef, useCallback } from 'react';
+import Link from 'next/link';
+import { ChevronRight, ChevronsUpDown, Settings2 } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
+import { FeeChargeStatusBadge } from '@/components/fees/fee-charge-status-badge';
+import { FeeOverrideDialog } from '@/components/fees/fee-override-dialog';
+import { useMemberFeeCharges } from '@/hooks/use-fee-charges';
+import { useFeeOverrides } from '@/hooks/use-fee-overrides';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface MemberFeeSectionProps {
+  slug: string;
+  memberId: string;
+  memberName: string;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const moneyFormatter = new Intl.NumberFormat('de-DE', {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+function formatDate(isoDate: string): string {
+  const [year, month, day] = isoDate.split('-');
+  if (!year || !month || !day) return isoDate;
+  return `${day}.${month}.${year}`;
+}
+
+const OVERRIDE_TYPE_LABELS: Record<string, string> = {
+  EXEMPT: 'Befreit',
+  CUSTOM_AMOUNT: 'Individuell',
+  ADDITIONAL: 'Zusatz',
+};
+
+// ============================================================================
+// Component
+// ============================================================================
+
+/**
+ * Collapsible section showing recent open charges for a member.
+ *
+ * Per UI-SPEC Member Detail Integration layout:
+ * - Shows up to 3 most recent open/overdue charges sorted by dueDate ASC
+ * - Link to pre-filtered fees page
+ * - Override management access via dialog
+ * - Loading: skeleton with 3 row placeholders
+ * - Empty: "Keine offenen Forderungen"
+ */
+export function MemberFeeSection({ slug, memberId, memberName }: MemberFeeSectionProps) {
+  const [isOpen, setIsOpen] = useState(true);
+  const [overrideDialogOpen, setOverrideDialogOpen] = useState(false);
+  const sectionRef = useRef<HTMLDivElement>(null);
+
+  const { data: charges, isLoading: chargesLoading } = useMemberFeeCharges(slug, memberId);
+  const { data: overrides } = useFeeOverrides(slug, memberId);
+
+  // Listen for expand event from the badge click
+  const handleExpand = useCallback(() => {
+    setIsOpen(true);
+  }, []);
+
+  useEffect(() => {
+    const el = sectionRef.current;
+    if (!el) return;
+    el.addEventListener('expand-fee-section', handleExpand);
+    return () => el.removeEventListener('expand-fee-section', handleExpand);
+  }, [handleExpand]);
+
+  // Filter and sort open/overdue charges: oldest overdue first
+  const openCharges = useMemo(() => {
+    if (!charges?.length) return [];
+    return charges
+      .filter((c) => c.status !== 'PAID')
+      .sort((a, b) => {
+        // Overdue first, then by dueDate ASC (oldest first)
+        if (a.isOverdue && !b.isOverdue) return -1;
+        if (!a.isOverdue && b.isOverdue) return 1;
+        return a.dueDate.localeCompare(b.dueDate);
+      });
+  }, [charges]);
+
+  const displayCharges = openCharges.slice(0, 3);
+  const remainingCount = openCharges.length - displayCharges.length;
+
+  const overrideCount = overrides?.length ?? 0;
+
+  return (
+    <div id="member-fee-section" ref={sectionRef} className="rounded-md border bg-muted/50">
+      <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+        <CollapsibleTrigger asChild>
+          <button
+            type="button"
+            className="flex w-full items-center justify-between px-4 py-3 text-left hover:bg-muted/80 transition-colors rounded-t-md"
+          >
+            <span className="text-sm font-semibold">Offene Beitraege</span>
+            <ChevronsUpDown className="h-4 w-4 text-muted-foreground" />
+          </button>
+        </CollapsibleTrigger>
+
+        <CollapsibleContent>
+          <div className="px-4 pb-4 space-y-3">
+            {/* Loading state */}
+            {chargesLoading && (
+              <div className="space-y-2">
+                <Skeleton className="h-8 w-full" />
+                <Skeleton className="h-8 w-full" />
+                <Skeleton className="h-8 w-full" />
+              </div>
+            )}
+
+            {/* Empty state */}
+            {!chargesLoading && openCharges.length === 0 && (
+              <p className="text-sm text-muted-foreground">Keine offenen Forderungen</p>
+            )}
+
+            {/* Charge rows */}
+            {!chargesLoading && displayCharges.length > 0 && (
+              <div className="space-y-2">
+                {displayCharges.map((charge) => (
+                  <div
+                    key={charge.id}
+                    className="flex items-center justify-between gap-2 text-sm"
+                  >
+                    <span className="truncate min-w-0">{charge.description}</span>
+                    <div className="flex items-center gap-2 shrink-0">
+                      <span className="tabular-nums text-right">
+                        {moneyFormatter.format(parseFloat(charge.remainingAmount))} EUR
+                      </span>
+                      <FeeChargeStatusBadge status={charge.status} isOverdue={charge.isOverdue} />
+                      <span className="text-xs text-muted-foreground tabular-nums">
+                        {formatDate(charge.dueDate)}
+                      </span>
+                    </div>
+                  </div>
+                ))}
+
+                {remainingCount > 0 && (
+                  <p className="text-sm text-muted-foreground">
+                    und {remainingCount} weitere...
+                  </p>
+                )}
+              </div>
+            )}
+
+            {/* Override summary */}
+            {overrideCount > 0 && (
+              <div className="flex items-center gap-2 flex-wrap">
+                <span className="text-sm text-muted-foreground">
+                  {overrideCount} Anpassung{overrideCount !== 1 ? 'en' : ''}
+                </span>
+                {overrides?.map((o) => (
+                  <Badge key={o.id} variant="outline" className="text-xs">
+                    {OVERRIDE_TYPE_LABELS[o.overrideType] ?? o.overrideType}
+                  </Badge>
+                ))}
+              </div>
+            )}
+
+            {/* Actions */}
+            <div className="flex items-center gap-3 pt-1">
+              <Link
+                href={`/clubs/${slug}/fees?tab=forderungen&memberId=${memberId}`}
+                className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
+              >
+                Beitragshistorie anzeigen
+                <ChevronRight className="h-3 w-3" />
+              </Link>
+
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => setOverrideDialogOpen(true)}
+              >
+                <Settings2 className="h-3.5 w-3.5" />
+                Anpassungen verwalten
+              </Button>
+            </div>
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
+
+      {/* Override dialog */}
+      <FeeOverrideDialog
+        slug={slug}
+        memberId={memberId}
+        memberName={memberName}
+        open={overrideDialogOpen}
+        onOpenChange={setOverrideDialogOpen}
+      />
+    </div>
+  );
+}

--- a/apps/web/components/fees/member-fee-section.tsx
+++ b/apps/web/components/fees/member-fee-section.tsx
@@ -26,10 +26,7 @@ interface MemberFeeSectionProps {
 // Helpers
 // ============================================================================
 
-const moneyFormatter = new Intl.NumberFormat('de-DE', {
-  minimumFractionDigits: 2,
-  maximumFractionDigits: 2,
-});
+import { moneyFormatter } from '@/lib/format-money';
 
 function formatDate(isoDate: string): string {
   const [year, month, day] = isoDate.split('-');

--- a/apps/web/components/fees/member-fee-section.tsx
+++ b/apps/web/components/fees/member-fee-section.tsx
@@ -100,7 +100,7 @@ export function MemberFeeSection({ slug, memberId, memberName }: MemberFeeSectio
             type="button"
             className="flex w-full items-center justify-between px-4 py-3 text-left hover:bg-muted/80 transition-colors rounded-t-md"
           >
-            <span className="text-sm font-semibold">Offene Beitraege</span>
+            <span className="text-sm font-semibold">Offene Beiträge</span>
             <ChevronsUpDown className="h-4 w-4 text-muted-foreground" />
           </button>
         </CollapsibleTrigger>

--- a/apps/web/components/fees/payment-record-dialog.tsx
+++ b/apps/web/components/fees/payment-record-dialog.tsx
@@ -32,14 +32,7 @@ interface PaymentRecordDialogProps {
 // Helpers
 // ============================================================================
 
-const moneyFormatter = new Intl.NumberFormat('de-DE', {
-  minimumFractionDigits: 2,
-  maximumFractionDigits: 2,
-});
-
-function formatMoney(value: string): string {
-  return `${moneyFormatter.format(parseFloat(value))} EUR`;
-}
+import { formatMoney } from '@/lib/format-money';
 
 function getTodayISO(): string {
   return new Date().toISOString().split('T')[0];

--- a/apps/web/components/fees/payment-record-dialog.tsx
+++ b/apps/web/components/fees/payment-record-dialog.tsx
@@ -128,7 +128,7 @@ export function PaymentRecordDialog({
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Zahlung erfassen</DialogTitle>
-          <DialogDescription>Manuelle Zahlung fuer eine Forderung erfassen</DialogDescription>
+          <DialogDescription>Manuelle Zahlung für eine Forderung erfassen</DialogDescription>
         </DialogHeader>
 
         {/* Charge context (read-only) */}

--- a/apps/web/components/fees/payment-record-dialog.tsx
+++ b/apps/web/components/fees/payment-record-dialog.tsx
@@ -1,0 +1,230 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Loader2 } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { useRecordPayment } from '@/hooks/use-payments';
+import type { FeeChargeResponse } from '@ktb/shared';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface PaymentRecordDialogProps {
+  charge: FeeChargeResponse;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  slug: string;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const moneyFormatter = new Intl.NumberFormat('de-DE', {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+function formatMoney(value: string): string {
+  return `${moneyFormatter.format(parseFloat(value))} EUR`;
+}
+
+function getTodayISO(): string {
+  return new Date().toISOString().split('T')[0];
+}
+
+// Validation: amount must be > 0, max 10 digits before decimal, max 2 after
+function validateAmount(value: string): string | null {
+  if (!value) return 'Betrag ist erforderlich';
+  const num = parseFloat(value);
+  if (isNaN(num) || num <= 0) return 'Betrag muss groesser als 0 sein';
+  if (!/^\d{1,10}(\.\d{1,2})?$/.test(value)) {
+    return 'Betrag darf maximal 10 Vorkomma- und 2 Nachkommastellen haben';
+  }
+  return null;
+}
+
+function validateDate(value: string): string | null {
+  if (!value) return 'Zahlungsdatum ist erforderlich';
+  const date = new Date(value);
+  const today = new Date();
+  today.setHours(23, 59, 59, 999);
+  if (date > today) return 'Zahlungsdatum darf nicht in der Zukunft liegen';
+  return null;
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+/**
+ * Dialog for recording a manual payment against a fee charge.
+ * Shows charge context (member, amounts) and a form for amount, date, notes.
+ */
+export function PaymentRecordDialog({
+  charge,
+  open,
+  onOpenChange,
+  slug,
+}: PaymentRecordDialogProps) {
+  const [amount, setAmount] = useState('');
+  const [paidAt, setPaidAt] = useState('');
+  const [notes, setNotes] = useState('');
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  const recordPayment = useRecordPayment(slug);
+
+  // Reset form when dialog opens
+  useEffect(() => {
+    if (open) {
+      setAmount(charge.remainingAmount);
+      setPaidAt(getTodayISO());
+      setNotes('');
+      setErrors({});
+    }
+  }, [open, charge.remainingAmount]);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+
+    // Validate
+    const newErrors: Record<string, string> = {};
+    const amountError = validateAmount(amount);
+    if (amountError) newErrors.amount = amountError;
+    const dateError = validateDate(paidAt);
+    if (dateError) newErrors.paidAt = dateError;
+
+    if (Object.keys(newErrors).length > 0) {
+      setErrors(newErrors);
+      return;
+    }
+
+    setErrors({});
+
+    recordPayment.mutate(
+      {
+        feeChargeId: charge.id,
+        amount,
+        paidAt,
+        notes: notes || undefined,
+      },
+      {
+        onSuccess: () => {
+          onOpenChange(false);
+        },
+      }
+    );
+  }
+
+  const isPending = recordPayment.isPending;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Zahlung erfassen</DialogTitle>
+          <DialogDescription>Manuelle Zahlung fuer eine Forderung erfassen</DialogDescription>
+        </DialogHeader>
+
+        {/* Charge context (read-only) */}
+        <div className="rounded-md border bg-muted/50 p-4 space-y-1 text-sm">
+          <div>
+            <span className="text-muted-foreground">Mitglied: </span>
+            <span className="font-medium">
+              {charge.member.lastName}, {charge.member.firstName}
+            </span>
+          </div>
+          <div>
+            <span className="text-muted-foreground">Beschreibung: </span>
+            <span>{charge.description}</span>
+          </div>
+          <div className="flex flex-wrap gap-4">
+            <div>
+              <span className="text-muted-foreground">Betrag: </span>
+              <span className="font-medium tabular-nums">{formatMoney(charge.amount)}</span>
+            </div>
+            <div>
+              <span className="text-muted-foreground">Bezahlt: </span>
+              <span className="font-medium tabular-nums">{formatMoney(charge.paidAmount)}</span>
+            </div>
+            <div>
+              <span className="text-muted-foreground">Offen: </span>
+              <span className="font-medium tabular-nums">
+                {formatMoney(charge.remainingAmount)}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        {/* Payment form */}
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="paymentAmount">Betrag (EUR)</Label>
+            <Input
+              id="paymentAmount"
+              type="number"
+              step="0.01"
+              min="0.01"
+              value={amount}
+              onChange={(e) => setAmount(e.target.value)}
+              disabled={isPending}
+              className="tabular-nums"
+            />
+            {errors.amount && <p className="text-sm text-destructive">{errors.amount}</p>}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="paymentDate">Zahlungsdatum</Label>
+            <Input
+              id="paymentDate"
+              type="date"
+              value={paidAt}
+              onChange={(e) => setPaidAt(e.target.value)}
+              disabled={isPending}
+            />
+            {errors.paidAt && <p className="text-sm text-destructive">{errors.paidAt}</p>}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="paymentNotes">Notizen</Label>
+            <Textarea
+              id="paymentNotes"
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              disabled={isPending}
+              placeholder="Optional..."
+              rows={3}
+            />
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isPending}
+            >
+              Abbrechen
+            </Button>
+            <Button type="submit" disabled={isPending}>
+              {isPending && <Loader2 className="h-4 w-4 animate-spin" />}
+              Zahlung erfassen
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/components/fees/payment-record-dialog.tsx
+++ b/apps/web/components/fees/payment-record-dialog.tsx
@@ -42,7 +42,7 @@ function getTodayISO(): string {
 function validateAmount(value: string): string | null {
   if (!value) return 'Betrag ist erforderlich';
   const num = parseFloat(value);
-  if (isNaN(num) || num <= 0) return 'Betrag muss groesser als 0 sein';
+  if (isNaN(num) || num <= 0) return 'Betrag muss größer als 0 sein';
   if (!/^\d{1,10}(\.\d{1,2})?$/.test(value)) {
     return 'Betrag darf maximal 10 Vorkomma- und 2 Nachkommastellen haben';
   }

--- a/apps/web/components/fees/payment-record-dialog.tsx
+++ b/apps/web/components/fees/payment-record-dialog.tsx
@@ -39,11 +39,14 @@ function getTodayISO(): string {
 }
 
 // Validation: amount must be > 0, max 10 digits before decimal, max 2 after
+// Accepts both dot and comma as decimal separator (German locale)
 function validateAmount(value: string): string | null {
   if (!value) return 'Betrag ist erforderlich';
-  const num = parseFloat(value);
+  // Normalize comma to dot for numeric parsing
+  const normalized = value.replace(',', '.');
+  const num = parseFloat(normalized);
   if (isNaN(num) || num <= 0) return 'Betrag muss größer als 0 sein';
-  if (!/^\d{1,10}(\.\d{1,2})?$/.test(value)) {
+  if (!/^\d{1,10}([.,]\d{1,2})?$/.test(value)) {
     return 'Betrag darf maximal 10 Vorkomma- und 2 Nachkommastellen haben';
   }
   return null;
@@ -106,10 +109,13 @@ export function PaymentRecordDialog({
 
     setErrors({});
 
+    // Normalize comma to dot before sending to API
+    const normalizedAmount = amount.replace(',', '.');
+
     recordPayment.mutate(
       {
         feeChargeId: charge.id,
-        amount,
+        amount: normalizedAmount,
         paidAt,
         notes: notes || undefined,
       },

--- a/apps/web/components/layout/settings-sidebar.tsx
+++ b/apps/web/components/layout/settings-sidebar.tsx
@@ -6,6 +6,7 @@ import {
   ArrowLeft,
   Bell,
   Building2,
+  Coins,
   Hash,
   IdCard,
   Key,
@@ -76,6 +77,7 @@ export function SettingsSidebar() {
           { href: `${clubBasePath}/invites`, title: 'Einladungen', icon: Key },
           { href: `${clubBasePath}/number-ranges`, title: 'Nummernkreise', icon: Hash },
           { href: `${clubBasePath}/membership-types`, title: 'Mitgliedsarten', icon: IdCard },
+          { href: `${clubBasePath}/fee-model`, title: 'Beiträge', icon: Coins },
         ]
       : [];
 

--- a/apps/web/components/layout/sidebar-nav-items.ts
+++ b/apps/web/components/layout/sidebar-nav-items.ts
@@ -94,7 +94,7 @@ export function getClubNavGroups(slug: string): NavGroup[] {
           title: 'Beiträge',
           url: `${base}/fees`,
           icon: CreditCard,
-          visibleTo: 'club-members',
+          visibleTo: 'finance',
         },
         {
           title: 'SEPA',

--- a/apps/web/components/layout/sidebar-nav-items.ts
+++ b/apps/web/components/layout/sidebar-nav-items.ts
@@ -94,7 +94,6 @@ export function getClubNavGroups(slug: string): NavGroup[] {
           title: 'Beiträge',
           url: `${base}/fees`,
           icon: CreditCard,
-          comingSoon: true,
           visibleTo: 'club-members',
         },
         {

--- a/apps/web/components/members/member-create-sheet.tsx
+++ b/apps/web/components/members/member-create-sheet.tsx
@@ -26,6 +26,7 @@ import { DateInput } from '@/components/ui/date-input';
 import { useCreateMember } from '@/hooks/use-members';
 import { useNumberRanges } from '@/hooks/use-number-ranges';
 import { useMembershipTypes } from '@/hooks/use-membership-types';
+import { useFeeTypes } from '@/hooks/use-fee-types';
 import { useToast } from '@/hooks/use-toast';
 import { getTodayISO } from '@/lib/format-date';
 import { STATUS_LABELS } from '@/lib/member-status-labels';
@@ -82,6 +83,13 @@ export function MemberCreateSheet({
   const createMember = useCreateMember(slug);
   const { data: numberRanges } = useNumberRanges(slug);
   const { data: membershipTypes } = useMembershipTypes(slug);
+  const { data: feeTypes } = useFeeTypes(slug);
+
+  // Active fee types for the dropdown
+  const activeFeeTypes = useMemo(() => {
+    if (!feeTypes) return [];
+    return feeTypes.filter((ft) => ft.isActive);
+  }, [feeTypes]);
 
   // Check if auto-generation is available
   const memberNumberRange = useMemo(
@@ -491,6 +499,34 @@ export function MemberCreateSheet({
                         ))}
                       </SelectContent>
                     </Select>
+                  </div>
+                )}
+
+                {/* Beitragsart (only shown when fee types exist) */}
+                {activeFeeTypes.length > 0 && (
+                  <div className="space-y-1.5">
+                    <Label>Beitragsart</Label>
+                    <Select
+                      disabled={isSubmitting}
+                      onValueChange={(val) =>
+                        setValue('feeTypeId', val === '__none__' ? null : val)
+                      }
+                    >
+                      <SelectTrigger className="w-full">
+                        <SelectValue placeholder="Beitragsart wählen" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="__none__">Keine Auswahl</SelectItem>
+                        {activeFeeTypes.map((ft) => (
+                          <SelectItem key={ft.id} value={ft.id}>
+                            {ft.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <p className="text-xs text-muted-foreground">
+                      Bestimmt den Grundbeitrag zusammen mit der Mitgliedsart.
+                    </p>
                   </div>
                 )}
               </div>

--- a/apps/web/components/members/member-detail-header.tsx
+++ b/apps/web/components/members/member-detail-header.tsx
@@ -27,6 +27,7 @@ import { useMemberStatusHistory } from '@/hooks/use-members';
 import { MemberAvatar } from './member-avatar';
 import { MemberStatusBadge } from './member-status-badge';
 import { HouseholdBadge } from './household-badge';
+import { MemberFeeBadge } from '@/components/fees/member-fee-badge';
 import { useCanManageUsers } from '@/lib/club-permissions';
 import { buildTransitionActions, CANCELLATION_STATUSES } from './member-status-actions';
 import type { MemberDetail } from '@/hooks/use-member-detail';
@@ -177,6 +178,7 @@ export function MemberDetailHeader({
               </Badge>
             )}
             <span className="text-sm text-muted-foreground font-mono">{member.memberNumber}</span>
+            <MemberFeeBadge slug={slug} memberId={member.id} />
             {member.household && (
               <HouseholdBadge
                 name={member.household.name}

--- a/apps/web/components/members/member-detail-panel.tsx
+++ b/apps/web/components/members/member-detail-panel.tsx
@@ -23,6 +23,7 @@ import { useToast } from '@/hooks/use-toast';
 import { formatDate } from '@/lib/format-date';
 import { MemberDetailHeader } from './member-detail-header';
 import { MemberForm } from './member-form/member-form';
+import { MemberFeeSection } from '@/components/fees/member-fee-section';
 import { MemberDeleteDialog } from './member-delete-dialog';
 import { MemberAnonymizeDialog } from './member-anonymize-dialog';
 import { MemberLinkUserDialog } from './member-link-user-dialog';
@@ -191,6 +192,19 @@ function DetailContent({
           onLinkUser={() => setLinkUserDialogOpen(true)}
           onDelete={() => setDeleteDialogOpen(true)}
           onAnonymize={() => setAnonymizeDialogOpen(true)}
+        />
+      </div>
+
+      {/* Fee section — collapsible section with open charges and override management */}
+      <div className="px-4 pt-3">
+        <MemberFeeSection
+          slug={slug}
+          memberId={member.id}
+          memberName={
+            member.personType === 'LEGAL_ENTITY' && member.organizationName
+              ? member.organizationName
+              : `${member.firstName} ${member.lastName}`
+          }
         />
       </div>
 

--- a/apps/web/components/members/member-form/member-form.tsx
+++ b/apps/web/components/members/member-form/member-form.tsx
@@ -1,13 +1,25 @@
 'use client';
 
 import { useCallback, useEffect, useMemo } from 'react';
-import { useForm } from 'react-hook-form';
+import { Controller, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Loader2 } from 'lucide-react';
 import { UpdateMemberSchema } from '@ktb/shared';
+import type { FeeTypeResponse, CrossTableEntryResponse } from '@ktb/shared';
 import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { Separator } from '@/components/ui/separator';
 import { useUpdateMember } from '@/hooks/use-members';
+import { useFeeTypes } from '@/hooks/use-fee-types';
+import { useCrossTable } from '@/hooks/use-cross-table';
+import { useClubSettings } from '@/hooks/use-club-settings';
 import { useToast } from '@/hooks/use-toast';
 import type { MemberDetail } from '@/hooks/use-member-detail';
 import { BasicInfoSection } from './basic-info-section';
@@ -29,6 +41,98 @@ interface MemberFormProps {
   slug: string;
   /** Called when the form dirty state changes */
   onDirtyChange?: (dirty: boolean) => void;
+}
+
+// ============================================================================
+// Helper: Format amount to German locale
+// ============================================================================
+
+function formatAmount(amount: string): string {
+  return parseFloat(amount).toFixed(2).replace('.', ',');
+}
+
+// ============================================================================
+// Helper: Suggest FeeType based on HouseholdBillingModel + household context
+// ============================================================================
+
+interface FeeTypeSuggestion {
+  feeTypeId: string;
+  feeTypeName: string;
+  reason: string;
+}
+
+function suggestFeeType(
+  model: string | null | undefined,
+  householdRole: string | null,
+  isInHousehold: boolean,
+  membershipTypeName: string | null,
+  feeTypes: FeeTypeResponse[]
+): FeeTypeSuggestion | null {
+  const activeFeeTypes = feeTypes.filter((ft) => ft.isActive);
+  if (activeFeeTypes.length === 0) return null;
+
+  // Find by name (case-insensitive, fuzzy start match)
+  const findByName = (name: string) =>
+    activeFeeTypes.find((ft) => ft.name.toLowerCase().includes(name.toLowerCase()));
+
+  // Honorary members always get "Beitragsfrei"
+  if (membershipTypeName?.toLowerCase().includes('ehren')) {
+    const free = findByName('beitragsfrei');
+    return free ? { feeTypeId: free.id, feeTypeName: free.name, reason: 'Ehrenmitglied' } : null;
+  }
+
+  if (!model || model === 'NONE' || !isInHousehold) {
+    const single = findByName('einzelbeitrag');
+    return single
+      ? { feeTypeId: single.id, feeTypeName: single.name, reason: 'Einzelperson' }
+      : null;
+  }
+
+  switch (model) {
+    case 'REDUCED_MEMBERS':
+      if (householdRole === 'HEAD') {
+        const single = findByName('einzelbeitrag');
+        return single
+          ? { feeTypeId: single.id, feeTypeName: single.name, reason: 'Hauptmitglied' }
+          : null;
+      } else {
+        const family = findByName('familientarif');
+        return family
+          ? { feeTypeId: family.id, feeTypeName: family.name, reason: 'Haushaltsmitglied' }
+          : null;
+      }
+
+    case 'FAMILY_PAYER':
+      if (householdRole === 'HEAD') {
+        const familyPay = findByName('familien-pauschal') ?? findByName('familienpauschal');
+        return familyPay
+          ? { feeTypeId: familyPay.id, feeTypeName: familyPay.name, reason: 'Familienzahler' }
+          : null;
+      } else {
+        const free = findByName('beitragsfrei');
+        return free
+          ? {
+              feeTypeId: free.id,
+              feeTypeName: free.name,
+              reason: 'Haushalt, beitragsfrei',
+            }
+          : null;
+      }
+
+    case 'ALL_REDUCED': {
+      const reduced = findByName('familientarif');
+      return reduced
+        ? {
+            feeTypeId: reduced.id,
+            feeTypeName: reduced.name,
+            reason: 'Alle reduziert',
+          }
+        : null;
+    }
+
+    default:
+      return null;
+  }
 }
 
 // ============================================================================
@@ -62,6 +166,7 @@ function memberToFormValues(member: MemberDetail): FormValues {
     postalCode: member.postalCode ?? '',
     city: member.city ?? '',
     country: member.country ?? 'DE',
+    feeTypeId: member.feeTypeId ?? undefined,
   };
 }
 
@@ -76,6 +181,9 @@ function memberToFormValues(member: MemberDetail): FormValues {
 export function MemberForm({ member, slug, onDirtyChange }: MemberFormProps) {
   const { toast } = useToast();
   const updateMember = useUpdateMember(slug);
+  const { data: feeTypes } = useFeeTypes(slug);
+  const { data: crossTableEntries } = useCrossTable(slug);
+  const { data: clubSettings } = useClubSettings(slug);
 
   const defaultValues = useMemo(() => memberToFormValues(member), [member]);
 
@@ -93,6 +201,58 @@ export function MemberForm({ member, slug, onDirtyChange }: MemberFormProps) {
     control,
     formState: { errors, isDirty, isSubmitting },
   } = form;
+
+  const selectedFeeTypeId = watch('feeTypeId');
+
+  // Resolve the member's current MembershipType from the latest period
+  const currentMembershipTypeId = useMemo(() => {
+    const periods = member.membershipPeriods ?? [];
+    // Latest period that has a membershipTypeId
+    const latest = [...periods]
+      .sort((a, b) => {
+        const dateA = a.joinDate ?? a.createdAt ?? '';
+        const dateB = b.joinDate ?? b.createdAt ?? '';
+        return dateB.localeCompare(dateA);
+      })
+      .find((p) => p.membershipTypeId);
+    return latest?.membershipTypeId ?? null;
+  }, [member.membershipPeriods]);
+
+  // Resolve MembershipType name for suggestion logic (fuzzy match via name)
+  const currentMembershipTypeName = useMemo(() => {
+    // We don't have membership type names directly, so use householdRole-based check only
+    // The membershipType name is not on MemberDetail — we rely on honorary check via null/code approach
+    return null;
+  }, []);
+
+  // Compute auto-suggestion
+  const suggestion = useMemo(() => {
+    if (!feeTypes?.length) return null;
+    const isInHousehold = !!member.householdId;
+    return suggestFeeType(
+      clubSettings?.householdBillingModel,
+      member.householdRole,
+      isInHousehold,
+      currentMembershipTypeName,
+      feeTypes
+    );
+  }, [
+    feeTypes,
+    clubSettings?.householdBillingModel,
+    member.householdRole,
+    member.householdId,
+    currentMembershipTypeName,
+  ]);
+
+  // Compute the cross-table entry for the currently selected feeType + membershipType
+  const selectedEntry = useMemo((): CrossTableEntryResponse | null => {
+    if (!selectedFeeTypeId || !currentMembershipTypeId || !crossTableEntries?.length) return null;
+    return (
+      crossTableEntries.find(
+        (e) => e.feeTypeId === selectedFeeTypeId && e.membershipTypeId === currentMembershipTypeId
+      ) ?? null
+    );
+  }, [selectedFeeTypeId, currentMembershipTypeId, crossTableEntries]);
 
   // Reset form when member data changes (e.g., after save or external refresh)
   useEffect(() => {
@@ -121,6 +281,11 @@ export function MemberForm({ member, slug, onDirtyChange }: MemberFormProps) {
           if ((value === '' || value === undefined) && original) {
             changed[key] = null;
           }
+        }
+
+        // Explicitly handle feeTypeId clearing (from value to null/undefined)
+        if (data.feeTypeId !== defaultValues.feeTypeId) {
+          changed.feeTypeId = data.feeTypeId ?? null;
         }
 
         if (Object.keys(changed).length === 0) {
@@ -183,6 +348,74 @@ export function MemberForm({ member, slug, onDirtyChange }: MemberFormProps) {
           {/* Section: Mitgliedschaft */}
           <SectionHeader title="Mitgliedschaft" />
           <MembershipSection member={member} slug={slug} />
+
+          <Separator />
+
+          {/* Section: Beitragsart */}
+          <SectionHeader title="Beitragsart" />
+          <div className="space-y-1.5">
+            <Label htmlFor="feeTypeId">Beitragsart</Label>
+            <Controller
+              name="feeTypeId"
+              control={control}
+              render={({ field }) => (
+                <Select
+                  value={field.value ?? ''}
+                  onValueChange={(val) => field.onChange(val === '__none__' ? null : val)}
+                  disabled={isSubmitting || !feeTypes?.length}
+                >
+                  <SelectTrigger id="feeTypeId">
+                    <SelectValue
+                      placeholder={
+                        feeTypes?.length ? 'Beitragsart wählen' : 'Keine Beitragsarten vorhanden'
+                      }
+                    />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="__none__">Keine Auswahl</SelectItem>
+                    {feeTypes
+                      ?.filter((ft) => ft.isActive)
+                      .map((ft) => {
+                        const entry = crossTableEntries?.find(
+                          (e) =>
+                            e.feeTypeId === ft.id && e.membershipTypeId === currentMembershipTypeId
+                        );
+                        return (
+                          <SelectItem key={ft.id} value={ft.id}>
+                            {ft.name}
+                            {entry ? ` (${formatAmount(entry.amount)} EUR/Jahr)` : ''}
+                          </SelectItem>
+                        );
+                      })}
+                  </SelectContent>
+                </Select>
+              )}
+            />
+            {/* Suggestion line (per D-10) */}
+            {suggestion && (
+              <p
+                className={
+                  selectedFeeTypeId && selectedFeeTypeId !== suggestion.feeTypeId
+                    ? 'text-sm text-warning'
+                    : 'text-sm text-muted-foreground'
+                }
+              >
+                {selectedFeeTypeId && selectedFeeTypeId !== suggestion.feeTypeId
+                  ? `Manuell gewählt (Vorschlag wäre: ${suggestion.feeTypeName})`
+                  : `Vorschlag: ${suggestion.feeTypeName} (${suggestion.reason})`}
+              </p>
+            )}
+            {/* Computed amount line */}
+            {selectedEntry ? (
+              <p className="text-sm font-medium tabular-nums">
+                Grundbeitrag: {formatAmount(selectedEntry.amount)} EUR / Jahr
+              </p>
+            ) : selectedFeeTypeId ? (
+              <p className="text-sm text-warning">
+                Kein Betrag in der Beitragstabelle für diese Kombination
+              </p>
+            ) : null}
+          </div>
 
           <Separator />
 

--- a/apps/web/components/settings/club-settings-form.tsx
+++ b/apps/web/components/settings/club-settings-form.tsx
@@ -74,6 +74,12 @@ function clubToFormValues(club: ClubSettingsResponse): SettingsFormValues {
     defaultMembershipTypeId:
       (club.defaultMembershipTypeId as SettingsFormValues['defaultMembershipTypeId']) ?? undefined,
     probationPeriodDays: club.probationPeriodDays ?? undefined,
+    // Beitragseinstellungen
+    proRataMode: (club.proRataMode as SettingsFormValues['proRataMode']) ?? undefined,
+    householdFeeMode:
+      (club.householdFeeMode as SettingsFormValues['householdFeeMode']) ?? undefined,
+    householdDiscountPercent: club.householdDiscountPercent ?? undefined,
+    householdFlatAmount: club.householdFlatAmount ?? undefined,
     // Sichtbarkeit
     visibility: club.visibility,
     // Logo & Avatar

--- a/apps/web/components/settings/club-settings-form.tsx
+++ b/apps/web/components/settings/club-settings-form.tsx
@@ -19,7 +19,6 @@ import { RegistrySection } from './sections/registry-section';
 import { TaxSection } from './sections/tax-section';
 import { BankSection } from './sections/bank-section';
 import { OperationalSection } from './sections/operational-section';
-import { BeitragsmodellSection } from './sections/beitragsmodell-section';
 import { VisibilitySection } from './sections/visibility-section';
 
 // ============================================================================
@@ -77,8 +76,6 @@ function clubToFormValues(club: ClubSettingsResponse): SettingsFormValues {
     probationPeriodDays: club.probationPeriodDays ?? undefined,
     // Beitragseinstellungen
     proRataMode: (club.proRataMode as SettingsFormValues['proRataMode']) ?? undefined,
-    householdBillingModel:
-      (club.householdBillingModel as SettingsFormValues['householdBillingModel']) ?? undefined,
     // Sichtbarkeit
     visibility: club.visibility,
     // Logo & Avatar
@@ -262,7 +259,6 @@ export function ClubSettingsForm({ club, slug }: ClubSettingsFormProps) {
           <TaxSection form={form} disabled={isSubmitting} />
           <BankSection form={form} disabled={isSubmitting} />
           <OperationalSection form={form} disabled={isSubmitting} />
-          <BeitragsmodellSection form={form} disabled={isSubmitting} slug={slug} />
           <VisibilitySection form={form} disabled={isSubmitting} />
         </div>
       </div>

--- a/apps/web/components/settings/club-settings-form.tsx
+++ b/apps/web/components/settings/club-settings-form.tsx
@@ -19,6 +19,7 @@ import { RegistrySection } from './sections/registry-section';
 import { TaxSection } from './sections/tax-section';
 import { BankSection } from './sections/bank-section';
 import { OperationalSection } from './sections/operational-section';
+import { BeitragsmodellSection } from './sections/beitragsmodell-section';
 import { VisibilitySection } from './sections/visibility-section';
 
 // ============================================================================
@@ -261,6 +262,7 @@ export function ClubSettingsForm({ club, slug }: ClubSettingsFormProps) {
           <TaxSection form={form} disabled={isSubmitting} />
           <BankSection form={form} disabled={isSubmitting} />
           <OperationalSection form={form} disabled={isSubmitting} />
+          <BeitragsmodellSection form={form} disabled={isSubmitting} slug={slug} />
           <VisibilitySection form={form} disabled={isSubmitting} />
         </div>
       </div>

--- a/apps/web/components/settings/club-settings-form.tsx
+++ b/apps/web/components/settings/club-settings-form.tsx
@@ -76,10 +76,8 @@ function clubToFormValues(club: ClubSettingsResponse): SettingsFormValues {
     probationPeriodDays: club.probationPeriodDays ?? undefined,
     // Beitragseinstellungen
     proRataMode: (club.proRataMode as SettingsFormValues['proRataMode']) ?? undefined,
-    householdFeeMode:
-      (club.householdFeeMode as SettingsFormValues['householdFeeMode']) ?? undefined,
-    householdDiscountPercent: club.householdDiscountPercent ?? undefined,
-    householdFlatAmount: club.householdFlatAmount ?? undefined,
+    householdBillingModel:
+      (club.householdBillingModel as SettingsFormValues['householdBillingModel']) ?? undefined,
     // Sichtbarkeit
     visibility: club.visibility,
     // Logo & Avatar

--- a/apps/web/components/settings/sections/beitragsmodell-section.tsx
+++ b/apps/web/components/settings/sections/beitragsmodell-section.tsx
@@ -28,7 +28,7 @@ const HOUSEHOLD_BILLING_OPTIONS = [
   },
   {
     value: 'FAMILY_PAYER',
-    label: 'Einer zahlt f\u00fcr alle',
+    label: 'Einer zahlt für alle',
     description:
       'Das Hauptmitglied zahlt einen Familien-Pauschalbeitrag, alle weiteren Mitglieder sind beitragsfrei.',
   },
@@ -52,9 +52,7 @@ export function BeitragsmodellSection({ form, disabled, slug }: BeitragsmodellSe
       <Card>
         <CardHeader>
           <CardTitle>Haushaltsbeitragsmodell</CardTitle>
-          <CardDescription>
-            Wie werden Beitr\u00e4ge f\u00fcr Haushaltsmitglieder berechnet?
-          </CardDescription>
+          <CardDescription>Wie werden Beiträge für Haushaltsmitglieder berechnet?</CardDescription>
         </CardHeader>
         <CardContent>
           <Controller
@@ -86,8 +84,8 @@ export function BeitragsmodellSection({ form, disabled, slug }: BeitragsmodellSe
             )}
           />
           <p className="mt-4 text-sm text-muted-foreground">
-            \u00c4nderung beeinflusst die automatische Beitragsart-Zuweisung f\u00fcr neue
-            Mitglieder und Haushaltswechsel. Bestehende Zuweisungen bleiben unver\u00e4ndert.
+            Änderung beeinflusst die automatische Beitragsart-Zuweisung für neue Mitglieder und
+            Haushaltswechsel. Bestehende Zuweisungen bleiben unverändert.
           </p>
         </CardContent>
       </Card>

--- a/apps/web/components/settings/sections/beitragsmodell-section.tsx
+++ b/apps/web/components/settings/sections/beitragsmodell-section.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { Controller, type UseFormReturn } from 'react-hook-form';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { FeeTypeList } from '@/components/fees/fee-type-list';
+import { CrossTableMatrix } from '@/components/fees/cross-table-matrix';
+import type { SettingsFormValues } from '../club-settings-form';
+
+interface BeitragsmodellSectionProps {
+  form: UseFormReturn<SettingsFormValues>;
+  disabled?: boolean;
+  slug: string;
+}
+
+const HOUSEHOLD_BILLING_OPTIONS = [
+  {
+    value: 'NONE',
+    label: 'Kein Rabatt',
+    description: 'Alle Mitglieder zahlen den Einzelbeitrag.',
+  },
+  {
+    value: 'REDUCED_MEMBERS',
+    label: 'Weitere Mitglieder reduziert',
+    description:
+      'Das Hauptmitglied zahlt voll, weitere Mitglieder zahlen einen reduzierten Beitrag.',
+  },
+  {
+    value: 'FAMILY_PAYER',
+    label: 'Einer zahlt f\u00fcr alle',
+    description:
+      'Das Hauptmitglied zahlt einen Familien-Pauschalbeitrag, alle weiteren Mitglieder sind beitragsfrei.',
+  },
+  {
+    value: 'ALL_REDUCED',
+    label: 'Alle im Haushalt reduziert',
+    description:
+      'Alle Haushaltsmitglieder (auch das Hauptmitglied) zahlen einen reduzierten Beitrag.',
+  },
+] as const;
+
+/**
+ * Beitragsmodell section in Settings.
+ * Combines HouseholdBillingModel RadioGroup (Surface 1), FeeType CRUD list (Surface 2),
+ * and cross-table matrix (Surface 3) per CONTEXT D-14.
+ */
+export function BeitragsmodellSection({ form, disabled, slug }: BeitragsmodellSectionProps) {
+  return (
+    <div className="space-y-6">
+      {/* Surface 1: HouseholdBillingModel RadioGroup */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Haushaltsbeitragsmodell</CardTitle>
+          <CardDescription>
+            Wie werden Beitr\u00e4ge f\u00fcr Haushaltsmitglieder berechnet?
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Controller
+            name="householdBillingModel"
+            control={form.control}
+            render={({ field }) => (
+              <RadioGroup
+                value={field.value ?? 'NONE'}
+                onValueChange={field.onChange}
+                disabled={disabled}
+                className="space-y-3"
+              >
+                {HOUSEHOLD_BILLING_OPTIONS.map((option) => (
+                  <div key={option.value} className="flex items-start space-x-3">
+                    <RadioGroupItem
+                      value={option.value}
+                      id={`hbm-${option.value}`}
+                      className="mt-1"
+                    />
+                    <div className="flex-1">
+                      <Label htmlFor={`hbm-${option.value}`} className="text-sm font-medium">
+                        {option.label}
+                      </Label>
+                      <p className="text-sm text-muted-foreground">{option.description}</p>
+                    </div>
+                  </div>
+                ))}
+              </RadioGroup>
+            )}
+          />
+          <p className="mt-4 text-sm text-muted-foreground">
+            \u00c4nderung beeinflusst die automatische Beitragsart-Zuweisung f\u00fcr neue
+            Mitglieder und Haushaltswechsel. Bestehende Zuweisungen bleiben unver\u00e4ndert.
+          </p>
+        </CardContent>
+      </Card>
+
+      {/* Surface 2: FeeType CRUD list */}
+      <FeeTypeList slug={slug} />
+
+      {/* Surface 3: Cross-table matrix */}
+      <CrossTableMatrix slug={slug} />
+    </div>
+  );
+}

--- a/apps/web/components/settings/sections/operational-section.tsx
+++ b/apps/web/components/settings/sections/operational-section.tsx
@@ -36,7 +36,8 @@ const MONTH_OPTIONS = [
 ] as const;
 
 /**
- * Betriebseinstellungen section: Geschäftsjahrbeginn, Standard-Mitgliedschaftstyp, Probezeitraum.
+ * Betriebseinstellungen section: Geschaeftsjahrbeginn, Standard-Mitgliedschaftstyp, Probezeitraum,
+ * and Beitragseinstellungen (proRataMode, householdFeeMode with conditional fields).
  */
 export function OperationalSection({ form, disabled }: OperationalSectionProps) {
   const params = useParams<{ slug: string }>();
@@ -45,93 +46,212 @@ export function OperationalSection({ form, disabled }: OperationalSectionProps) 
   const {
     register,
     control,
+    watch,
     formState: { errors },
   } = form;
 
+  const householdFeeMode = watch('householdFeeMode');
+
   return (
-    <Card id="section-defaults">
-      <CardHeader>
-        <CardTitle>Vereinsvorgaben</CardTitle>
-        <CardDescription>Standardwerte für Mitgliedschaften und Geschäftsjahr</CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        {/* Geschäftsjahrbeginn */}
-        <div className="space-y-1.5">
-          <Label htmlFor="settings-fiscalYearStartMonth">Geschäftsjahrbeginn</Label>
-          <Controller
-            name="fiscalYearStartMonth"
-            control={control}
-            render={({ field }) => (
-              <Select
-                value={field.value != null ? String(field.value) : undefined}
-                onValueChange={(val) => field.onChange(Number(val))}
-                disabled={disabled}
-              >
-                <SelectTrigger id="settings-fiscalYearStartMonth" className="w-full">
-                  <SelectValue placeholder="Monat wählen" />
-                </SelectTrigger>
-                <SelectContent>
-                  {MONTH_OPTIONS.map((month) => (
-                    <SelectItem key={month.value} value={month.value}>
-                      {month.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            )}
-          />
-        </div>
+    <>
+      <Card id="section-defaults">
+        <CardHeader>
+          <CardTitle>Vereinsvorgaben</CardTitle>
+          <CardDescription>Standardwerte fuer Mitgliedschaften und Geschaeftsjahr</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {/* Geschaeftsjahrbeginn */}
+          <div className="space-y-1.5">
+            <Label htmlFor="settings-fiscalYearStartMonth">Geschaeftsjahrbeginn</Label>
+            <Controller
+              name="fiscalYearStartMonth"
+              control={control}
+              render={({ field }) => (
+                <Select
+                  value={field.value != null ? String(field.value) : undefined}
+                  onValueChange={(val) => field.onChange(Number(val))}
+                  disabled={disabled}
+                >
+                  <SelectTrigger id="settings-fiscalYearStartMonth" className="w-full">
+                    <SelectValue placeholder="Monat waehlen" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {MONTH_OPTIONS.map((month) => (
+                      <SelectItem key={month.value} value={month.value}>
+                        {month.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            />
+          </div>
 
-        {/* Standard-Mitgliedschaftstyp */}
-        <div className="space-y-1.5">
-          <Label htmlFor="settings-defaultMembershipTypeId">Standard-Mitgliedschaftstyp</Label>
-          <Controller
-            name="defaultMembershipTypeId"
-            control={control}
-            render={({ field }) => (
-              <Select
-                value={field.value ?? undefined}
-                onValueChange={field.onChange}
-                disabled={disabled}
-              >
-                <SelectTrigger id="settings-defaultMembershipTypeId" className="w-full">
-                  <SelectValue placeholder="Typ wählen" />
-                </SelectTrigger>
-                <SelectContent>
-                  {(membershipTypes ?? []).map((type) => (
-                    <SelectItem key={type.id} value={type.id}>
-                      {type.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            )}
-          />
-        </div>
+          {/* Standard-Mitgliedschaftstyp */}
+          <div className="space-y-1.5">
+            <Label htmlFor="settings-defaultMembershipTypeId">Standard-Mitgliedschaftstyp</Label>
+            <Controller
+              name="defaultMembershipTypeId"
+              control={control}
+              render={({ field }) => (
+                <Select
+                  value={field.value ?? undefined}
+                  onValueChange={field.onChange}
+                  disabled={disabled}
+                >
+                  <SelectTrigger id="settings-defaultMembershipTypeId" className="w-full">
+                    <SelectValue placeholder="Typ waehlen" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {(membershipTypes ?? []).map((type) => (
+                      <SelectItem key={type.id} value={type.id}>
+                        {type.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            />
+          </div>
 
-        {/* Probezeitraum */}
-        <div className="space-y-1.5">
-          <Label htmlFor="settings-probationPeriodDays">Probezeitraum (Tage)</Label>
-          <Input
-            id="settings-probationPeriodDays"
-            type="number"
-            min={0}
-            max={365}
-            placeholder="0"
-            disabled={disabled}
-            {...register('probationPeriodDays', {
-              setValueAs: (v: string | number | undefined | null) => {
-                if (v === '' || v === undefined || v === null) return undefined;
-                const n = Number(v);
-                return Number.isNaN(n) ? undefined : n;
-              },
-            })}
-          />
-          {errors.probationPeriodDays?.message && (
-            <p className="text-xs text-destructive">{String(errors.probationPeriodDays.message)}</p>
+          {/* Probezeitraum */}
+          <div className="space-y-1.5">
+            <Label htmlFor="settings-probationPeriodDays">Probezeitraum (Tage)</Label>
+            <Input
+              id="settings-probationPeriodDays"
+              type="number"
+              min={0}
+              max={365}
+              placeholder="0"
+              disabled={disabled}
+              {...register('probationPeriodDays', {
+                setValueAs: (v: string | number | undefined | null) => {
+                  if (v === '' || v === undefined || v === null) return undefined;
+                  const n = Number(v);
+                  return Number.isNaN(n) ? undefined : n;
+                },
+              })}
+            />
+            {errors.probationPeriodDays?.message && (
+              <p className="text-xs text-destructive">
+                {String(errors.probationPeriodDays.message)}
+              </p>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card id="section-fees">
+        <CardHeader>
+          <CardTitle>Beitragseinstellungen</CardTitle>
+          <CardDescription>
+            Konfiguration fuer anteilige Berechnung und Haushaltsrabatte
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {/* Anteilige Berechnung (proRataMode) */}
+          <div className="space-y-1.5">
+            <Label htmlFor="settings-proRataMode">Anteilige Berechnung</Label>
+            <Controller
+              name="proRataMode"
+              control={control}
+              render={({ field }) => (
+                <Select
+                  value={field.value ?? undefined}
+                  onValueChange={field.onChange}
+                  disabled={disabled}
+                >
+                  <SelectTrigger id="settings-proRataMode" className="w-full">
+                    <SelectValue placeholder="Modus waehlen" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="FULL">Voller Beitrag</SelectItem>
+                    <SelectItem value="MONTHLY_PRO_RATA">Monatsanteilig</SelectItem>
+                  </SelectContent>
+                </Select>
+              )}
+            />
+            <p className="text-xs text-muted-foreground">
+              Bestimmt, ob bei unterjährigem Eintritt der volle Beitrag oder ein anteiliger Betrag
+              berechnet wird.
+            </p>
+          </div>
+
+          {/* Haushaltsbeitrag (householdFeeMode) */}
+          <div className="space-y-1.5">
+            <Label htmlFor="settings-householdFeeMode">Haushaltsbeitrag</Label>
+            <Controller
+              name="householdFeeMode"
+              control={control}
+              render={({ field }) => (
+                <Select
+                  value={field.value ?? undefined}
+                  onValueChange={field.onChange}
+                  disabled={disabled}
+                >
+                  <SelectTrigger id="settings-householdFeeMode" className="w-full">
+                    <SelectValue placeholder="Modus waehlen" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="NONE">Kein Rabatt</SelectItem>
+                    <SelectItem value="PERCENTAGE">Prozentual</SelectItem>
+                    <SelectItem value="FLAT">Pauschal</SelectItem>
+                  </SelectContent>
+                </Select>
+              )}
+            />
+            <p className="text-xs text-muted-foreground">
+              Rabatt fuer weitere Haushaltsmitglieder.
+            </p>
+          </div>
+
+          {/* Conditional: Rabatt (%) for PERCENTAGE mode */}
+          {householdFeeMode === 'PERCENTAGE' && (
+            <div className="space-y-1.5">
+              <Label htmlFor="settings-householdDiscountPercent">Rabatt (%)</Label>
+              <Input
+                id="settings-householdDiscountPercent"
+                type="number"
+                min={0}
+                max={100}
+                placeholder="z.B. 50"
+                disabled={disabled}
+                {...register('householdDiscountPercent', {
+                  setValueAs: (v: string | number | undefined | null) => {
+                    if (v === '' || v === undefined || v === null) return undefined;
+                    const n = Number(v);
+                    return Number.isNaN(n) ? undefined : n;
+                  },
+                })}
+              />
+              {errors.householdDiscountPercent?.message && (
+                <p className="text-xs text-destructive">
+                  {String(errors.householdDiscountPercent.message)}
+                </p>
+              )}
+            </div>
           )}
-        </div>
-      </CardContent>
-    </Card>
+
+          {/* Conditional: Pauschalbetrag (EUR) for FLAT mode */}
+          {householdFeeMode === 'FLAT' && (
+            <div className="space-y-1.5">
+              <Label htmlFor="settings-householdFlatAmount">Pauschalbetrag (EUR)</Label>
+              <Input
+                id="settings-householdFlatAmount"
+                placeholder="z.B. 50.00"
+                inputMode="decimal"
+                disabled={disabled}
+                {...register('householdFlatAmount')}
+              />
+              {errors.householdFlatAmount?.message && (
+                <p className="text-xs text-destructive">
+                  {String(errors.householdFlatAmount.message)}
+                </p>
+              )}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </>
   );
 }

--- a/apps/web/components/settings/sections/operational-section.tsx
+++ b/apps/web/components/settings/sections/operational-section.tsx
@@ -141,9 +141,7 @@ export function OperationalSection({ form, disabled }: OperationalSectionProps) 
       <Card id="section-fees">
         <CardHeader>
           <CardTitle>Beitragseinstellungen</CardTitle>
-          <CardDescription>
-            Konfiguration für anteilige Berechnung und Haushaltsrabatte
-          </CardDescription>
+          <CardDescription>Konfiguration für anteilige Berechnung</CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
           {/* Anteilige Berechnung (proRataMode) */}
@@ -159,7 +157,7 @@ export function OperationalSection({ form, disabled }: OperationalSectionProps) 
                   disabled={disabled}
                 >
                   <SelectTrigger id="settings-proRataMode" className="w-full">
-                    <SelectValue placeholder="Modus waehlen" />
+                    <SelectValue placeholder="Modus w\u00e4hlen" />
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="FULL">Voller Beitrag</SelectItem>
@@ -169,41 +167,8 @@ export function OperationalSection({ form, disabled }: OperationalSectionProps) 
               )}
             />
             <p className="text-xs text-muted-foreground">
-              Bestimmt, ob bei unterjährigem Eintritt der volle Beitrag oder ein anteiliger Betrag
-              berechnet wird.
-            </p>
-          </div>
-
-          {/* Haushalts-Abrechnungsmodell (householdBillingModel) */}
-          <div className="space-y-1.5">
-            <Label htmlFor="settings-householdBillingModel">Haushalts-Abrechnungsmodell</Label>
-            <Controller
-              name="householdBillingModel"
-              control={control}
-              render={({ field }) => (
-                <Select
-                  value={field.value ?? undefined}
-                  onValueChange={field.onChange}
-                  disabled={disabled}
-                >
-                  <SelectTrigger id="settings-householdBillingModel" className="w-full">
-                    <SelectValue placeholder="Modell wählen" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="NONE">Kein Haushaltsmodell</SelectItem>
-                    <SelectItem value="REDUCED_MEMBERS">
-                      Reduzierter Beitrag für weitere Mitglieder
-                    </SelectItem>
-                    <SelectItem value="FAMILY_PAYER">
-                      Familienzahler (Kopf zahlt, Rest beitragsfrei)
-                    </SelectItem>
-                    <SelectItem value="ALL_REDUCED">Alle Haushaltsmitglieder reduziert</SelectItem>
-                  </SelectContent>
-                </Select>
-              )}
-            />
-            <p className="text-xs text-muted-foreground">
-              Bestimmt, wie Beitragsarten für Haushaltsmitglieder vorgeschlagen werden.
+              Bestimmt, ob bei unterj\u00e4hrigem Eintritt der volle Beitrag oder ein anteiliger
+              Betrag berechnet wird.
             </p>
           </div>
         </CardContent>

--- a/apps/web/components/settings/sections/operational-section.tsx
+++ b/apps/web/components/settings/sections/operational-section.tsx
@@ -46,7 +46,6 @@ export function OperationalSection({ form, disabled }: OperationalSectionProps) 
   const {
     register,
     control,
-    watch,
     formState: { errors },
   } = form;
 
@@ -192,8 +191,12 @@ export function OperationalSection({ form, disabled }: OperationalSectionProps) 
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="NONE">Kein Haushaltsmodell</SelectItem>
-                    <SelectItem value="REDUCED_MEMBERS">Reduzierter Beitrag für weitere Mitglieder</SelectItem>
-                    <SelectItem value="FAMILY_PAYER">Familienzahler (Kopf zahlt, Rest beitragsfrei)</SelectItem>
+                    <SelectItem value="REDUCED_MEMBERS">
+                      Reduzierter Beitrag für weitere Mitglieder
+                    </SelectItem>
+                    <SelectItem value="FAMILY_PAYER">
+                      Familienzahler (Kopf zahlt, Rest beitragsfrei)
+                    </SelectItem>
                     <SelectItem value="ALL_REDUCED">Alle Haushaltsmitglieder reduziert</SelectItem>
                   </SelectContent>
                 </Select>

--- a/apps/web/components/settings/sections/operational-section.tsx
+++ b/apps/web/components/settings/sections/operational-section.tsx
@@ -23,7 +23,7 @@ interface OperationalSectionProps {
 const MONTH_OPTIONS = [
   { value: '1', label: 'Januar' },
   { value: '2', label: 'Februar' },
-  { value: '3', label: 'Maerz' },
+  { value: '3', label: 'März' },
   { value: '4', label: 'April' },
   { value: '5', label: 'Mai' },
   { value: '6', label: 'Juni' },
@@ -36,8 +36,8 @@ const MONTH_OPTIONS = [
 ] as const;
 
 /**
- * Betriebseinstellungen section: Geschaeftsjahrbeginn, Standard-Mitgliedschaftstyp, Probezeitraum,
- * and Beitragseinstellungen (proRataMode, householdFeeMode with conditional fields).
+ * Betriebseinstellungen section: Geschäftsjahrbeginn, Standard-Mitgliedschaftstyp, Probezeitraum,
+ * and Beitragseinstellungen (proRataMode, householdBillingModel).
  */
 export function OperationalSection({ form, disabled }: OperationalSectionProps) {
   const params = useParams<{ slug: string }>();
@@ -50,19 +50,17 @@ export function OperationalSection({ form, disabled }: OperationalSectionProps) 
     formState: { errors },
   } = form;
 
-  const householdFeeMode = watch('householdFeeMode');
-
   return (
     <>
       <Card id="section-defaults">
         <CardHeader>
           <CardTitle>Vereinsvorgaben</CardTitle>
-          <CardDescription>Standardwerte fuer Mitgliedschaften und Geschaeftsjahr</CardDescription>
+          <CardDescription>Standardwerte für Mitgliedschaften und Geschäftsjahr</CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
-          {/* Geschaeftsjahrbeginn */}
+          {/* Geschäftsjahrbeginn */}
           <div className="space-y-1.5">
-            <Label htmlFor="settings-fiscalYearStartMonth">Geschaeftsjahrbeginn</Label>
+            <Label htmlFor="settings-fiscalYearStartMonth">Geschäftsjahrbeginn</Label>
             <Controller
               name="fiscalYearStartMonth"
               control={control}
@@ -145,7 +143,7 @@ export function OperationalSection({ form, disabled }: OperationalSectionProps) 
         <CardHeader>
           <CardTitle>Beitragseinstellungen</CardTitle>
           <CardDescription>
-            Konfiguration fuer anteilige Berechnung und Haushaltsrabatte
+            Konfiguration für anteilige Berechnung und Haushaltsrabatte
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
@@ -177,11 +175,11 @@ export function OperationalSection({ form, disabled }: OperationalSectionProps) 
             </p>
           </div>
 
-          {/* Haushaltsbeitrag (householdFeeMode) */}
+          {/* Haushalts-Abrechnungsmodell (householdBillingModel) */}
           <div className="space-y-1.5">
-            <Label htmlFor="settings-householdFeeMode">Haushaltsbeitrag</Label>
+            <Label htmlFor="settings-householdBillingModel">Haushalts-Abrechnungsmodell</Label>
             <Controller
-              name="householdFeeMode"
+              name="householdBillingModel"
               control={control}
               render={({ field }) => (
                 <Select
@@ -189,67 +187,22 @@ export function OperationalSection({ form, disabled }: OperationalSectionProps) 
                   onValueChange={field.onChange}
                   disabled={disabled}
                 >
-                  <SelectTrigger id="settings-householdFeeMode" className="w-full">
-                    <SelectValue placeholder="Modus waehlen" />
+                  <SelectTrigger id="settings-householdBillingModel" className="w-full">
+                    <SelectValue placeholder="Modell wählen" />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="NONE">Kein Rabatt</SelectItem>
-                    <SelectItem value="PERCENTAGE">Prozentual</SelectItem>
-                    <SelectItem value="FLAT">Pauschal</SelectItem>
+                    <SelectItem value="NONE">Kein Haushaltsmodell</SelectItem>
+                    <SelectItem value="REDUCED_MEMBERS">Reduzierter Beitrag für weitere Mitglieder</SelectItem>
+                    <SelectItem value="FAMILY_PAYER">Familienzahler (Kopf zahlt, Rest beitragsfrei)</SelectItem>
+                    <SelectItem value="ALL_REDUCED">Alle Haushaltsmitglieder reduziert</SelectItem>
                   </SelectContent>
                 </Select>
               )}
             />
             <p className="text-xs text-muted-foreground">
-              Rabatt fuer weitere Haushaltsmitglieder.
+              Bestimmt, wie Beitragsarten für Haushaltsmitglieder vorgeschlagen werden.
             </p>
           </div>
-
-          {/* Conditional: Rabatt (%) for PERCENTAGE mode */}
-          {householdFeeMode === 'PERCENTAGE' && (
-            <div className="space-y-1.5">
-              <Label htmlFor="settings-householdDiscountPercent">Rabatt (%)</Label>
-              <Input
-                id="settings-householdDiscountPercent"
-                type="number"
-                min={0}
-                max={100}
-                placeholder="z.B. 50"
-                disabled={disabled}
-                {...register('householdDiscountPercent', {
-                  setValueAs: (v: string | number | undefined | null) => {
-                    if (v === '' || v === undefined || v === null) return undefined;
-                    const n = Number(v);
-                    return Number.isNaN(n) ? undefined : n;
-                  },
-                })}
-              />
-              {errors.householdDiscountPercent?.message && (
-                <p className="text-xs text-destructive">
-                  {String(errors.householdDiscountPercent.message)}
-                </p>
-              )}
-            </div>
-          )}
-
-          {/* Conditional: Pauschalbetrag (EUR) for FLAT mode */}
-          {householdFeeMode === 'FLAT' && (
-            <div className="space-y-1.5">
-              <Label htmlFor="settings-householdFlatAmount">Pauschalbetrag (EUR)</Label>
-              <Input
-                id="settings-householdFlatAmount"
-                placeholder="z.B. 50.00"
-                inputMode="decimal"
-                disabled={disabled}
-                {...register('householdFlatAmount')}
-              />
-              {errors.householdFlatAmount?.message && (
-                <p className="text-xs text-destructive">
-                  {String(errors.householdFlatAmount.message)}
-                </p>
-              )}
-            </div>
-          )}
         </CardContent>
       </Card>
     </>

--- a/apps/web/hooks/use-billing-run.ts
+++ b/apps/web/hooks/use-billing-run.ts
@@ -1,0 +1,100 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiFetch } from '@/lib/api';
+import { useToast } from '@/hooks/use-toast';
+import { feeChargeKeys } from '@/hooks/use-fee-charges';
+import type {
+  BillingRunPreview,
+  BillingRunPreviewResponse,
+  BillingRunConfirm,
+} from '@ktb/shared';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface BillingRunConfirmResponse {
+  chargesCreated: number;
+}
+
+// ============================================================================
+// Mutation Hooks
+// ============================================================================
+
+/**
+ * Preview a billing run (no side effects).
+ * Returns member counts, totals, exemptions, and breakdown.
+ */
+export function useBillingRunPreview(slug: string) {
+  const { toast } = useToast();
+
+  return useMutation<BillingRunPreviewResponse, Error, BillingRunPreview>({
+    mutationFn: async (data) => {
+      const res = await apiFetch(`/api/clubs/${slug}/fees/charges/billing-run/preview`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+
+      if (!res.ok) {
+        const error = await res.json().catch(() => ({}));
+        throw new Error(
+          error.message ||
+            'Die Beitragserhebung konnte nicht durchgefuehrt werden. Bitte versuche es erneut.'
+        );
+      }
+
+      return res.json();
+    },
+    onError: (error) => {
+      toast({
+        title:
+          'Die Beitragserhebung konnte nicht durchgefuehrt werden. Bitte versuche es erneut.',
+        variant: 'destructive',
+      });
+    },
+  });
+}
+
+/**
+ * Confirm a billing run (creates FeeCharge records).
+ * On success, invalidates fee charge queries and shows success toast.
+ */
+export function useBillingRunConfirm(slug: string) {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation<BillingRunConfirmResponse, Error, BillingRunConfirm>({
+    mutationFn: async (data) => {
+      const res = await apiFetch(`/api/clubs/${slug}/fees/charges/billing-run/confirm`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+
+      if (!res.ok) {
+        const error = await res.json().catch(() => ({}));
+        throw new Error(
+          error.message ||
+            'Die Beitragserhebung konnte nicht durchgefuehrt werden. Bitte versuche es erneut.'
+        );
+      }
+
+      return res.json();
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({
+        queryKey: feeChargeKeys.all(slug),
+      });
+      toast({
+        title: `Erhebung abgeschlossen -- ${data.chargesCreated} Forderungen erstellt`,
+      });
+    },
+    onError: () => {
+      toast({
+        title:
+          'Die Beitragserhebung konnte nicht durchgefuehrt werden. Bitte versuche es erneut.',
+        variant: 'destructive',
+      });
+    },
+  });
+}

--- a/apps/web/hooks/use-billing-run.ts
+++ b/apps/web/hooks/use-billing-run.ts
@@ -2,11 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiFetch } from '@/lib/api';
 import { useToast } from '@/hooks/use-toast';
 import { feeChargeKeys } from '@/hooks/use-fee-charges';
-import type {
-  BillingRunPreview,
-  BillingRunPreviewResponse,
-  BillingRunConfirm,
-} from '@ktb/shared';
+import type { BillingRunPreview, BillingRunPreviewResponse, BillingRunConfirm } from '@ktb/shared';
 
 // ============================================================================
 // Types
@@ -45,10 +41,9 @@ export function useBillingRunPreview(slug: string) {
 
       return res.json();
     },
-    onError: (error) => {
+    onError: () => {
       toast({
-        title:
-          'Die Beitragserhebung konnte nicht durchgefuehrt werden. Bitte versuche es erneut.',
+        title: 'Die Beitragserhebung konnte nicht durchgefuehrt werden. Bitte versuche es erneut.',
         variant: 'destructive',
       });
     },
@@ -91,8 +86,7 @@ export function useBillingRunConfirm(slug: string) {
     },
     onError: () => {
       toast({
-        title:
-          'Die Beitragserhebung konnte nicht durchgefuehrt werden. Bitte versuche es erneut.',
+        title: 'Die Beitragserhebung konnte nicht durchgefuehrt werden. Bitte versuche es erneut.',
         variant: 'destructive',
       });
     },

--- a/apps/web/hooks/use-billing-run.ts
+++ b/apps/web/hooks/use-billing-run.ts
@@ -35,7 +35,7 @@ export function useBillingRunPreview(slug: string) {
         const error = await res.json().catch(() => ({}));
         throw new Error(
           error.message ||
-            'Die Beitragserhebung konnte nicht durchgefuehrt werden. Bitte versuche es erneut.'
+            'Die Beitragserhebung konnte nicht durchgeführt werden. Bitte versuche es erneut.'
         );
       }
 
@@ -43,7 +43,7 @@ export function useBillingRunPreview(slug: string) {
     },
     onError: () => {
       toast({
-        title: 'Die Beitragserhebung konnte nicht durchgefuehrt werden. Bitte versuche es erneut.',
+        title: 'Die Beitragserhebung konnte nicht durchgeführt werden. Bitte versuche es erneut.',
         variant: 'destructive',
       });
     },
@@ -70,7 +70,7 @@ export function useBillingRunConfirm(slug: string) {
         const error = await res.json().catch(() => ({}));
         throw new Error(
           error.message ||
-            'Die Beitragserhebung konnte nicht durchgefuehrt werden. Bitte versuche es erneut.'
+            'Die Beitragserhebung konnte nicht durchgeführt werden. Bitte versuche es erneut.'
         );
       }
 
@@ -86,7 +86,7 @@ export function useBillingRunConfirm(slug: string) {
     },
     onError: () => {
       toast({
-        title: 'Die Beitragserhebung konnte nicht durchgefuehrt werden. Bitte versuche es erneut.',
+        title: 'Die Beitragserhebung konnte nicht durchgeführt werden. Bitte versuche es erneut.',
         variant: 'destructive',
       });
     },

--- a/apps/web/hooks/use-club-settings.ts
+++ b/apps/web/hooks/use-club-settings.ts
@@ -44,6 +44,11 @@ export interface ClubSettingsResponse {
   fiscalYearStartMonth?: number | null;
   defaultMembershipTypeId?: string | null;
   probationPeriodDays?: number | null;
+  // Beitragseinstellungen
+  proRataMode?: string | null;
+  householdFeeMode?: string | null;
+  householdDiscountPercent?: number | null;
+  householdFlatAmount?: string | null;
   // Logo
   logoFileId?: string | null;
   // Meta

--- a/apps/web/hooks/use-club-settings.ts
+++ b/apps/web/hooks/use-club-settings.ts
@@ -46,9 +46,7 @@ export interface ClubSettingsResponse {
   probationPeriodDays?: number | null;
   // Beitragseinstellungen
   proRataMode?: string | null;
-  householdFeeMode?: string | null;
-  householdDiscountPercent?: number | null;
-  householdFlatAmount?: string | null;
+  householdBillingModel?: string | null;
   // Logo
   logoFileId?: string | null;
   // Meta

--- a/apps/web/hooks/use-cross-table.ts
+++ b/apps/web/hooks/use-cross-table.ts
@@ -1,0 +1,109 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiFetch } from '@/lib/api';
+import { useToast } from '@/hooks/use-toast';
+import type { CrossTableEntryResponse, UpsertCrossTableEntry } from '@ktb/shared';
+
+// ============================================================================
+// Query Key Factory
+// ============================================================================
+
+export const crossTableKeys = {
+  all: (slug: string) => ['crossTable', slug] as const,
+  list: (slug: string) => [...crossTableKeys.all(slug), 'list'] as const,
+};
+
+// ============================================================================
+// Query Hooks
+// ============================================================================
+
+/**
+ * Fetch all cross-table entries for a club.
+ */
+export function useCrossTable(slug: string) {
+  return useQuery<CrossTableEntryResponse[]>({
+    queryKey: crossTableKeys.list(slug),
+    queryFn: async () => {
+      const res = await apiFetch(`/api/clubs/${slug}/fees/types/cross-table`);
+      if (!res.ok) {
+        throw new Error('Beitragstabelle konnte nicht geladen werden');
+      }
+      return res.json();
+    },
+    staleTime: 60_000,
+    enabled: !!slug,
+  });
+}
+
+// ============================================================================
+// Mutation Hooks
+// ============================================================================
+
+/**
+ * Upsert a cross-table entry (create or update an amount cell).
+ */
+export function useUpsertCrossTableEntry(slug: string) {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async (data: UpsertCrossTableEntry): Promise<CrossTableEntryResponse> => {
+      const res = await apiFetch(`/api/clubs/${slug}/fees/types/cross-table`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      if (!res.ok) {
+        const error = await res.json().catch(() => ({}));
+        throw new Error(error.message || 'Betrag konnte nicht gespeichert werden');
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: crossTableKeys.all(slug),
+      });
+      toast({ title: 'Betrag gespeichert' });
+    },
+    onError: (error) => {
+      toast({
+        title: 'Fehler',
+        description:
+          error instanceof Error ? error.message : 'Betrag konnte nicht gespeichert werden',
+        variant: 'destructive',
+      });
+    },
+  });
+}
+
+/**
+ * Delete a cross-table entry.
+ */
+export function useDeleteCrossTableEntry(slug: string) {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async (id: string): Promise<void> => {
+      const res = await apiFetch(`/api/clubs/${slug}/fees/types/cross-table/${id}`, {
+        method: 'DELETE',
+      });
+      if (!res.ok) {
+        const error = await res.json().catch(() => ({}));
+        throw new Error(error.message || 'Eintrag konnte nicht gel\u00f6scht werden');
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: crossTableKeys.all(slug),
+      });
+    },
+    onError: (error) => {
+      toast({
+        title: 'Fehler',
+        description:
+          error instanceof Error ? error.message : 'Eintrag konnte nicht gel\u00f6scht werden',
+        variant: 'destructive',
+      });
+    },
+  });
+}

--- a/apps/web/hooks/use-cross-table.ts
+++ b/apps/web/hooks/use-cross-table.ts
@@ -89,7 +89,7 @@ export function useDeleteCrossTableEntry(slug: string) {
       });
       if (!res.ok) {
         const error = await res.json().catch(() => ({}));
-        throw new Error(error.message || 'Eintrag konnte nicht gel\u00f6scht werden');
+        throw new Error(error.message || 'Eintrag konnte nicht gelöscht werden');
       }
     },
     onSuccess: () => {
@@ -101,7 +101,7 @@ export function useDeleteCrossTableEntry(slug: string) {
       toast({
         title: 'Fehler',
         description:
-          error instanceof Error ? error.message : 'Eintrag konnte nicht gel\u00f6scht werden',
+          error instanceof Error ? error.message : 'Eintrag konnte nicht gelöscht werden',
         variant: 'destructive',
       });
     },

--- a/apps/web/hooks/use-fee-categories.ts
+++ b/apps/web/hooks/use-fee-categories.ts
@@ -1,0 +1,160 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiFetch } from '@/lib/api';
+import { useToast } from '@/hooks/use-toast';
+import type { FeeCategoryResponse, CreateFeeCategory, UpdateFeeCategory } from '@ktb/shared';
+
+// ============================================================================
+// Query Key Factory
+// ============================================================================
+
+export const feeCategoryKeys = {
+  all: (slug: string) => ['feeCategories', slug] as const,
+  list: (slug: string) => [...feeCategoryKeys.all(slug), 'list'] as const,
+};
+
+// ============================================================================
+// Query Hooks
+// ============================================================================
+
+/**
+ * Fetch all fee categories for a club.
+ */
+export function useFeeCategories(slug: string) {
+  return useQuery<FeeCategoryResponse[]>({
+    queryKey: feeCategoryKeys.list(slug),
+    queryFn: async () => {
+      const res = await apiFetch(`/api/clubs/${slug}/fees/categories`);
+      if (!res.ok) {
+        throw new Error('Fehler beim Laden der Beitragsdaten. Bitte versuche es erneut.');
+      }
+      return res.json();
+    },
+    staleTime: 60_000, // 1 minute
+    enabled: !!slug,
+  });
+}
+
+// ============================================================================
+// Mutation Hooks
+// ============================================================================
+
+/**
+ * Create a new fee category.
+ */
+export function useCreateFeeCategory(slug: string) {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async (data: CreateFeeCategory): Promise<FeeCategoryResponse> => {
+      const res = await apiFetch(`/api/clubs/${slug}/fees/categories`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      if (!res.ok) {
+        const error = await res.json().catch(() => ({}));
+        throw new Error(
+          error.message ||
+            'Beitragskategorie konnte nicht erstellt werden. Bitte pruefe deine Eingaben.'
+        );
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: feeCategoryKeys.list(slug),
+      });
+      toast({ title: 'Beitragskategorie erstellt' });
+    },
+    onError: (error) => {
+      toast({
+        title: 'Fehler',
+        description:
+          error instanceof Error
+            ? error.message
+            : 'Beitragskategorie konnte nicht erstellt werden. Bitte pruefe deine Eingaben.',
+        variant: 'destructive',
+      });
+    },
+  });
+}
+
+/**
+ * Update an existing fee category.
+ */
+export function useUpdateFeeCategory(slug: string) {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async ({
+      id,
+      data,
+    }: {
+      id: string;
+      data: UpdateFeeCategory;
+    }): Promise<FeeCategoryResponse> => {
+      const res = await apiFetch(`/api/clubs/${slug}/fees/categories/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      if (!res.ok) {
+        const error = await res.json().catch(() => ({}));
+        throw new Error(error.message || 'Fehler beim Aktualisieren der Beitragskategorie');
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: feeCategoryKeys.list(slug),
+      });
+      toast({ title: 'Beitragskategorie aktualisiert' });
+    },
+    onError: (error) => {
+      toast({
+        title: 'Fehler',
+        description:
+          error instanceof Error
+            ? error.message
+            : 'Fehler beim Aktualisieren der Beitragskategorie',
+        variant: 'destructive',
+      });
+    },
+  });
+}
+
+/**
+ * Delete a fee category (soft delete).
+ */
+export function useDeleteFeeCategory(slug: string) {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async (id: string): Promise<void> => {
+      const res = await apiFetch(`/api/clubs/${slug}/fees/categories/${id}`, {
+        method: 'DELETE',
+      });
+      if (!res.ok) {
+        const error = await res.json().catch(() => ({}));
+        throw new Error(error.message || 'Fehler beim Loeschen der Beitragskategorie');
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: feeCategoryKeys.list(slug),
+      });
+      toast({ title: 'Beitragskategorie geloescht' });
+    },
+    onError: (error) => {
+      toast({
+        title: 'Fehler',
+        description:
+          error instanceof Error ? error.message : 'Fehler beim Loeschen der Beitragskategorie',
+        variant: 'destructive',
+      });
+    },
+  });
+}

--- a/apps/web/hooks/use-fee-categories.ts
+++ b/apps/web/hooks/use-fee-categories.ts
@@ -56,7 +56,7 @@ export function useCreateFeeCategory(slug: string) {
         const error = await res.json().catch(() => ({}));
         throw new Error(
           error.message ||
-            'Beitragskategorie konnte nicht erstellt werden. Bitte pruefe deine Eingaben.'
+            'Beitragskategorie konnte nicht erstellt werden. Bitte prüfe deine Eingaben.'
         );
       }
       return res.json();
@@ -73,7 +73,7 @@ export function useCreateFeeCategory(slug: string) {
         description:
           error instanceof Error
             ? error.message
-            : 'Beitragskategorie konnte nicht erstellt werden. Bitte pruefe deine Eingaben.',
+            : 'Beitragskategorie konnte nicht erstellt werden. Bitte prüfe deine Eingaben.',
         variant: 'destructive',
       });
     },
@@ -139,20 +139,20 @@ export function useDeleteFeeCategory(slug: string) {
       });
       if (!res.ok) {
         const error = await res.json().catch(() => ({}));
-        throw new Error(error.message || 'Fehler beim Loeschen der Beitragskategorie');
+        throw new Error(error.message || 'Fehler beim Löschen der Beitragskategorie');
       }
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: feeCategoryKeys.list(slug),
       });
-      toast({ title: 'Beitragskategorie geloescht' });
+      toast({ title: 'Beitragskategorie gelöscht' });
     },
     onError: (error) => {
       toast({
         title: 'Fehler',
         description:
-          error instanceof Error ? error.message : 'Fehler beim Loeschen der Beitragskategorie',
+          error instanceof Error ? error.message : 'Fehler beim Löschen der Beitragskategorie',
         variant: 'destructive',
       });
     },

--- a/apps/web/hooks/use-fee-charges.ts
+++ b/apps/web/hooks/use-fee-charges.ts
@@ -90,7 +90,8 @@ export function useMemberFeeCharges(slug: string, memberId: string) {
         throw new Error('Fehler beim Laden der Beitragsdaten');
       }
 
-      return res.json();
+      const json = await res.json();
+      return json.data as FeeChargeResponse[];
     },
     staleTime: 30_000,
     enabled: !!slug && !!memberId,

--- a/apps/web/hooks/use-fee-charges.ts
+++ b/apps/web/hooks/use-fee-charges.ts
@@ -1,4 +1,4 @@
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { apiFetch } from '@/lib/api';
 import { useToast } from '@/hooks/use-toast';
 import type { FeeChargeResponse, FeeChargeQuery } from '@ktb/shared';

--- a/apps/web/hooks/use-fee-charges.ts
+++ b/apps/web/hooks/use-fee-charges.ts
@@ -1,0 +1,98 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { apiFetch } from '@/lib/api';
+import { useToast } from '@/hooks/use-toast';
+import type { FeeChargeResponse, FeeChargeQuery } from '@ktb/shared';
+
+// ============================================================================
+// Query Key Factory
+// ============================================================================
+
+export const feeChargeKeys = {
+  all: (slug: string) => ['feeCharges', slug] as const,
+  list: (slug: string, filters?: FeeChargeFilters) =>
+    [...feeChargeKeys.all(slug), 'list', filters] as const,
+  member: (slug: string, memberId: string) =>
+    [...feeChargeKeys.all(slug), 'member', memberId] as const,
+};
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type FeeChargeFilters = Omit<FeeChargeQuery, 'page' | 'limit'> & {
+  page?: number;
+  limit?: number;
+};
+
+export interface FeeChargeListResponse {
+  data: FeeChargeResponse[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+// ============================================================================
+// Query Hooks
+// ============================================================================
+
+/**
+ * Fetch fee charges for a club with optional filters.
+ */
+export function useFeeCharges(slug: string, filters?: FeeChargeFilters) {
+  const { toast } = useToast();
+
+  return useQuery<FeeChargeListResponse>({
+    queryKey: feeChargeKeys.list(slug, filters),
+    queryFn: async () => {
+      const params = new URLSearchParams();
+      if (filters?.status) params.set('status', filters.status);
+      if (filters?.memberId) params.set('memberId', filters.memberId);
+      if (filters?.periodStart) params.set('periodStart', filters.periodStart);
+      if (filters?.periodEnd) params.set('periodEnd', filters.periodEnd);
+      if (filters?.page) params.set('page', String(filters.page));
+      if (filters?.limit) params.set('limit', String(filters.limit));
+
+      const query = params.toString();
+      const url = `/api/clubs/${slug}/fees/charges${query ? `?${query}` : ''}`;
+      const res = await apiFetch(url);
+
+      if (!res.ok) {
+        toast({
+          title: 'Fehler beim Laden der Beitragsdaten. Bitte versuche es erneut.',
+          variant: 'destructive',
+        });
+        throw new Error('Fehler beim Laden der Beitragsdaten');
+      }
+
+      return res.json();
+    },
+    staleTime: 30_000,
+    enabled: !!slug,
+  });
+}
+
+/**
+ * Fetch fee charges for a specific member.
+ */
+export function useMemberFeeCharges(slug: string, memberId: string) {
+  const { toast } = useToast();
+
+  return useQuery<FeeChargeResponse[]>({
+    queryKey: feeChargeKeys.member(slug, memberId),
+    queryFn: async () => {
+      const res = await apiFetch(`/api/clubs/${slug}/fees/charges/member/${memberId}`);
+
+      if (!res.ok) {
+        toast({
+          title: 'Fehler beim Laden der Beitragsdaten. Bitte versuche es erneut.',
+          variant: 'destructive',
+        });
+        throw new Error('Fehler beim Laden der Beitragsdaten');
+      }
+
+      return res.json();
+    },
+    staleTime: 30_000,
+    enabled: !!slug && !!memberId,
+  });
+}

--- a/apps/web/hooks/use-fee-overrides.ts
+++ b/apps/web/hooks/use-fee-overrides.ts
@@ -1,0 +1,146 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiFetch } from '@/lib/api';
+import { useToast } from '@/hooks/use-toast';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type FeeOverrideType = 'EXEMPT' | 'CUSTOM_AMOUNT' | 'ADDITIONAL';
+
+export interface FeeOverrideResponse {
+  id: string;
+  memberId: string;
+  feeCategoryId: string | null;
+  overrideType: FeeOverrideType;
+  customAmount: string | null;
+  reason: string | null;
+  isBaseFee: boolean;
+  feeCategory: {
+    id: string;
+    name: string;
+    amount: string;
+  } | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateFeeOverrideInput {
+  memberId: string;
+  feeCategoryId?: string;
+  overrideType: FeeOverrideType;
+  customAmount?: string;
+  reason?: string;
+  isBaseFee?: boolean;
+}
+
+// ============================================================================
+// Query Key Factory
+// ============================================================================
+
+export const feeOverrideKeys = {
+  all: (slug: string) => ['feeOverrides', slug] as const,
+  member: (slug: string, memberId: string) =>
+    [...feeOverrideKeys.all(slug), 'member', memberId] as const,
+};
+
+// ============================================================================
+// Query Hooks
+// ============================================================================
+
+/**
+ * Fetch all fee overrides for a specific member.
+ */
+export function useFeeOverrides(slug: string, memberId: string) {
+  return useQuery<FeeOverrideResponse[]>({
+    queryKey: feeOverrideKeys.member(slug, memberId),
+    queryFn: async () => {
+      const res = await apiFetch(`/api/clubs/${slug}/fees/overrides/member/${memberId}`);
+      if (!res.ok) {
+        throw new Error('Fehler beim Laden der Beitragsanpassungen');
+      }
+      return res.json();
+    },
+    staleTime: 60_000,
+    enabled: !!slug && !!memberId,
+  });
+}
+
+// ============================================================================
+// Mutation Hooks
+// ============================================================================
+
+/**
+ * Create a new fee override for a member.
+ */
+export function useCreateFeeOverride(slug: string) {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async (data: CreateFeeOverrideInput): Promise<FeeOverrideResponse> => {
+      const res = await apiFetch(`/api/clubs/${slug}/fees/overrides`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      if (!res.ok) {
+        const error = await res.json().catch(() => ({}));
+        throw new Error(
+          error.message || 'Beitragsanpassung konnte nicht erstellt werden. Bitte pruefe deine Eingaben.'
+        );
+      }
+      return res.json();
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: feeOverrideKeys.member(slug, variables.memberId),
+      });
+      toast({ title: 'Beitragsanpassung gespeichert' });
+    },
+    onError: (error) => {
+      toast({
+        title: 'Fehler',
+        description:
+          error instanceof Error
+            ? error.message
+            : 'Beitragsanpassung konnte nicht erstellt werden. Bitte pruefe deine Eingaben.',
+        variant: 'destructive',
+      });
+    },
+  });
+}
+
+/**
+ * Delete a fee override.
+ */
+export function useDeleteFeeOverride(slug: string) {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async (id: string): Promise<void> => {
+      const res = await apiFetch(`/api/clubs/${slug}/fees/overrides/${id}`, {
+        method: 'DELETE',
+      });
+      if (!res.ok) {
+        const error = await res.json().catch(() => ({}));
+        throw new Error(error.message || 'Fehler beim Entfernen der Beitragsanpassung');
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: feeOverrideKeys.all(slug),
+      });
+      toast({ title: 'Beitragsanpassung entfernt' });
+    },
+    onError: (error) => {
+      toast({
+        title: 'Fehler',
+        description:
+          error instanceof Error ? error.message : 'Fehler beim Entfernen der Beitragsanpassung',
+        variant: 'destructive',
+      });
+    },
+  });
+}

--- a/apps/web/hooks/use-fee-overrides.ts
+++ b/apps/web/hooks/use-fee-overrides.ts
@@ -87,7 +87,8 @@ export function useCreateFeeOverride(slug: string) {
       if (!res.ok) {
         const error = await res.json().catch(() => ({}));
         throw new Error(
-          error.message || 'Beitragsanpassung konnte nicht erstellt werden. Bitte pruefe deine Eingaben.'
+          error.message ||
+            'Beitragsanpassung konnte nicht erstellt werden. Bitte pruefe deine Eingaben.'
         );
       }
       return res.json();

--- a/apps/web/hooks/use-fee-overrides.ts
+++ b/apps/web/hooks/use-fee-overrides.ts
@@ -88,7 +88,7 @@ export function useCreateFeeOverride(slug: string) {
         const error = await res.json().catch(() => ({}));
         throw new Error(
           error.message ||
-            'Beitragsanpassung konnte nicht erstellt werden. Bitte pruefe deine Eingaben.'
+            'Beitragsanpassung konnte nicht erstellt werden. Bitte prüfe deine Eingaben.'
         );
       }
       return res.json();
@@ -105,7 +105,7 @@ export function useCreateFeeOverride(slug: string) {
         description:
           error instanceof Error
             ? error.message
-            : 'Beitragsanpassung konnte nicht erstellt werden. Bitte pruefe deine Eingaben.',
+            : 'Beitragsanpassung konnte nicht erstellt werden. Bitte prüfe deine Eingaben.',
         variant: 'destructive',
       });
     },

--- a/apps/web/hooks/use-fee-types.ts
+++ b/apps/web/hooks/use-fee-types.ts
@@ -55,7 +55,8 @@ export function useCreateFeeType(slug: string) {
       if (!res.ok) {
         const error = await res.json().catch(() => ({}));
         throw new Error(
-          error.message || 'Beitragsart konnte nicht erstellt werden. Bitte pr\u00fcfe deine Eingaben.'
+          error.message ||
+            'Beitragsart konnte nicht erstellt werden. Bitte pr\u00fcfe deine Eingaben.'
         );
       }
       return res.json();
@@ -115,9 +116,7 @@ export function useUpdateFeeType(slug: string) {
       toast({
         title: 'Fehler',
         description:
-          error instanceof Error
-            ? error.message
-            : 'Fehler beim Aktualisieren der Beitragsart',
+          error instanceof Error ? error.message : 'Fehler beim Aktualisieren der Beitragsart',
         variant: 'destructive',
       });
     },

--- a/apps/web/hooks/use-fee-types.ts
+++ b/apps/web/hooks/use-fee-types.ts
@@ -1,0 +1,159 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiFetch } from '@/lib/api';
+import { useToast } from '@/hooks/use-toast';
+import type { FeeTypeResponse, CreateFeeType, UpdateFeeType } from '@ktb/shared';
+
+// ============================================================================
+// Query Key Factory
+// ============================================================================
+
+export const feeTypeKeys = {
+  all: (slug: string) => ['feeTypes', slug] as const,
+  list: (slug: string) => [...feeTypeKeys.all(slug), 'list'] as const,
+};
+
+// ============================================================================
+// Query Hooks
+// ============================================================================
+
+/**
+ * Fetch all fee types for a club.
+ */
+export function useFeeTypes(slug: string) {
+  return useQuery<FeeTypeResponse[]>({
+    queryKey: feeTypeKeys.list(slug),
+    queryFn: async () => {
+      const res = await apiFetch(`/api/clubs/${slug}/fees/types`);
+      if (!res.ok) {
+        throw new Error('Beitragsarten konnten nicht geladen werden');
+      }
+      return res.json();
+    },
+    staleTime: 60_000,
+    enabled: !!slug,
+  });
+}
+
+// ============================================================================
+// Mutation Hooks
+// ============================================================================
+
+/**
+ * Create a new fee type.
+ */
+export function useCreateFeeType(slug: string) {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async (data: CreateFeeType): Promise<FeeTypeResponse> => {
+      const res = await apiFetch(`/api/clubs/${slug}/fees/types`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      if (!res.ok) {
+        const error = await res.json().catch(() => ({}));
+        throw new Error(
+          error.message || 'Beitragsart konnte nicht erstellt werden. Bitte pr\u00fcfe deine Eingaben.'
+        );
+      }
+      return res.json();
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({
+        queryKey: feeTypeKeys.list(slug),
+      });
+      toast({ title: `Beitragsart "${data.name}" erstellt` });
+    },
+    onError: (error) => {
+      toast({
+        title: 'Fehler',
+        description:
+          error instanceof Error
+            ? error.message
+            : 'Beitragsart konnte nicht erstellt werden. Bitte pr\u00fcfe deine Eingaben.',
+        variant: 'destructive',
+      });
+    },
+  });
+}
+
+/**
+ * Update an existing fee type.
+ */
+export function useUpdateFeeType(slug: string) {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async ({
+      id,
+      data,
+    }: {
+      id: string;
+      data: UpdateFeeType;
+    }): Promise<FeeTypeResponse> => {
+      const res = await apiFetch(`/api/clubs/${slug}/fees/types/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      if (!res.ok) {
+        const error = await res.json().catch(() => ({}));
+        throw new Error(error.message || 'Fehler beim Aktualisieren der Beitragsart');
+      }
+      return res.json();
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({
+        queryKey: feeTypeKeys.list(slug),
+      });
+      toast({ title: `Beitragsart "${data.name}" aktualisiert` });
+    },
+    onError: (error) => {
+      toast({
+        title: 'Fehler',
+        description:
+          error instanceof Error
+            ? error.message
+            : 'Fehler beim Aktualisieren der Beitragsart',
+        variant: 'destructive',
+      });
+    },
+  });
+}
+
+/**
+ * Delete a fee type (soft delete).
+ */
+export function useDeleteFeeType(slug: string) {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async (id: string): Promise<void> => {
+      const res = await apiFetch(`/api/clubs/${slug}/fees/types/${id}`, {
+        method: 'DELETE',
+      });
+      if (!res.ok) {
+        const error = await res.json().catch(() => ({}));
+        throw new Error(error.message || 'Fehler beim L\u00f6schen der Beitragsart');
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: feeTypeKeys.list(slug),
+      });
+      toast({ title: 'Beitragsart gel\u00f6scht' });
+    },
+    onError: (error) => {
+      toast({
+        title: 'Fehler',
+        description:
+          error instanceof Error ? error.message : 'Fehler beim L\u00f6schen der Beitragsart',
+        variant: 'destructive',
+      });
+    },
+  });
+}

--- a/apps/web/hooks/use-fee-types.ts
+++ b/apps/web/hooks/use-fee-types.ts
@@ -55,8 +55,7 @@ export function useCreateFeeType(slug: string) {
       if (!res.ok) {
         const error = await res.json().catch(() => ({}));
         throw new Error(
-          error.message ||
-            'Beitragsart konnte nicht erstellt werden. Bitte pr\u00fcfe deine Eingaben.'
+          error.message || 'Beitragsart konnte nicht erstellt werden. Bitte prüfe deine Eingaben.'
         );
       }
       return res.json();
@@ -73,7 +72,7 @@ export function useCreateFeeType(slug: string) {
         description:
           error instanceof Error
             ? error.message
-            : 'Beitragsart konnte nicht erstellt werden. Bitte pr\u00fcfe deine Eingaben.',
+            : 'Beitragsart konnte nicht erstellt werden. Bitte prüfe deine Eingaben.',
         variant: 'destructive',
       });
     },
@@ -137,20 +136,19 @@ export function useDeleteFeeType(slug: string) {
       });
       if (!res.ok) {
         const error = await res.json().catch(() => ({}));
-        throw new Error(error.message || 'Fehler beim L\u00f6schen der Beitragsart');
+        throw new Error(error.message || 'Fehler beim Löschen der Beitragsart');
       }
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: feeTypeKeys.list(slug),
       });
-      toast({ title: 'Beitragsart gel\u00f6scht' });
+      toast({ title: 'Beitragsart gelöscht' });
     },
     onError: (error) => {
       toast({
         title: 'Fehler',
-        description:
-          error instanceof Error ? error.message : 'Fehler beim L\u00f6schen der Beitragsart',
+        description: error instanceof Error ? error.message : 'Fehler beim Löschen der Beitragsart',
         variant: 'destructive',
       });
     },

--- a/apps/web/hooks/use-member-detail.ts
+++ b/apps/web/hooks/use-member-detail.ts
@@ -45,6 +45,7 @@ interface MemberDetail {
   userImage: string | null;
   householdId: string | null;
   householdRole: string | null;
+  feeTypeId: string | null;
   household: {
     id: string;
     name: string;

--- a/apps/web/hooks/use-payments.ts
+++ b/apps/web/hooks/use-payments.ts
@@ -1,0 +1,128 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiFetch } from '@/lib/api';
+import { useToast } from '@/hooks/use-toast';
+import { feeChargeKeys } from '@/hooks/use-fee-charges';
+import type { PaymentResponse, RecordPayment } from '@ktb/shared';
+
+// ============================================================================
+// Query Key Factory
+// ============================================================================
+
+export const paymentKeys = {
+  all: (slug: string) => ['payments', slug] as const,
+  forCharge: (slug: string, chargeId: string) =>
+    [...paymentKeys.all(slug), 'charge', chargeId] as const,
+};
+
+// ============================================================================
+// Query Hooks
+// ============================================================================
+
+/**
+ * Fetch payments for a specific fee charge.
+ */
+export function usePaymentsForCharge(slug: string, chargeId: string) {
+  return useQuery<PaymentResponse[]>({
+    queryKey: paymentKeys.forCharge(slug, chargeId),
+    queryFn: async () => {
+      const res = await apiFetch(`/api/clubs/${slug}/fees/payments/charge/${chargeId}`);
+
+      if (!res.ok) {
+        throw new Error('Fehler beim Laden der Zahlungsdaten');
+      }
+
+      return res.json();
+    },
+    staleTime: 30_000,
+    enabled: !!slug && !!chargeId,
+  });
+}
+
+// ============================================================================
+// Mutation Hooks
+// ============================================================================
+
+/**
+ * Record a manual payment against a fee charge.
+ * On success, invalidates both payment and fee charge queries.
+ */
+export function useRecordPayment(slug: string) {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation<PaymentResponse, Error, RecordPayment>({
+    mutationFn: async (data) => {
+      const res = await apiFetch(`/api/clubs/${slug}/fees/payments`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+
+      if (!res.ok) {
+        const error = await res.json().catch(() => ({}));
+        throw new Error(
+          error.message ||
+            'Zahlung konnte nicht erfasst werden. Bitte versuche es erneut.'
+        );
+      }
+
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: paymentKeys.all(slug),
+      });
+      queryClient.invalidateQueries({
+        queryKey: feeChargeKeys.all(slug),
+      });
+      toast({
+        title: 'Zahlung erfasst',
+      });
+    },
+    onError: () => {
+      toast({
+        title: 'Zahlung konnte nicht erfasst werden. Bitte versuche es erneut.',
+        variant: 'destructive',
+      });
+    },
+  });
+}
+
+/**
+ * Delete a payment (soft delete).
+ * On success, invalidates both payment and fee charge queries.
+ */
+export function useDeletePayment(slug: string) {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation<void, Error, string>({
+    mutationFn: async (paymentId) => {
+      const res = await apiFetch(`/api/clubs/${slug}/fees/payments/${paymentId}`, {
+        method: 'DELETE',
+      });
+
+      if (!res.ok) {
+        const error = await res.json().catch(() => ({}));
+        throw new Error(error.message || 'Zahlung konnte nicht geloescht werden');
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: paymentKeys.all(slug),
+      });
+      queryClient.invalidateQueries({
+        queryKey: feeChargeKeys.all(slug),
+      });
+      toast({
+        title: 'Zahlung geloescht',
+      });
+    },
+    onError: () => {
+      toast({
+        title: 'Zahlung konnte nicht geloescht werden. Bitte versuche es erneut.',
+        variant: 'destructive',
+      });
+    },
+  });
+}

--- a/apps/web/hooks/use-payments.ts
+++ b/apps/web/hooks/use-payments.ts
@@ -61,8 +61,7 @@ export function useRecordPayment(slug: string) {
       if (!res.ok) {
         const error = await res.json().catch(() => ({}));
         throw new Error(
-          error.message ||
-            'Zahlung konnte nicht erfasst werden. Bitte versuche es erneut.'
+          error.message || 'Zahlung konnte nicht erfasst werden. Bitte versuche es erneut.'
         );
       }
 

--- a/apps/web/hooks/use-payments.ts
+++ b/apps/web/hooks/use-payments.ts
@@ -103,7 +103,7 @@ export function useDeletePayment(slug: string) {
 
       if (!res.ok) {
         const error = await res.json().catch(() => ({}));
-        throw new Error(error.message || 'Zahlung konnte nicht geloescht werden');
+        throw new Error(error.message || 'Zahlung konnte nicht gelöscht werden');
       }
     },
     onSuccess: () => {
@@ -114,12 +114,12 @@ export function useDeletePayment(slug: string) {
         queryKey: feeChargeKeys.all(slug),
       });
       toast({
-        title: 'Zahlung geloescht',
+        title: 'Zahlung gelöscht',
       });
     },
     onError: () => {
       toast({
-        title: 'Zahlung konnte nicht geloescht werden. Bitte versuche es erneut.',
+        title: 'Zahlung konnte nicht gelöscht werden. Bitte versuche es erneut.',
         variant: 'destructive',
       });
     },

--- a/apps/web/lib/breadcrumb-config.ts
+++ b/apps/web/lib/breadcrumb-config.ts
@@ -12,6 +12,7 @@ const segmentLabels: Record<string, string> = {
   // Settings sub-pages
   users: 'Benutzer',
   'number-ranges': 'Nummernkreise',
+  'fee-model': 'Beiträge',
   clubs: 'Vereine',
   tiers: 'Tarife',
   invites: 'Einladungen',

--- a/apps/web/lib/format-money.ts
+++ b/apps/web/lib/format-money.ts
@@ -1,0 +1,20 @@
+/**
+ * German locale money formatting utilities.
+ *
+ * moneyFormatter — Intl.NumberFormat instance for German locale (1.234,56)
+ * formatMoney    — Formats a decimal string as "1.234,56 EUR"
+ * formatMoneyValue — Formats a number as "1.234,56" (no currency suffix)
+ */
+
+export const moneyFormatter = new Intl.NumberFormat('de-DE', {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+export function formatMoney(value: string): string {
+  return `${moneyFormatter.format(parseFloat(value))} EUR`;
+}
+
+export function formatMoneyValue(value: number): string {
+  return moneyFormatter.format(value);
+}

--- a/apps/web/lib/iban-utils.test.ts
+++ b/apps/web/lib/iban-utils.test.ts
@@ -67,14 +67,14 @@ describe('validateAndLookupIBAN', () => {
     const result = validateAndLookupIBAN('DE00370400440532013000');
 
     expect(result.valid).toBe(false);
-    expect(result.error).toBe('Ungueltige IBAN');
+    expect(result.error).toBe('Ungültige IBAN');
   });
 
   it('should reject a malformed IBAN', () => {
     const result = validateAndLookupIBAN('INVALIDIBAN12345');
 
     expect(result.valid).toBe(false);
-    expect(result.error).toBe('Ungueltige IBAN');
+    expect(result.error).toBe('Ungültige IBAN');
   });
 });
 

--- a/apps/web/lib/iban-utils.ts
+++ b/apps/web/lib/iban-utils.ts
@@ -30,7 +30,7 @@ export function validateAndLookupIBAN(ibanInput: string): IBANValidationResult {
   if (!validation.valid) {
     return {
       valid: false,
-      error: 'Ungueltige IBAN',
+      error: 'Ungültige IBAN',
       bankName: null,
       bic: null,
       electronic,

--- a/packages/shared/src/schemas/billing-run.ts
+++ b/packages/shared/src/schemas/billing-run.ts
@@ -1,0 +1,63 @@
+import { z } from 'zod';
+
+import { BillingIntervalEnum } from './fee-category.ts';
+
+/**
+ * Schema for billing run preview request.
+ * Treasurer selects period and interval to see what would be generated.
+ */
+export const BillingRunPreviewSchema = z.object({
+  /** Start of the billing period (ISO date string) */
+  periodStart: z.string().date(),
+
+  /** End of the billing period (ISO date string) */
+  periodEnd: z.string().date(),
+
+  /** Billing interval to generate charges for */
+  billingInterval: BillingIntervalEnum,
+});
+
+export type BillingRunPreview = z.infer<typeof BillingRunPreviewSchema>;
+
+/**
+ * Response schema for billing run preview.
+ * Shows what would be generated without creating anything.
+ */
+export const BillingRunPreviewResponseSchema = z.object({
+  /** Number of members that would receive charges */
+  memberCount: z.number(),
+
+  /** Total amount of all charges (decimal string) */
+  totalAmount: z.string(),
+
+  /** Number of members exempt from this billing */
+  exemptions: z.number(),
+
+  /** Breakdown by membership type */
+  breakdown: z.array(
+    z.object({
+      /** Membership type name */
+      membershipType: z.string(),
+      /** Number of members in this type */
+      count: z.number(),
+      /** Subtotal for this type (decimal string) */
+      subtotal: z.string(),
+    })
+  ),
+
+  /** Number of existing charges for this period (duplicate warning) */
+  existingCharges: z.number(),
+});
+
+export type BillingRunPreviewResponse = z.infer<typeof BillingRunPreviewResponseSchema>;
+
+/**
+ * Schema for confirming a billing run (creates FeeCharge records).
+ * Same fields as preview plus due date.
+ */
+export const BillingRunConfirmSchema = BillingRunPreviewSchema.extend({
+  /** Due date for all generated charges (ISO date string) */
+  dueDate: z.string().date(),
+});
+
+export type BillingRunConfirm = z.infer<typeof BillingRunConfirmSchema>;

--- a/packages/shared/src/schemas/billing-run.ts
+++ b/packages/shared/src/schemas/billing-run.ts
@@ -36,10 +36,12 @@ export const BillingRunPreviewResponseSchema = z.object({
   /** Number of members exempt from this billing */
   exemptions: z.number(),
 
-  /** Breakdown by membership type */
+  /** Breakdown by membership type or category */
   breakdown: z.array(
     z.object({
-      /** Membership type name */
+      /** Distinguishes base-fee rows from category rows so identically named entries do not merge */
+      kind: z.enum(['membershipType', 'category']),
+      /** Display name: membership type name for base fees, category name for category rows */
       membershipType: z.string(),
       /** Number of members in this type */
       count: z.number(),

--- a/packages/shared/src/schemas/billing-run.ts
+++ b/packages/shared/src/schemas/billing-run.ts
@@ -27,6 +27,9 @@ export const BillingRunPreviewResponseSchema = z.object({
   /** Number of members that would receive charges */
   memberCount: z.number(),
 
+  /** Total number of charges that would be created */
+  chargeCount: z.number(),
+
   /** Total amount of all charges (decimal string) */
   totalAmount: z.string(),
 
@@ -47,6 +50,18 @@ export const BillingRunPreviewResponseSchema = z.object({
 
   /** Number of existing charges for this period (duplicate warning) */
   existingCharges: z.number(),
+
+  /** Warnings for members excluded from billing (e.g., no feeTypeId assigned) */
+  warnings: z
+    .array(
+      z.object({
+        memberId: z.string(),
+        memberName: z.string(),
+        reason: z.string(),
+      })
+    )
+    .optional()
+    .default([]),
 });
 
 export type BillingRunPreviewResponse = z.infer<typeof BillingRunPreviewResponseSchema>;

--- a/packages/shared/src/schemas/club-settings.ts
+++ b/packages/shared/src/schemas/club-settings.ts
@@ -27,6 +27,20 @@ export const ClubVisibilitySchema = z.enum(['PUBLIC', 'PRIVATE']);
 export type ClubVisibility = z.infer<typeof ClubVisibilitySchema>;
 
 /**
+ * Pro-rata mode for mid-period membership joins.
+ * Must match Prisma ProRataMode enum exactly.
+ */
+export const ProRataModeSchema = z.enum(['FULL', 'MONTHLY_PRO_RATA']);
+export type ProRataMode = z.infer<typeof ProRataModeSchema>;
+
+/**
+ * Household fee discount mode.
+ * Must match Prisma HouseholdFeeMode enum exactly.
+ */
+export const HouseholdFeeModeSchema = z.enum(['NONE', 'PERCENTAGE', 'FLAT']);
+export type HouseholdFeeMode = z.infer<typeof HouseholdFeeModeSchema>;
+
+/**
  * Schema for updating club settings (PATCH semantics).
  * All fields optional — only provided fields are updated.
  * Uses `.optional().nullable()` for clearable fields and `.optional()` for booleans/enums with defaults.
@@ -74,6 +88,12 @@ export const UpdateClubSettingsSchema = z.object({
     .union([z.nan().transform(() => null), z.number().int().min(0).max(365)])
     .optional()
     .nullable(),
+
+  // Beitragseinstellungen (Fee Settings)
+  proRataMode: ProRataModeSchema.optional(),
+  householdFeeMode: HouseholdFeeModeSchema.optional(),
+  householdDiscountPercent: z.number().int().min(0).max(100).optional().nullable(),
+  householdFlatAmount: z.string().optional().nullable(),
 
   // Sichtbarkeit
   visibility: ClubVisibilitySchema.optional(),

--- a/packages/shared/src/schemas/club-settings.ts
+++ b/packages/shared/src/schemas/club-settings.ts
@@ -34,11 +34,16 @@ export const ProRataModeSchema = z.enum(['FULL', 'MONTHLY_PRO_RATA']);
 export type ProRataMode = z.infer<typeof ProRataModeSchema>;
 
 /**
- * Household fee discount mode.
- * Must match Prisma HouseholdFeeMode enum exactly.
+ * Household billing model (determines FeeType auto-suggestion rules).
+ * Must match Prisma HouseholdBillingModel enum exactly.
  */
-export const HouseholdFeeModeSchema = z.enum(['NONE', 'PERCENTAGE', 'FLAT']);
-export type HouseholdFeeMode = z.infer<typeof HouseholdFeeModeSchema>;
+export const HouseholdBillingModelSchema = z.enum([
+  'NONE',
+  'REDUCED_MEMBERS',
+  'FAMILY_PAYER',
+  'ALL_REDUCED',
+]);
+export type HouseholdBillingModel = z.infer<typeof HouseholdBillingModelSchema>;
 
 /**
  * Schema for updating club settings (PATCH semantics).
@@ -91,9 +96,7 @@ export const UpdateClubSettingsSchema = z.object({
 
   // Beitragseinstellungen (Fee Settings)
   proRataMode: ProRataModeSchema.optional(),
-  householdFeeMode: HouseholdFeeModeSchema.optional(),
-  householdDiscountPercent: z.number().int().min(0).max(100).optional().nullable(),
-  householdFlatAmount: z.string().optional().nullable(),
+  householdBillingModel: HouseholdBillingModelSchema.optional(),
 
   // Sichtbarkeit
   visibility: ClubVisibilitySchema.optional(),

--- a/packages/shared/src/schemas/fee-category.ts
+++ b/packages/shared/src/schemas/fee-category.ts
@@ -1,0 +1,68 @@
+import { z } from 'zod';
+
+/**
+ * Available billing intervals for fee categories.
+ */
+export const BillingIntervalEnum = z.enum(['MONTHLY', 'QUARTERLY', 'ANNUALLY']);
+export type BillingInterval = z.infer<typeof BillingIntervalEnum>;
+
+/**
+ * Regex for validating decimal amounts (e.g., "12.50", "0.00", "1000.99").
+ */
+const DECIMAL_REGEX = /^\d+(\.\d{1,2})?$/;
+
+/**
+ * Schema for creating a new fee category (club-scoped entity).
+ * Additional fee categories beyond the base MembershipType fee.
+ */
+export const CreateFeeCategorySchema = z.object({
+  /** Category name (e.g., "Aufnahmegebuehr", "Tennisabteilung") */
+  name: z.string().min(1, 'Name ist erforderlich').max(100),
+
+  /** Optional description */
+  description: z.string().max(500).optional(),
+
+  /** Fee amount as decimal string (e.g., "120.00") */
+  amount: z.string().regex(DECIMAL_REGEX, 'Betrag muss ein gueltiges Dezimalformat haben'),
+
+  /** Billing frequency */
+  billingInterval: BillingIntervalEnum.default('ANNUALLY'),
+
+  /** Whether this is a one-time fee (e.g., enrollment fee) */
+  isOneTime: z.boolean().default(false),
+
+  /** Display order in lists */
+  sortOrder: z.number().int().min(0).default(0),
+});
+
+export type CreateFeeCategory = z.infer<typeof CreateFeeCategorySchema>;
+
+/**
+ * Schema for updating an existing fee category.
+ * All fields optional for partial updates.
+ */
+export const UpdateFeeCategorySchema = CreateFeeCategorySchema.partial().extend({
+  /** Whether this category is active */
+  isActive: z.boolean().optional(),
+});
+
+export type UpdateFeeCategory = z.infer<typeof UpdateFeeCategorySchema>;
+
+/**
+ * Full fee category response schema including server-generated fields.
+ */
+export const FeeCategoryResponseSchema = z.object({
+  id: z.string(),
+  clubId: z.string(),
+  name: z.string(),
+  description: z.string().nullable(),
+  amount: z.string(),
+  billingInterval: BillingIntervalEnum,
+  isActive: z.boolean(),
+  isOneTime: z.boolean(),
+  sortOrder: z.number(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export type FeeCategoryResponse = z.infer<typeof FeeCategoryResponseSchema>;

--- a/packages/shared/src/schemas/fee-category.ts
+++ b/packages/shared/src/schemas/fee-category.ts
@@ -7,23 +7,34 @@ export const BillingIntervalEnum = z.enum(['MONTHLY', 'QUARTERLY', 'ANNUALLY']);
 export type BillingInterval = z.infer<typeof BillingIntervalEnum>;
 
 /**
- * Regex for validating decimal amounts (e.g., "12.50", "0.00", "1000.99").
+ * Scope of a fee category (which members it applies to).
+ * Must match Prisma FeeCategoryScope enum exactly.
  */
-const DECIMAL_REGEX = /^\d+(\.\d{1,2})?$/;
+export const FeeCategoryScopeEnum = z.enum(['ALL_MEMBERS', 'BY_MEMBERSHIP_TYPE', 'INDIVIDUAL']);
+export type FeeCategoryScope = z.infer<typeof FeeCategoryScopeEnum>;
+
+/**
+ * Regex for validating decimal amounts (e.g., "12.50", "0.00", "1000.99", "120,00").
+ * Accepts both dot and comma as decimal separator.
+ */
+const DECIMAL_REGEX = /^\d+([.,]\d{1,2})?$/;
 
 /**
  * Schema for creating a new fee category (club-scoped entity).
  * Additional fee categories beyond the base MembershipType fee.
  */
 export const CreateFeeCategorySchema = z.object({
-  /** Category name (e.g., "Aufnahmegebuehr", "Tennisabteilung") */
+  /** Category name (e.g., "Aufnahmegebühr", "Tennisabteilung") */
   name: z.string().min(1, 'Name ist erforderlich').max(100),
 
   /** Optional description */
   description: z.string().max(500).optional(),
 
-  /** Fee amount as decimal string (e.g., "120.00") */
-  amount: z.string().regex(DECIMAL_REGEX, 'Betrag muss ein gueltiges Dezimalformat haben'),
+  /** Fee amount as decimal string (e.g., "120.00" or "120,00") — normalized to dot */
+  amount: z
+    .string()
+    .transform((v) => v.replace(',', '.'))
+    .pipe(z.string().regex(DECIMAL_REGEX, 'Betrag muss ein gültiges Dezimalformat haben')),
 
   /** Billing frequency */
   billingInterval: BillingIntervalEnum.default('ANNUALLY'),
@@ -33,6 +44,12 @@ export const CreateFeeCategorySchema = z.object({
 
   /** Display order in lists */
   sortOrder: z.number().int().min(0).default(0),
+
+  /** Scope: which members this category applies to */
+  scope: FeeCategoryScopeEnum.optional().default('ALL_MEMBERS'),
+
+  /** Membership type IDs (for BY_MEMBERSHIP_TYPE scope) */
+  membershipTypeIds: z.array(z.string().cuid()).optional(),
 });
 
 export type CreateFeeCategory = z.infer<typeof CreateFeeCategorySchema>;
@@ -61,6 +78,16 @@ export const FeeCategoryResponseSchema = z.object({
   isActive: z.boolean(),
   isOneTime: z.boolean(),
   sortOrder: z.number(),
+  scope: FeeCategoryScopeEnum,
+  /** Membership types this category is scoped to (for BY_MEMBERSHIP_TYPE scope) */
+  membershipTypes: z
+    .array(
+      z.object({
+        id: z.string(),
+        membershipTypeId: z.string(),
+      })
+    )
+    .optional(),
   createdAt: z.string(),
   updatedAt: z.string(),
 });

--- a/packages/shared/src/schemas/fee-charge.ts
+++ b/packages/shared/src/schemas/fee-charge.ts
@@ -6,6 +6,10 @@ import { z } from 'zod';
 export const FeeChargeStatusEnum = z.enum(['OPEN', 'PARTIAL', 'PAID']);
 export type FeeChargeStatus = z.infer<typeof FeeChargeStatusEnum>;
 
+/** Extended status enum for query filters — includes OVERDUE (a computed pseudo-status). */
+export const FeeChargeFilterStatusEnum = z.enum(['OPEN', 'PARTIAL', 'PAID', 'OVERDUE']);
+export type FeeChargeFilterStatus = z.infer<typeof FeeChargeFilterStatusEnum>;
+
 /**
  * Full fee charge response schema including derived payment status.
  * Amounts are serialized as strings for Decimal precision.
@@ -50,8 +54,8 @@ export type FeeChargeResponse = z.infer<typeof FeeChargeResponseSchema>;
  * Query parameters for filtering fee charges.
  */
 export const FeeChargeQuerySchema = z.object({
-  /** Filter by derived payment status */
-  status: FeeChargeStatusEnum.optional(),
+  /** Filter by derived payment status (includes OVERDUE pseudo-status) */
+  status: FeeChargeFilterStatusEnum.optional(),
   /** Filter by specific member */
   memberId: z.string().optional(),
   /** Filter by period start (inclusive) */

--- a/packages/shared/src/schemas/fee-charge.ts
+++ b/packages/shared/src/schemas/fee-charge.ts
@@ -1,0 +1,67 @@
+import { z } from 'zod';
+
+/**
+ * Derived status of a fee charge based on payment sum vs. charge amount.
+ */
+export const FeeChargeStatusEnum = z.enum(['OPEN', 'PARTIAL', 'PAID']);
+export type FeeChargeStatus = z.infer<typeof FeeChargeStatusEnum>;
+
+/**
+ * Full fee charge response schema including derived payment status.
+ * Amounts are serialized as strings for Decimal precision.
+ */
+export const FeeChargeResponseSchema = z.object({
+  id: z.string(),
+  clubId: z.string(),
+  memberId: z.string(),
+  feeCategoryId: z.string().nullable(),
+  membershipTypeId: z.string().nullable(),
+  description: z.string(),
+  periodStart: z.string(),
+  periodEnd: z.string(),
+  amount: z.string(),
+  dueDate: z.string(),
+  /** Amount of discount applied (null if no discount) */
+  discountAmount: z.string().nullable(),
+  /** Human-readable reason for the discount */
+  discountReason: z.string().nullable(),
+  /** Derived status: OPEN, PARTIAL, or PAID */
+  status: FeeChargeStatusEnum,
+  /** Sum of all payments against this charge */
+  paidAmount: z.string(),
+  /** Remaining amount to be paid */
+  remainingAmount: z.string(),
+  /** Whether the charge is past due date and not fully paid */
+  isOverdue: z.boolean(),
+  /** Member summary for list display */
+  member: z.object({
+    id: z.string(),
+    firstName: z.string(),
+    lastName: z.string(),
+    memberNumber: z.string(),
+  }),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export type FeeChargeResponse = z.infer<typeof FeeChargeResponseSchema>;
+
+/**
+ * Query parameters for filtering fee charges.
+ */
+export const FeeChargeQuerySchema = z.object({
+  /** Filter by derived payment status */
+  status: FeeChargeStatusEnum.optional(),
+  /** Filter by specific member */
+  memberId: z.string().optional(),
+  /** Filter by period start (inclusive) */
+  periodStart: z.string().date().optional(),
+  /** Filter by period end (inclusive) */
+  periodEnd: z.string().date().optional(),
+  /** Page number for pagination */
+  page: z.coerce.number().int().min(1).optional(),
+  /** Items per page */
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+});
+
+export type FeeChargeQuery = z.infer<typeof FeeChargeQuerySchema>;

--- a/packages/shared/src/schemas/fee-type.ts
+++ b/packages/shared/src/schemas/fee-type.ts
@@ -1,0 +1,93 @@
+import { z } from 'zod';
+import { BillingIntervalEnum } from './fee-category.ts';
+
+/**
+ * Regex for validating decimal amounts (e.g., "12.50", "0.00", "1000.99", "120,00").
+ * Accepts both dot and comma as decimal separator.
+ */
+const DECIMAL_REGEX = /^\d+([.,]\d{1,2})?$/;
+
+// =============================================================================
+// FeeType Schemas
+// =============================================================================
+
+/**
+ * Schema for creating a new fee type (club-scoped entity).
+ * A FeeType defines how a member pays (e.g., Einzelbeitrag, Familientarif, Beitragsfrei).
+ */
+export const CreateFeeTypeSchema = z.object({
+  /** Display name (e.g., "Einzelbeitrag", "Familientarif") */
+  name: z.string().min(1, 'Name ist erforderlich').max(100),
+
+  /** Optional description explaining when this fee type applies */
+  description: z.string().max(500).optional(),
+
+  /** Whether this fee type is currently available for selection */
+  isActive: z.boolean().optional().default(true),
+});
+
+export type CreateFeeType = z.infer<typeof CreateFeeTypeSchema>;
+
+/**
+ * Schema for updating an existing fee type.
+ * All fields optional for partial updates.
+ */
+export const UpdateFeeTypeSchema = CreateFeeTypeSchema.partial();
+export type UpdateFeeType = z.infer<typeof UpdateFeeTypeSchema>;
+
+/**
+ * Full fee type response schema including server-generated fields.
+ */
+export const FeeTypeResponseSchema = z.object({
+  id: z.string(),
+  clubId: z.string(),
+  name: z.string(),
+  description: z.string().nullable(),
+  isActive: z.boolean(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export type FeeTypeResponse = z.infer<typeof FeeTypeResponseSchema>;
+
+// =============================================================================
+// Cross-Table (MembershipTypeFeeType) Schemas
+// =============================================================================
+
+/**
+ * Schema for upserting a cross-table entry (MembershipType x FeeType = amount).
+ * Used for creating or updating a single cell in the fee matrix.
+ */
+export const UpsertCrossTableEntrySchema = z.object({
+  /** Reference to the membership type */
+  membershipTypeId: z.string().cuid(),
+
+  /** Reference to the fee type */
+  feeTypeId: z.string().cuid(),
+
+  /** Fee amount as decimal string (e.g., "65.00" or "65,00") -- normalized to dot */
+  amount: z
+    .string()
+    .transform((v) => v.replace(',', '.'))
+    .pipe(z.string().regex(DECIMAL_REGEX, 'Bitte gib einen gueltigen Betrag ein (z.B. 65.00)')),
+
+  /** Billing frequency for this combination */
+  billingInterval: BillingIntervalEnum.optional().default('ANNUALLY'),
+});
+
+export type UpsertCrossTableEntry = z.infer<typeof UpsertCrossTableEntrySchema>;
+
+/**
+ * Full cross-table entry response schema including server-generated fields.
+ */
+export const CrossTableEntryResponseSchema = z.object({
+  id: z.string(),
+  membershipTypeId: z.string(),
+  feeTypeId: z.string(),
+  amount: z.string(),
+  billingInterval: BillingIntervalEnum,
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export type CrossTableEntryResponse = z.infer<typeof CrossTableEntryResponseSchema>;

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -12,3 +12,7 @@ export * from './club-settings.ts';
 export * from './file.ts';
 export * from './user-profile.ts';
 export * from './club-deletion.schema.ts';
+export * from './fee-category.ts';
+export * from './fee-charge.ts';
+export * from './payment.ts';
+export * from './billing-run.ts';

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -13,6 +13,7 @@ export * from './file.ts';
 export * from './user-profile.ts';
 export * from './club-deletion.schema.ts';
 export * from './fee-category.ts';
+export * from './fee-type.ts';
 export * from './fee-charge.ts';
 export * from './payment.ts';
 export * from './billing-run.ts';

--- a/packages/shared/src/schemas/member.ts
+++ b/packages/shared/src/schemas/member.ts
@@ -53,7 +53,7 @@ export const CreateMemberSchema = z
     vatId: z.string().max(50).optional(),
 
     /** Club communication email (independent from User login email) */
-    email: z.string().email('Ungueltige E-Mail-Adresse').optional().or(z.literal('')),
+    email: z.string().email('Ungültige E-Mail-Adresse').optional().or(z.literal('')),
 
     /** Phone number (landline or general) */
     phone: z.string().max(30).optional(),
@@ -71,10 +71,13 @@ export const CreateMemberSchema = z
     status: MemberStatusSchema.default('PENDING'),
 
     /** Join/entry date as ISO date string YYYY-MM-DD (NOT z.coerce.date()) */
-    joinDate: z.string().date('Ungueltiges Datum (YYYY-MM-DD erwartet)').optional(),
+    joinDate: z.string().date('Ungültiges Datum (YYYY-MM-DD erwartet)').optional(),
 
     /** Membership type ID (FK to MembershipType entity) for initial membership period */
     membershipTypeId: z.string().optional(),
+
+    /** Fee type ID (FK to FeeType entity) for billing amount determination */
+    feeTypeId: z.string().cuid().optional().nullable(),
   })
   .merge(AddressSchema)
   .refine(
@@ -116,6 +119,9 @@ export const UpdateMemberSchema = z
     // dedicated ChangeStatusSchema endpoint (see C-3 consistency requirement)
     joinDate: z.string().date().optional(),
     membershipTypeId: z.string().optional(),
+
+    /** Fee type ID (FK to FeeType entity) for billing amount determination */
+    feeTypeId: z.string().cuid().optional().nullable(),
   })
   .merge(AddressSchema.partial());
 
@@ -158,6 +164,7 @@ export const MemberResponseSchema = z.object({
   status: MemberStatusSchema,
   joinDate: z.string().nullable().optional(),
   membershipTypeId: z.string().nullable().optional(),
+  feeTypeId: z.string().nullable().optional(),
 
   statusChangedAt: z.string().nullable().optional(),
   statusChangedBy: z.string().nullable().optional(),

--- a/packages/shared/src/schemas/membership-period.ts
+++ b/packages/shared/src/schemas/membership-period.ts
@@ -9,10 +9,10 @@ import { z } from 'zod';
 export const CreateMembershipPeriodSchema = z
   .object({
     /** Start date of the membership period (ISO date string YYYY-MM-DD) */
-    joinDate: z.string().date('Ungueltiges Eintrittsdatum (YYYY-MM-DD erwartet)'),
+    joinDate: z.string().date('Ungültiges Eintrittsdatum (YYYY-MM-DD erwartet)'),
 
     /** End date of the membership period (null = current/ongoing) */
-    leaveDate: z.string().date('Ungueltiges Austrittsdatum (YYYY-MM-DD erwartet)').optional(),
+    leaveDate: z.string().date('Ungültiges Austrittsdatum (YYYY-MM-DD erwartet)').optional(),
 
     /** Membership type ID (FK to MembershipType entity) */
     membershipTypeId: z.string().optional(),

--- a/packages/shared/src/schemas/membership-type.ts
+++ b/packages/shared/src/schemas/membership-type.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { BillingIntervalEnum } from './fee-category.js';
 
 /**
  * Available badge colors for membership types.
@@ -57,6 +58,12 @@ export const CreateMembershipTypeSchema = z.object({
 
   /** Badge color for UI display */
   color: MemberTypeColorSchema.optional(),
+
+  /** Fee amount as decimal string (e.g., "120.00") — nullable, not all types have fees */
+  feeAmount: z.string().nullable().optional(),
+
+  /** Billing frequency for this membership type's base fee */
+  billingInterval: BillingIntervalEnum.optional(),
 });
 
 export type CreateMembershipType = z.infer<typeof CreateMembershipTypeSchema>;
@@ -85,6 +92,8 @@ export const MembershipTypeResponseSchema = z.object({
   assemblyAttendance: z.boolean(),
   eligibleForOffice: z.boolean(),
   color: MemberTypeColorSchema,
+  feeAmount: z.string().nullable().optional(),
+  billingInterval: BillingIntervalEnum.optional(),
   createdAt: z.string(),
   updatedAt: z.string(),
 });

--- a/packages/shared/src/schemas/membership-type.ts
+++ b/packages/shared/src/schemas/membership-type.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { BillingIntervalEnum } from './fee-category.js';
+import { BillingIntervalEnum } from './fee-category.ts';
 
 /**
  * Available badge colors for membership types.

--- a/packages/shared/src/schemas/membership-type.ts
+++ b/packages/shared/src/schemas/membership-type.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod';
-import { BillingIntervalEnum } from './fee-category.ts';
 
 /**
  * Available badge colors for membership types.
@@ -58,12 +57,6 @@ export const CreateMembershipTypeSchema = z.object({
 
   /** Badge color for UI display */
   color: MemberTypeColorSchema.optional(),
-
-  /** Fee amount as decimal string (e.g., "120.00") — nullable, not all types have fees */
-  feeAmount: z.string().nullable().optional(),
-
-  /** Billing frequency for this membership type's base fee */
-  billingInterval: BillingIntervalEnum.optional(),
 });
 
 export type CreateMembershipType = z.infer<typeof CreateMembershipTypeSchema>;
@@ -92,8 +85,6 @@ export const MembershipTypeResponseSchema = z.object({
   assemblyAttendance: z.boolean(),
   eligibleForOffice: z.boolean(),
   color: MemberTypeColorSchema,
-  feeAmount: z.string().nullable().optional(),
-  billingInterval: BillingIntervalEnum.optional(),
   createdAt: z.string(),
   updatedAt: z.string(),
 });

--- a/packages/shared/src/schemas/payment.ts
+++ b/packages/shared/src/schemas/payment.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod';
+
+/**
+ * Source of a payment recording.
+ */
+export const PaymentSourceEnum = z.enum(['MANUAL', 'BANK_IMPORT', 'SEPA']);
+export type PaymentSource = z.infer<typeof PaymentSourceEnum>;
+
+/**
+ * Regex for validating decimal amounts (e.g., "12.50", "0.00", "1000.99").
+ */
+const DECIMAL_REGEX = /^\d+(\.\d{1,2})?$/;
+
+/**
+ * Schema for recording a new payment against a fee charge.
+ */
+export const RecordPaymentSchema = z.object({
+  /** The fee charge this payment is for */
+  feeChargeId: z.string(),
+
+  /** Payment amount as decimal string */
+  amount: z.string().regex(DECIMAL_REGEX, 'Betrag muss ein gueltiges Dezimalformat haben'),
+
+  /** Date the payment was made (ISO date string, e.g., "2026-01-15") */
+  paidAt: z.string().date(),
+
+  /** Optional notes about this payment */
+  notes: z.string().max(500).optional(),
+});
+
+export type RecordPayment = z.infer<typeof RecordPaymentSchema>;
+
+/**
+ * Full payment response schema including server-generated fields.
+ */
+export const PaymentResponseSchema = z.object({
+  id: z.string(),
+  feeChargeId: z.string(),
+  amount: z.string(),
+  paidAt: z.string(),
+  source: PaymentSourceEnum,
+  reference: z.string().nullable(),
+  notes: z.string().nullable(),
+  recordedBy: z.string(),
+  createdAt: z.string(),
+});
+
+export type PaymentResponse = z.infer<typeof PaymentResponseSchema>;

--- a/packages/shared/src/schemas/payment.ts
+++ b/packages/shared/src/schemas/payment.ts
@@ -7,9 +7,10 @@ export const PaymentSourceEnum = z.enum(['MANUAL', 'BANK_IMPORT', 'SEPA']);
 export type PaymentSource = z.infer<typeof PaymentSourceEnum>;
 
 /**
- * Regex for validating decimal amounts (e.g., "12.50", "0.00", "1000.99").
+ * Regex for validating decimal amounts (e.g., "12.50", "0.00", "1000.99", "120,00").
+ * Accepts both dot and comma as decimal separator.
  */
-const DECIMAL_REGEX = /^\d+(\.\d{1,2})?$/;
+const DECIMAL_REGEX = /^\d+([.,]\d{1,2})?$/;
 
 /**
  * Schema for recording a new payment against a fee charge.
@@ -18,8 +19,11 @@ export const RecordPaymentSchema = z.object({
   /** The fee charge this payment is for */
   feeChargeId: z.string(),
 
-  /** Payment amount as decimal string */
-  amount: z.string().regex(DECIMAL_REGEX, 'Betrag muss ein gueltiges Dezimalformat haben'),
+  /** Payment amount as decimal string — normalized to dot */
+  amount: z
+    .string()
+    .transform((v) => v.replace(',', '.'))
+    .pipe(z.string().regex(DECIMAL_REGEX, 'Betrag muss ein gültiges Dezimalformat haben')),
 
   /** Date the payment was made (ISO date string, e.g., "2026-01-15") */
   paidAt: z.string().date(),

--- a/prisma/migrations/20260326155100_add_fee_management_models/migration.sql
+++ b/prisma/migrations/20260326155100_add_fee_management_models/migration.sql
@@ -1,0 +1,143 @@
+-- CreateEnum
+CREATE TYPE "BillingInterval" AS ENUM ('MONTHLY', 'QUARTERLY', 'ANNUALLY');
+
+-- CreateEnum
+CREATE TYPE "PaymentSource" AS ENUM ('MANUAL', 'BANK_IMPORT', 'SEPA');
+
+-- CreateEnum
+CREATE TYPE "FeeOverrideType" AS ENUM ('EXEMPT', 'CUSTOM_AMOUNT', 'ADDITIONAL');
+
+-- CreateEnum
+CREATE TYPE "ProRataMode" AS ENUM ('FULL', 'MONTHLY_PRO_RATA');
+
+-- CreateEnum
+CREATE TYPE "HouseholdFeeMode" AS ENUM ('NONE', 'PERCENTAGE', 'FLAT');
+
+-- AlterTable
+ALTER TABLE "clubs" ADD COLUMN     "householdDiscountPercent" INTEGER,
+ADD COLUMN     "householdFeeMode" "HouseholdFeeMode" NOT NULL DEFAULT 'NONE',
+ADD COLUMN     "householdFlatAmount" DECIMAL(10,2),
+ADD COLUMN     "proRataMode" "ProRataMode" NOT NULL DEFAULT 'FULL';
+
+-- AlterTable
+ALTER TABLE "membership_types" ADD COLUMN     "billingInterval" "BillingInterval" NOT NULL DEFAULT 'ANNUALLY',
+ADD COLUMN     "feeAmount" DECIMAL(10,2);
+
+-- CreateTable
+CREATE TABLE "fee_categories" (
+    "id" TEXT NOT NULL,
+    "clubId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "amount" DECIMAL(10,2) NOT NULL,
+    "billingInterval" "BillingInterval" NOT NULL DEFAULT 'ANNUALLY',
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "isOneTime" BOOLEAN NOT NULL DEFAULT false,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "deletedAt" TIMESTAMP(3),
+    "deletedBy" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "fee_categories_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "member_fee_overrides" (
+    "id" TEXT NOT NULL,
+    "memberId" TEXT NOT NULL,
+    "feeCategoryId" TEXT,
+    "overrideType" "FeeOverrideType" NOT NULL,
+    "customAmount" DECIMAL(10,2),
+    "reason" TEXT,
+    "isBaseFee" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "member_fee_overrides_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "fee_charges" (
+    "id" TEXT NOT NULL,
+    "clubId" TEXT NOT NULL,
+    "memberId" TEXT NOT NULL,
+    "feeCategoryId" TEXT,
+    "membershipTypeId" TEXT,
+    "description" TEXT NOT NULL,
+    "periodStart" DATE NOT NULL,
+    "periodEnd" DATE NOT NULL,
+    "amount" DECIMAL(10,2) NOT NULL,
+    "dueDate" DATE NOT NULL,
+    "discountAmount" DECIMAL(10,2),
+    "discountReason" TEXT,
+    "deletedAt" TIMESTAMP(3),
+    "deletedBy" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "fee_charges_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "payments" (
+    "id" TEXT NOT NULL,
+    "feeChargeId" TEXT NOT NULL,
+    "amount" DECIMAL(10,2) NOT NULL,
+    "paidAt" DATE NOT NULL,
+    "source" "PaymentSource" NOT NULL DEFAULT 'MANUAL',
+    "reference" TEXT,
+    "notes" TEXT,
+    "recordedBy" TEXT NOT NULL,
+    "deletedAt" TIMESTAMP(3),
+    "deletedBy" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "payments_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "fee_categories_clubId_idx" ON "fee_categories"("clubId");
+
+-- CreateIndex
+CREATE INDEX "member_fee_overrides_memberId_idx" ON "member_fee_overrides"("memberId");
+
+-- CreateIndex
+CREATE INDEX "fee_charges_clubId_idx" ON "fee_charges"("clubId");
+
+-- CreateIndex
+CREATE INDEX "fee_charges_memberId_idx" ON "fee_charges"("memberId");
+
+-- CreateIndex
+CREATE INDEX "fee_charges_clubId_dueDate_idx" ON "fee_charges"("clubId", "dueDate");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "fee_charges_billing_unique" ON "fee_charges"("memberId", "feeCategoryId", "membershipTypeId", "periodStart", "periodEnd");
+
+-- CreateIndex
+CREATE INDEX "payments_feeChargeId_idx" ON "payments"("feeChargeId");
+
+-- AddForeignKey
+ALTER TABLE "fee_categories" ADD CONSTRAINT "fee_categories_clubId_fkey" FOREIGN KEY ("clubId") REFERENCES "clubs"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "member_fee_overrides" ADD CONSTRAINT "member_fee_overrides_memberId_fkey" FOREIGN KEY ("memberId") REFERENCES "members"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "member_fee_overrides" ADD CONSTRAINT "member_fee_overrides_feeCategoryId_fkey" FOREIGN KEY ("feeCategoryId") REFERENCES "fee_categories"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "fee_charges" ADD CONSTRAINT "fee_charges_clubId_fkey" FOREIGN KEY ("clubId") REFERENCES "clubs"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "fee_charges" ADD CONSTRAINT "fee_charges_memberId_fkey" FOREIGN KEY ("memberId") REFERENCES "members"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "fee_charges" ADD CONSTRAINT "fee_charges_feeCategoryId_fkey" FOREIGN KEY ("feeCategoryId") REFERENCES "fee_categories"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "fee_charges" ADD CONSTRAINT "fee_charges_membershipTypeId_fkey" FOREIGN KEY ("membershipTypeId") REFERENCES "membership_types"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "payments" ADD CONSTRAINT "payments_feeChargeId_fkey" FOREIGN KEY ("feeChargeId") REFERENCES "fee_charges"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20260402114534_fee_model_redesign/migration.sql
+++ b/prisma/migrations/20260402114534_fee_model_redesign/migration.sql
@@ -1,0 +1,104 @@
+-- CreateEnum
+CREATE TYPE "HouseholdBillingModel" AS ENUM ('NONE', 'REDUCED_MEMBERS', 'FAMILY_PAYER', 'ALL_REDUCED');
+
+-- CreateEnum
+CREATE TYPE "FeeCategoryScope" AS ENUM ('ALL_MEMBERS', 'BY_MEMBERSHIP_TYPE', 'INDIVIDUAL');
+
+-- DropIndex
+DROP INDEX "fee_charges_billing_unique";
+
+-- AlterTable
+ALTER TABLE "clubs" DROP COLUMN "householdDiscountPercent",
+DROP COLUMN "householdFeeMode",
+DROP COLUMN "householdFlatAmount",
+ADD COLUMN     "householdBillingModel" "HouseholdBillingModel" NOT NULL DEFAULT 'NONE';
+
+-- AlterTable
+ALTER TABLE "fee_categories" ADD COLUMN     "scope" "FeeCategoryScope" NOT NULL DEFAULT 'ALL_MEMBERS';
+
+-- AlterTable
+ALTER TABLE "fee_charges" ADD COLUMN     "feeTypeId" TEXT;
+
+-- AlterTable
+ALTER TABLE "members" ADD COLUMN     "feeTypeId" TEXT;
+
+-- AlterTable
+ALTER TABLE "membership_types" DROP COLUMN "billingInterval",
+DROP COLUMN "feeAmount";
+
+-- DropEnum
+DROP TYPE "HouseholdFeeMode";
+
+-- CreateTable
+CREATE TABLE "fee_types" (
+    "id" TEXT NOT NULL,
+    "clubId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "deletedAt" TIMESTAMP(3),
+    "deletedBy" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "fee_types_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "membership_type_fee_types" (
+    "id" TEXT NOT NULL,
+    "membershipTypeId" TEXT NOT NULL,
+    "feeTypeId" TEXT NOT NULL,
+    "amount" DECIMAL(10,2) NOT NULL,
+    "billingInterval" "BillingInterval" NOT NULL DEFAULT 'ANNUALLY',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "membership_type_fee_types_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "fee_category_membership_types" (
+    "id" TEXT NOT NULL,
+    "feeCategoryId" TEXT NOT NULL,
+    "membershipTypeId" TEXT NOT NULL,
+
+    CONSTRAINT "fee_category_membership_types_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "fee_types_clubId_idx" ON "fee_types"("clubId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "fee_types_clubId_name_key" ON "fee_types"("clubId", "name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "membership_type_fee_types_membershipTypeId_feeTypeId_key" ON "membership_type_fee_types"("membershipTypeId", "feeTypeId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "fee_category_membership_types_feeCategoryId_membershipTypeI_key" ON "fee_category_membership_types"("feeCategoryId", "membershipTypeId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "fee_charges_billing_unique" ON "fee_charges"("memberId", "feeCategoryId", "membershipTypeId", "feeTypeId", "periodStart", "periodEnd");
+
+-- AddForeignKey
+ALTER TABLE "members" ADD CONSTRAINT "members_feeTypeId_fkey" FOREIGN KEY ("feeTypeId") REFERENCES "fee_types"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "fee_charges" ADD CONSTRAINT "fee_charges_feeTypeId_fkey" FOREIGN KEY ("feeTypeId") REFERENCES "fee_types"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "fee_types" ADD CONSTRAINT "fee_types_clubId_fkey" FOREIGN KEY ("clubId") REFERENCES "clubs"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "membership_type_fee_types" ADD CONSTRAINT "membership_type_fee_types_membershipTypeId_fkey" FOREIGN KEY ("membershipTypeId") REFERENCES "membership_types"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "membership_type_fee_types" ADD CONSTRAINT "membership_type_fee_types_feeTypeId_fkey" FOREIGN KEY ("feeTypeId") REFERENCES "fee_types"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "fee_category_membership_types" ADD CONSTRAINT "fee_category_membership_types_feeCategoryId_fkey" FOREIGN KEY ("feeCategoryId") REFERENCES "fee_categories"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "fee_category_membership_types" ADD CONSTRAINT "fee_category_membership_types_membershipTypeId_fkey" FOREIGN KEY ("membershipTypeId") REFERENCES "membership_types"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+

--- a/prisma/migrations/20260610133400_fee_charges_billing_unique_nulls_not_distinct/migration.sql
+++ b/prisma/migrations/20260610133400_fee_charges_billing_unique_nulls_not_distinct/migration.sql
@@ -1,0 +1,10 @@
+-- WARNING: This migration assumes there are NO pre-existing duplicate charge rows under
+-- the new NULLS NOT DISTINCT semantics. With the old index, rows differing only in NULL
+-- key columns (e.g. base-fee charges with feeCategoryId IS NULL, category charges with
+-- membershipTypeId/feeTypeId IS NULL) were allowed to coexist. Recreating the index with
+-- NULLS NOT DISTINCT will fail if such duplicates already exist. A developer running this
+-- against a database with real data MUST de-duplicate those fee_charges rows first.
+
+-- Make the billing dedupe index treat NULL key columns as equal so re-running a period is a true no-op (Postgres 15+).
+DROP INDEX "fee_charges_billing_unique";
+CREATE UNIQUE INDEX "fee_charges_billing_unique" ON "fee_charges"("memberId", "feeCategoryId", "membershipTypeId", "feeTypeId", "periodStart", "periodEnd") NULLS NOT DISTINCT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -97,6 +97,16 @@ model Club {
   /// Probezeit in Tagen / Probation period in days
   probationPeriodDays     Int?
 
+  // --- Beitragseinstellungen (Fee Settings) ---
+  /// Whether to pro-rate fees for mid-period joins
+  proRataMode          ProRataMode      @default(FULL)
+  /// Household discount mode
+  householdFeeMode     HouseholdFeeMode @default(NONE)
+  /// Percentage discount for additional household members (for PERCENTAGE mode)
+  householdDiscountPercent Int?
+  /// Flat household fee (for FLAT mode)
+  householdFlatAmount  Decimal?         @db.Decimal(10, 2)
+
   // --- Logo ---
   /// Referenz zur Logo-Datei / Reference to the logo file
   logoFileId String? @unique
@@ -135,6 +145,8 @@ model Club {
   membershipTypes    MembershipType[]
   statusTransitions  MemberStatusTransition[]
   auditLogs          AuditLog[]
+  feeCategories      FeeCategory[]
+  feeCharges         FeeCharge[]
 
   @@map("clubs")
 }
@@ -540,6 +552,12 @@ model MembershipType {
   /// Badge color for UI display (light/dark mode aware)
   color               MemberTypeColor @default(BLUE)
 
+  // --- Beitragseinstellungen (Fee Settings) ---
+  /// Base fee amount for this membership type (nullable to avoid breaking existing data)
+  feeAmount           Decimal?        @db.Decimal(10, 2)
+  /// Billing frequency for the base fee
+  billingInterval     BillingInterval @default(ANNUALLY)
+
   createdAt           DateTime        @default(now())
   updatedAt           DateTime        @updatedAt
 
@@ -547,6 +565,8 @@ model MembershipType {
   membershipPeriods   MembershipPeriod[]
   /// Clubs using this as default membership type
   clubDefaults        Club[]   @relation("ClubDefaultMembershipType")
+  /// Fee charges referencing this membership type
+  feeCharges          FeeCharge[]
 
   @@unique([clubId, code])
   @@index([clubId])
@@ -696,9 +716,13 @@ model Member {
 
   // Relations
   /// Membership periods (supports membership type changes with multiple consecutive periods)
-  membershipPeriods  MembershipPeriod[]
+  membershipPeriods    MembershipPeriod[]
   /// Status transition history
-  statusTransitions  MemberStatusTransition[]
+  statusTransitions    MemberStatusTransition[]
+  /// Per-member fee overrides (exemptions, custom amounts)
+  memberFeeOverrides   MemberFeeOverride[]
+  /// Fee charges (Forderungen) for this member
+  feeCharges           FeeCharge[]
 
   @@unique([clubId, memberNumber])
   @@index([clubId])
@@ -881,6 +905,225 @@ model LedgerAccount {
   @@unique([clubId, code])
   @@index([clubId])
   @@map("ledger_accounts")
+}
+
+// =============================================================================
+// Fee Management Models (Phase 12)
+// =============================================================================
+// Fee categories, member overrides, billing charges, and payments.
+// Supports hybrid model: MembershipType defines base fee,
+// FeeCategory handles additional charges.
+
+/// Billing frequency for fees
+enum BillingInterval {
+  /// Monthly billing (Monatlich)
+  MONTHLY
+  /// Quarterly billing (Quartalsweise)
+  QUARTERLY
+  /// Annual billing (Jaehrlich)
+  ANNUALLY
+}
+
+/// Source of a payment recording
+enum PaymentSource {
+  /// Manually recorded by treasurer
+  MANUAL
+  /// Matched from bank statement import (Phase 15)
+  BANK_IMPORT
+  /// Generated via SEPA direct debit (Phase 16)
+  SEPA
+}
+
+/// Type of per-member fee override
+enum FeeOverrideType {
+  /// Member is exempt from this fee (Befreiung)
+  EXEMPT
+  /// Custom amount replaces the standard fee (Individueller Betrag)
+  CUSTOM_AMOUNT
+  /// Additional fee on top of standard (Zusatzbeitrag)
+  ADDITIONAL
+}
+
+/// Pro-rata mode for mid-period membership joins
+enum ProRataMode {
+  /// Full fee regardless of join date
+  FULL
+  /// Monthly pro-rata calculation
+  MONTHLY_PRO_RATA
+}
+
+/// Household fee discount mode
+enum HouseholdFeeMode {
+  /// No household discount
+  NONE
+  /// Percentage discount for additional household members
+  PERCENTAGE
+  /// Flat household fee regardless of member count
+  FLAT
+}
+
+/// Additional fee category beyond base MembershipType fee.
+/// Examples: Aufnahmegebuehr, Abteilungsbeitrag, Sonderbeitrag.
+model FeeCategory {
+  /// Unique identifier (CUID format)
+  id              String          @id @default(cuid())
+  /// Reference to the parent club (tenant)
+  clubId          String
+  /// The club this fee category belongs to
+  club            Club            @relation(fields: [clubId], references: [id])
+
+  /// Category name (e.g., "Aufnahmegebuehr", "Tennisabteilung")
+  name            String
+  /// Optional description
+  description     String?
+  /// Fee amount
+  amount          Decimal         @db.Decimal(10, 2)
+  /// Billing frequency
+  billingInterval BillingInterval @default(ANNUALLY)
+  /// Whether this category is active and available for billing
+  isActive        Boolean         @default(true)
+  /// Whether this is a one-time fee (e.g., enrollment fee)
+  isOneTime       Boolean         @default(false)
+  /// Display order in lists
+  sortOrder       Int             @default(0)
+
+  /// Soft deletion timestamp (CONV-006)
+  deletedAt DateTime?
+  /// User ID who performed the soft deletion
+  deletedBy String?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  // Relations
+  memberFeeOverrides MemberFeeOverride[]
+  feeCharges         FeeCharge[]
+
+  @@index([clubId])
+  @@map("fee_categories")
+}
+
+/// Per-member fee adjustment (exemption, custom amount, additional fee).
+/// Overrides are replaced, not soft-deleted.
+model MemberFeeOverride {
+  /// Unique identifier (CUID format)
+  id            String          @id @default(cuid())
+  /// Reference to the member
+  memberId      String
+  /// The member this override applies to
+  member        Member          @relation(fields: [memberId], references: [id])
+  /// Reference to the fee category (null if overriding base fee)
+  feeCategoryId String?
+  /// The fee category being overridden (null = base membership fee)
+  feeCategory   FeeCategory?    @relation(fields: [feeCategoryId], references: [id])
+
+  /// Type of override
+  overrideType  FeeOverrideType
+  /// Custom amount (for CUSTOM_AMOUNT and ADDITIONAL types)
+  customAmount  Decimal?        @db.Decimal(10, 2)
+  /// Reason for the override
+  reason        String?
+  /// Whether this override applies to the base membership fee
+  isBaseFee     Boolean         @default(false)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([memberId])
+  @@map("member_fee_overrides")
+}
+
+/// A fee demand (Forderung) generated by a billing run.
+/// Represents what a member owes for a specific period.
+model FeeCharge {
+  /// Unique identifier (CUID format)
+  id               String       @id @default(cuid())
+  /// Reference to the parent club (tenant)
+  clubId           String
+  /// The club this charge belongs to
+  club             Club         @relation(fields: [clubId], references: [id])
+  /// Reference to the member
+  memberId         String
+  /// The member this charge is for
+  member           Member       @relation(fields: [memberId], references: [id])
+  /// Reference to the fee category (null for base membership fee)
+  feeCategoryId    String?
+  /// The fee category (null = base membership fee from MembershipType)
+  feeCategory      FeeCategory? @relation(fields: [feeCategoryId], references: [id])
+  /// Reference to the membership type (for base fee charges)
+  membershipTypeId String?
+  /// The membership type (for base fee charges)
+  membershipType   MembershipType? @relation(fields: [membershipTypeId], references: [id])
+
+  /// Human-readable description of the charge
+  description   String
+  /// Start of the billing period (date-only)
+  periodStart   DateTime    @db.Date
+  /// End of the billing period (date-only)
+  periodEnd     DateTime    @db.Date
+  /// Charged amount
+  amount        Decimal     @db.Decimal(10, 2)
+  /// Due date for payment (date-only)
+  dueDate       DateTime    @db.Date
+
+  // --- Discount traceability (review concern: override traceability) ---
+  /// Amount of discount applied (e.g., household discount, override reduction)
+  discountAmount Decimal?   @db.Decimal(10, 2)
+  /// Human-readable reason for the discount
+  discountReason String?
+
+  /// Soft deletion timestamp (CONV-006)
+  deletedAt DateTime?
+  /// User ID who performed the soft deletion
+  deletedBy String?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  // Relations
+  payments Payment[]
+
+  @@index([clubId])
+  @@index([memberId])
+  @@index([clubId, dueDate])
+  /// Prevents duplicate charges for same member + fee source + period
+  @@unique([memberId, feeCategoryId, membershipTypeId, periodStart, periodEnd], map: "fee_charges_billing_unique")
+  @@map("fee_charges")
+}
+
+/// Payment recorded against a fee charge.
+/// Status is derived: sum(payments.amount) vs FeeCharge.amount.
+model Payment {
+  /// Unique identifier (CUID format)
+  id          String        @id @default(cuid())
+  /// Reference to the fee charge
+  feeChargeId String
+  /// The fee charge this payment is for
+  feeCharge   FeeCharge     @relation(fields: [feeChargeId], references: [id])
+
+  /// Payment amount
+  amount      Decimal       @db.Decimal(10, 2)
+  /// Date the payment was made (date-only)
+  paidAt      DateTime      @db.Date
+  /// Source of the payment
+  source      PaymentSource @default(MANUAL)
+  /// Reference number (bank transaction ID, SEPA end-to-end ID)
+  reference   String?
+  /// Optional notes
+  notes       String?
+  /// User ID who recorded this payment
+  recordedBy  String
+
+  /// Soft deletion timestamp (CONV-006)
+  deletedAt DateTime?
+  /// User ID who performed the soft deletion
+  deletedBy String?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([feeChargeId])
+  @@map("payments")
 }
 
 // =============================================================================

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -99,13 +99,9 @@ model Club {
 
   // --- Beitragseinstellungen (Fee Settings) ---
   /// Whether to pro-rate fees for mid-period joins
-  proRataMode          ProRataMode      @default(FULL)
-  /// Household discount mode
-  householdFeeMode     HouseholdFeeMode @default(NONE)
-  /// Percentage discount for additional household members (for PERCENTAGE mode)
-  householdDiscountPercent Int?
-  /// Flat household fee (for FLAT mode)
-  householdFlatAmount  Decimal?         @db.Decimal(10, 2)
+  proRataMode            ProRataMode          @default(FULL)
+  /// Household billing model (determines FeeType auto-suggestion rules)
+  householdBillingModel  HouseholdBillingModel @default(NONE)
 
   // --- Logo ---
   /// Referenz zur Logo-Datei / Reference to the logo file
@@ -147,6 +143,7 @@ model Club {
   auditLogs          AuditLog[]
   feeCategories      FeeCategory[]
   feeCharges         FeeCharge[]
+  feeTypes           FeeType[]
 
   @@map("clubs")
 }
@@ -552,21 +549,19 @@ model MembershipType {
   /// Badge color for UI display (light/dark mode aware)
   color               MemberTypeColor @default(BLUE)
 
-  // --- Beitragseinstellungen (Fee Settings) ---
-  /// Base fee amount for this membership type (nullable to avoid breaking existing data)
-  feeAmount           Decimal?        @db.Decimal(10, 2)
-  /// Billing frequency for the base fee
-  billingInterval     BillingInterval @default(ANNUALLY)
-
   createdAt           DateTime        @default(now())
   updatedAt           DateTime        @updatedAt
 
   /// Membership periods using this type
-  membershipPeriods   MembershipPeriod[]
+  membershipPeriods           MembershipPeriod[]
   /// Clubs using this as default membership type
-  clubDefaults        Club[]   @relation("ClubDefaultMembershipType")
+  clubDefaults                Club[]   @relation("ClubDefaultMembershipType")
   /// Fee charges referencing this membership type
-  feeCharges          FeeCharge[]
+  feeCharges                  FeeCharge[]
+  /// Cross-table: fee amounts per FeeType for this membership type
+  membershipTypeFees          MembershipTypeFeeType[]
+  /// Fee categories scoped to this membership type
+  feeCategoryMembershipTypes  FeeCategoryMembershipType[]
 
   @@unique([clubId, code])
   @@index([clubId])
@@ -691,6 +686,12 @@ model Member {
   userId String?
   /// Relation to the linked user (for avatar image, etc.)
   user   User?   @relation(fields: [userId], references: [id])
+
+  // --- Beitragsart (Fee Type) ---
+  /// The fee type assigned to this member (determines billing amount via cross-table)
+  feeTypeId String?
+  /// Relation to the fee type
+  feeType   FeeType? @relation(fields: [feeTypeId], references: [id])
 
   // --- Household ---
   /// Household this member belongs to
@@ -952,14 +953,26 @@ enum ProRataMode {
   MONTHLY_PRO_RATA
 }
 
-/// Household fee discount mode
-enum HouseholdFeeMode {
-  /// No household discount
+/// Household billing model (determines FeeType auto-suggestion rules)
+enum HouseholdBillingModel {
+  /// No household-based billing (all members pay individual rate)
   NONE
-  /// Percentage discount for additional household members
-  PERCENTAGE
-  /// Flat household fee regardless of member count
-  FLAT
+  /// Non-HEAD household members get reduced rate
+  REDUCED_MEMBERS
+  /// HEAD pays family flat rate, others are fee-free
+  FAMILY_PAYER
+  /// All household members get reduced rate
+  ALL_REDUCED
+}
+
+/// Scope of a fee category (which members it applies to)
+enum FeeCategoryScope {
+  /// Applies to all members
+  ALL_MEMBERS
+  /// Applies only to members of specific membership types
+  BY_MEMBERSHIP_TYPE
+  /// Applied individually via MemberFeeOverride
+  INDIVIDUAL
 }
 
 /// Additional fee category beyond base MembershipType fee.
@@ -986,6 +999,8 @@ model FeeCategory {
   isOneTime       Boolean         @default(false)
   /// Display order in lists
   sortOrder       Int             @default(0)
+  /// Scope: which members this category applies to
+  scope           FeeCategoryScope @default(ALL_MEMBERS)
 
   /// Soft deletion timestamp (CONV-006)
   deletedAt DateTime?
@@ -996,8 +1011,10 @@ model FeeCategory {
   updatedAt DateTime @updatedAt
 
   // Relations
-  memberFeeOverrides MemberFeeOverride[]
-  feeCharges         FeeCharge[]
+  memberFeeOverrides          MemberFeeOverride[]
+  feeCharges                  FeeCharge[]
+  /// Membership types this category is scoped to (for BY_MEMBERSHIP_TYPE scope)
+  feeCategoryMembershipTypes  FeeCategoryMembershipType[]
 
   @@index([clubId])
   @@map("fee_categories")
@@ -1054,6 +1071,10 @@ model FeeCharge {
   membershipTypeId String?
   /// The membership type (for base fee charges)
   membershipType   MembershipType? @relation(fields: [membershipTypeId], references: [id])
+  /// Reference to the fee type used at billing time (for traceability)
+  feeTypeId        String?
+  /// The fee type used at billing time
+  feeType          FeeType?        @relation(fields: [feeTypeId], references: [id])
 
   /// Human-readable description of the charge
   description   String
@@ -1086,9 +1107,89 @@ model FeeCharge {
   @@index([clubId])
   @@index([memberId])
   @@index([clubId, dueDate])
-  /// Prevents duplicate charges for same member + fee source + period
-  @@unique([memberId, feeCategoryId, membershipTypeId, periodStart, periodEnd], map: "fee_charges_billing_unique")
+  /// Prevents duplicate charges for same member + fee source + fee type + period
+  @@unique([memberId, feeCategoryId, membershipTypeId, feeTypeId, periodStart, periodEnd], map: "fee_charges_billing_unique")
   @@map("fee_charges")
+}
+
+/// A fee type defines how a member pays (e.g., Einzelbeitrag, Familientarif, Beitragsfrei).
+/// Combined with MembershipType via MembershipTypeFeeType cross-table to determine actual amounts.
+model FeeType {
+  /// Unique identifier (CUID format)
+  id          String   @id @default(cuid())
+  /// Reference to the parent club (tenant)
+  clubId      String
+  /// The club this fee type belongs to
+  club        Club     @relation(fields: [clubId], references: [id])
+  /// Display name (e.g., "Einzelbeitrag", "Familientarif")
+  name        String
+  /// Optional description explaining when this fee type applies
+  description String?
+  /// Whether this fee type is currently available for selection
+  isActive    Boolean  @default(true)
+
+  /// Soft deletion timestamp (CONV-006)
+  deletedAt   DateTime?
+  /// User ID who performed the soft deletion
+  deletedBy   String?
+
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  // Relations
+  /// Cross-table: fee amounts per MembershipType for this fee type
+  membershipTypeFees  MembershipTypeFeeType[]
+  /// Members assigned to this fee type
+  members             Member[]
+  /// Fee charges that used this fee type at billing time
+  feeCharges          FeeCharge[]
+
+  @@unique([clubId, name])
+  @@index([clubId])
+  @@map("fee_types")
+}
+
+/// Cross-table entry: defines the fee amount for a specific MembershipType x FeeType combination.
+/// This is the core of the two-dimensional fee model.
+model MembershipTypeFeeType {
+  /// Unique identifier (CUID format)
+  id               String          @id @default(cuid())
+  /// Reference to the membership type
+  membershipTypeId String
+  /// The membership type
+  membershipType   MembershipType  @relation(fields: [membershipTypeId], references: [id])
+  /// Reference to the fee type
+  feeTypeId        String
+  /// The fee type
+  feeType          FeeType         @relation(fields: [feeTypeId], references: [id])
+  /// Fee amount for this combination
+  amount           Decimal         @db.Decimal(10, 2)
+  /// Billing frequency for this combination
+  billingInterval  BillingInterval @default(ANNUALLY)
+
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+
+  @@unique([membershipTypeId, feeTypeId])
+  @@map("membership_type_fee_types")
+}
+
+/// Join table for scoping fee categories to specific membership types.
+/// Used when FeeCategory.scope is BY_MEMBERSHIP_TYPE.
+model FeeCategoryMembershipType {
+  /// Unique identifier (CUID format)
+  id               String          @id @default(cuid())
+  /// Reference to the fee category
+  feeCategoryId    String
+  /// The fee category
+  feeCategory      FeeCategory     @relation(fields: [feeCategoryId], references: [id])
+  /// Reference to the membership type
+  membershipTypeId String
+  /// The membership type
+  membershipType   MembershipType  @relation(fields: [membershipTypeId], references: [id])
+
+  @@unique([feeCategoryId, membershipTypeId])
+  @@map("fee_category_membership_types")
 }
 
 /// Payment recorded against a fee charge.


### PR DESCRIPTION
## Überblick

Baut das Beitragsmodell um: zweidimensionale **FeeType × MembershipType-Kreuztabelle** statt Flat-Fee, FeeCategory-Scopes, per-Club `householdBillingModel` und eine Billing-Run-Preview/Execute-Pipeline.

## Enthalten

- FeeType-CRUD + Kreuztabelle (Beträge je MembershipType × FeeType)
- FeeCategory-Scope (`ALL_MEMBERS` / `BY_MEMBERSHIP_TYPE` / `INDIVIDUAL`)
- Beitragsart-Dropdown mit Auto-Suggestion im Mitgliedsformular
- Billing-Run Preview + Execute inkl. Warnungen
- Eigene Beitragsmodell-Settings-Seite

## Code-Review-Härtung (Security + Korrektheit)

- **Cross-Tenant-Lücke geschlossen:** Kreuztabellen-`upsert`/`delete` sind jetzt club-scoped (vorher konnte ein Verein fremde Beitragsmatrizen per ID überschreiben/löschen)
- FK-Ownership-Prüfung für `feeTypeId` (Mitglied) und `feeCategoryId` (Override)
- FeeCategory-Schreibvorgänge laufen jetzt **innerhalb** der Transaktion (Atomarität)
- Billing-Run: Schutz gegen Doppelabrechnung einer Periode (`ConflictException`) + `NULLS NOT DISTINCT`-Index-Migration
- `kind`-Diskriminator in der Aufschlüsselung (Kategorie vs. Mitgliedsart, kein Namens-Merge mehr)
- Kreuztabellen-Zelle löschen verkabelt; toter Warn-Zweig in der Preview entfernt
- Tenant-Safe-Kommentare an ungescopten Payment-/Override-Queries

## Bewusst verschoben (nachverfolgt)

- **Haushaltsrabatt in der Billing-Engine → Phase 12.2.** `householdBillingModel` ist konfigurierbar/persistiert, wird aber noch nicht bei der Beitragsberechnung angewendet.
- **Tagesgenaue anteilige Berechnung → Backlog.** Aktuelle Regel ist kalendermonats-granular (dokumentiert + per Boundary-Tests abgesichert).

## Tests

- Typecheck, 1165 Unit-Tests, Lint/Format lokal grün.

## Hinweis: DB-Migration

Enthält `20260610133400_fee_charges_billing_unique_nulls_not_distinct`. Nach dem Merge `prisma migrate deploy` ausführen. Die Migration setzt voraus, dass **keine vorbestehenden Duplikat-Zeilen** in `fee_charges` existieren (unter der neuen `NULLS NOT DISTINCT`-Semantik) — bei produktiven Daten vorher deduplizieren.