### PR TITLE
chore(dependabot): group actions, bundle security updates, lower PR limits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,14 +7,26 @@ updates:
       day: 'monday'
       time: '03:00'
       timezone: 'Europe/Berlin'
-    open-pull-requests-limit: 10
+    # Lower limit reduces how many PRs touch pnpm-lock.yaml at once, shrinking the
+    # window in which they conflict with each other.
+    open-pull-requests-limit: 5
+    # Let Dependabot rebase open PRs after each merge and regenerate the lockfile.
+    rebase-strategy: 'auto'
     groups:
-      minor-and-patch:
+      # Version updates: bundle minor/patch into one PR, majors into another.
+      npm-minor-patch:
+        applies-to: version-updates
         patterns: ['*']
         update-types: ['minor', 'patch']
-      major:
+      npm-major:
+        applies-to: version-updates
         patterns: ['*']
         update-types: ['major']
+      # Security updates (incl. transitive) bundled so they don't arrive as many
+      # single-package PRs (e.g. ajv, minimatch, brace-expansion).
+      npm-security:
+        applies-to: security-updates
+        patterns: ['*']
     labels:
       - 'dependencies'
 
@@ -23,7 +35,17 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'monday'
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 3
+    rebase-strategy: 'auto'
+    groups:
+      # One PR for all action bumps instead of one per action; several actions
+      # share the same workflow file (e.g. sbom.yml), so separate PRs collided.
+      github-actions:
+        applies-to: version-updates
+        patterns: ['*']
+      github-actions-security:
+        applies-to: security-updates
+        patterns: ['*']
     labels:
       - 'dependencies'
       - 'github-actions'

--- a/docs/BRANCH-RULESET.md
+++ b/docs/BRANCH-RULESET.md
@@ -45,6 +45,27 @@ After configuration:
 3. Verify the `CI Success` status check is required
 4. Check that the ruleset appears in Settings > Rules > Rulesets
 
+## Dependabot & Auto-Merge
+
+Dependabot updates are configured in `.github/dependabot.yml` to minimise PRs that
+block each other on `pnpm-lock.yaml` and shared workflow files (e.g. `sbom.yml`):
+
+- **Grouping** – npm version updates are grouped (minor/patch and major separately),
+  github-actions updates are grouped into a single PR, and security updates (npm +
+  actions) are bundled via `applies-to: security-updates`. This collapses what used
+  to be many single-package PRs into a few.
+- **Lower PR limits** (`open-pull-requests-limit`: npm 5, actions 3) and
+  `rebase-strategy: auto` keep the number of simultaneously open, lockfile-touching
+  PRs small and let Dependabot regenerate the lockfile after each merge.
+- **Auto-merge** – `.github/workflows/dependabot-auto-merge.yml` waits for CI and
+  enables auto-merge for non-major updates. Grouped PRs are evaluated by their
+  highest update type, so a group containing a major bump needs manual review.
+
+**Required repo setting:** "Allow auto-merge" must be enabled under
+**Settings > General > Pull Requests**, otherwise `gh pr merge --auto` is a no-op and
+PRs accumulate again. Combined with the required `CI Success` check above, auto-merge
+only completes once CI is green.
+
 ## Notes
 
 - Rulesets with code scanning merge protection are available for public repos on GitHub Free


### PR DESCRIPTION
Strukturelle Verbesserung, damit sich Dependabot-PRs nicht mehr gegenseitig über `pnpm-lock.yaml` bzw. geteilte Workflow-Dateien blockieren (Root Cause der zuletzt aufgelaufenen 18 PRs).

## Änderungen (`.github/dependabot.yml`)
- **github-actions gruppiert** – ein PR statt einer pro Action (mehrere Actions teilen sich `sbom.yml`, dadurch kollidierten Einzel-PRs).
- **Security-Updates gebündelt** – via `applies-to: security-updates` (npm + actions), damit transitive Bumps wie ajv/minimatch/brace-expansion nicht mehr als viele Einzel-PRs ankommen.
- **npm-Version-Gruppen** explizit getrennt (minor/patch vs. major).
- **open-pull-requests-limit gesenkt** (npm 10→5, actions 5→3) – kleinere Konfliktfläche.
- **`rebase-strategy: auto`** – Dependabot rebasiert offene PRs nach jedem Merge und regeneriert das Lockfile selbst.

## Doku (`docs/BRANCH-RULESET.md`)
- Abschnitt zur Dependabot-/Auto-Merge-Strategie ergänzt, inkl. der **Voraussetzung**, dass das Repo-Setting **"Allow auto-merge"** aktiv sein muss (sonst ist `gh pr merge --auto` ein No-op).

Der bestehende Auto-Merge-Workflow bleibt unverändert; er greift ecosystem-übergreifend und damit auch für die neue actions-Gruppe.